### PR TITLE
fix(core): correct isFilters discrimination and relation extract; add core test baseline

### DIFF
--- a/packages/core/src/parameter/filters/collection/check.ts
+++ b/packages/core/src/parameter/filters/collection/check.ts
@@ -6,13 +6,22 @@
  */
 
 import type { ICondition } from '../condition';
+import { isObject } from '../../../utils';
 import type { IFilters } from './types';
 
 export function isFilters(
     input: ICondition,
     operator?: string,
 ) : input is IFilters {
-    if (!Array.isArray(input)) return false;
+    // A compound `Filters` node is the only `ICondition` that carries a
+    // `flatten` method; a leaf `Filter` never does. This distinguishes the two
+    // reliably, even when a leaf filter's `value` happens to be an array (e.g. `in`).
+    if (
+        !isObject(input) ||
+        typeof (input as Partial<IFilters>).flatten !== 'function'
+    ) {
+        return false;
+    }
 
     if (operator) {
         return operator === input.operator;

--- a/packages/core/test/unit/parameter/fields.spec.ts
+++ b/packages/core/test/unit/parameter/fields.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { Field, FieldOperator, Fields } from '../../../src';
+
+function names(fields: { value: { name: string }[] }) : string[] {
+    return fields.value.map((field) => field.name);
+}
+
+describe('src/parameter/fields/*.ts', () => {
+    describe('without allow-list and defaults', () => {
+        it('should return explicate selection as-is', () => {
+            const fields = new Fields([
+                new Field('id'),
+                new Field('name'),
+            ]);
+
+            const output = fields.execute({ default: [], allowed: [] });
+            expect(names(output)).toEqual(['id', 'name']);
+        });
+
+        it('should return include selection when no explicates given', () => {
+            const fields = new Fields([
+                new Field('id', FieldOperator.INCLUDE),
+                new Field('name', FieldOperator.INCLUDE),
+            ]);
+
+            const output = fields.execute({ default: [], allowed: [] });
+            expect(names(output)).toEqual(['id', 'name']);
+        });
+
+        it('should prefer explicates over includes', () => {
+            const fields = new Fields([
+                new Field('id'),
+                new Field('name', FieldOperator.INCLUDE),
+            ]);
+
+            const output = fields.execute({ default: [], allowed: [] });
+            expect(names(output)).toEqual(['id']);
+        });
+
+        it('should deduplicate', () => {
+            const fields = new Fields([
+                new Field('id'),
+                new Field('id'),
+            ]);
+
+            const output = fields.execute({ default: [], allowed: [] });
+            expect(names(output)).toEqual(['id']);
+        });
+    });
+
+    describe('with allow-list / defaults', () => {
+        it('should keep an explicate that is allowed', () => {
+            const fields = new Fields([new Field('id')]);
+
+            const output = fields.execute({ default: [], allowed: ['id', 'name', 'email'] });
+            expect(names(output)).toEqual(['id']);
+        });
+
+        it('should fall back to defaults when no valid selection is given', () => {
+            const fields = new Fields([]);
+
+            const output = fields.execute({ default: ['id', 'name'], allowed: ['email'] });
+            expect(names(output)).toEqual(['id', 'name']);
+        });
+
+        it('should fall back to the allowed set when defaults are empty and nothing valid is requested', () => {
+            const fields = new Fields([new Field('secret')]);
+
+            const output = fields.execute({ default: [], allowed: ['id', 'name'] });
+            expect(names(output)).toEqual(['id', 'name']);
+        });
+
+        it('should extend the default selection with an allowed include', () => {
+            const fields = new Fields([new Field('email', FieldOperator.INCLUDE)]);
+
+            const output = fields.execute({ default: ['id', 'name'], allowed: ['email'] });
+            expect(names(output)).toEqual(['id', 'name', 'email']);
+        });
+
+        it('should drop an include that is neither allowed nor default', () => {
+            const fields = new Fields([new Field('secret', FieldOperator.INCLUDE)]);
+
+            const output = fields.execute({ default: ['id', 'name'], allowed: ['email'] });
+            expect(names(output)).toEqual(['id', 'name']);
+        });
+
+        it('should remove excluded fields from the default selection', () => {
+            const fields = new Fields([new Field('email', FieldOperator.EXCLUDE)]);
+
+            const output = fields.execute({ default: ['id', 'name', 'email'], allowed: [] });
+            expect(names(output)).toEqual(['id', 'name']);
+        });
+
+        it('should keep an explicate over the defaults', () => {
+            const fields = new Fields([new Field('id')]);
+
+            const output = fields.execute({ default: ['name', 'email'], allowed: ['id'] });
+            expect(names(output)).toEqual(['id']);
+        });
+    });
+});

--- a/packages/core/test/unit/parameter/filters.spec.ts
+++ b/packages/core/test/unit/parameter/filters.spec.ts
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IFilter, IFilterVisitor } from '../../../src';
+import {
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+} from '../../../src';
+
+/**
+ * A real visitor that reports which method handled the filter — so dispatch
+ * can be observed through the public interface instead of mocking.
+ */
+class NamingFilterVisitor implements IFilterVisitor<string> {
+    visitFilter(_: IFilter) {
+        return 'visitFilter';
+    }
+
+    visitFilterEqual(_: IFilter) {
+        return 'visitFilterEqual';
+    }
+
+    visitFilterNotEqual(_: IFilter) {
+        return 'visitFilterNotEqual';
+    }
+
+    visitFilterLessThan(_: IFilter) {
+        return 'visitFilterLessThan';
+    }
+
+    visitFilterLessThanEqual(_: IFilter) {
+        return 'visitFilterLessThanEqual';
+    }
+
+    visitFilterGreaterThan(_: IFilter) {
+        return 'visitFilterGreaterThan';
+    }
+
+    visitFilterGreaterThanEqual(_: IFilter) {
+        return 'visitFilterGreaterThanEqual';
+    }
+
+    visitFilterExists(_: IFilter) {
+        return 'visitFilterExists';
+    }
+
+    visitFilterIn(_: IFilter) {
+        return 'visitFilterIn';
+    }
+
+    visitFilterNotIn(_: IFilter) {
+        return 'visitFilterNotIn';
+    }
+
+    visitFilterMod(_: IFilter) {
+        return 'visitFilterMod';
+    }
+
+    visitFilterElemMatch(_: IFilter) {
+        return 'visitFilterElemMatch';
+    }
+
+    visitFilterContains(_: IFilter) {
+        return 'visitFilterContains';
+    }
+
+    visitFilterNotContains(_: IFilter) {
+        return 'visitFilterNotContains';
+    }
+
+    visitFilterStartsWith(_: IFilter) {
+        return 'visitFilterStartsWith';
+    }
+
+    visitFilterNotStartsWith(_: IFilter) {
+        return 'visitFilterNotStartsWith';
+    }
+
+    visitFilterEndsWith(_: IFilter) {
+        return 'visitFilterEndsWith';
+    }
+
+    visitFilterNotEndsWith(_: IFilter) {
+        return 'visitFilterNotEndsWith';
+    }
+
+    visitFilterRegex(_: IFilter) {
+        return 'visitFilterRegex';
+    }
+}
+
+const OPERATOR_METHOD: [string, string][] = [
+    [FilterFieldOperator.EQUAL, 'visitFilterEqual'],
+    [FilterFieldOperator.NOT_EQUAL, 'visitFilterNotEqual'],
+    [FilterFieldOperator.LESS_THAN, 'visitFilterLessThan'],
+    [FilterFieldOperator.LESS_THAN_EQUAL, 'visitFilterLessThanEqual'],
+    [FilterFieldOperator.GREATER_THAN, 'visitFilterGreaterThan'],
+    [FilterFieldOperator.GREATER_THAN_EQUAL, 'visitFilterGreaterThanEqual'],
+    [FilterFieldOperator.EXISTS, 'visitFilterExists'],
+    [FilterFieldOperator.IN, 'visitFilterIn'],
+    [FilterFieldOperator.NOT_IN, 'visitFilterNotIn'],
+    [FilterFieldOperator.MOD, 'visitFilterMod'],
+    [FilterFieldOperator.ELEM_MATCH, 'visitFilterElemMatch'],
+    [FilterFieldOperator.CONTAINS, 'visitFilterContains'],
+    [FilterFieldOperator.NOT_CONTAINS, 'visitFilterNotContains'],
+    [FilterFieldOperator.STARTS_WITH, 'visitFilterStartsWith'],
+    [FilterFieldOperator.NOT_STARTS_WITH, 'visitFilterNotStartsWith'],
+    [FilterFieldOperator.ENDS_WITH, 'visitFilterEndsWith'],
+    [FilterFieldOperator.NOT_ENDS_WITH, 'visitFilterNotEndsWith'],
+    [FilterFieldOperator.REGEX, 'visitFilterRegex'],
+];
+
+describe('src/parameter/filters/record/*.ts', () => {
+    describe('Filter.accept dispatch', () => {
+        it.each(OPERATOR_METHOD)('should dispatch operator %s to %s', (operator, method) => {
+            const filter = new Filter(operator, 'field', 1);
+            expect(filter.accept(new NamingFilterVisitor())).toBe(method);
+        });
+
+        it('should fall back to visitFilter when the operator method is absent', () => {
+            // Only the mandatory method is implemented — every operator must route to it.
+            const visitor : IFilterVisitor<string> = {
+                visitFilter: () => 'fallback',
+            };
+            OPERATOR_METHOD.forEach(([operator]) => {
+                expect(new Filter(operator, 'field', 1).accept(visitor)).toBe('fallback');
+            });
+        });
+
+        it('should use visitFilter for an unknown operator', () => {
+            const filter = new Filter('totally-unknown', 'field', 1);
+            expect(filter.accept(new NamingFilterVisitor())).toBe('visitFilter');
+        });
+    });
+});
+
+describe('src/parameter/filters/collection/*.ts', () => {
+    describe('Filters.flatten', () => {
+        it('should hoist a nested group sharing the parent operator', () => {
+            const a = new Filter(FilterFieldOperator.EQUAL, 'a', 1);
+            const b = new Filter(FilterFieldOperator.EQUAL, 'b', 2);
+            const c = new Filter(FilterFieldOperator.EQUAL, 'c', 3);
+
+            const inner = new Filters(FilterCompoundOperator.AND, [a, b]);
+            const outer = new Filters(FilterCompoundOperator.AND, [c, inner]);
+
+            const flat = outer.flatten();
+
+            expect(flat.operator).toBe(FilterCompoundOperator.AND);
+            expect(flat.value).toEqual([c, a, b]);
+        });
+
+        it('should keep a nested group with a different operator nested', () => {
+            const a = new Filter(FilterFieldOperator.EQUAL, 'a', 1);
+            const b = new Filter(FilterFieldOperator.EQUAL, 'b', 2);
+            const c = new Filter(FilterFieldOperator.EQUAL, 'c', 3);
+
+            const innerOr = new Filters(FilterCompoundOperator.OR, [a, b]);
+            const outer = new Filters(FilterCompoundOperator.AND, [c, innerOr]);
+
+            const flat = outer.flatten();
+
+            expect(flat.operator).toBe(FilterCompoundOperator.AND);
+            expect(flat.value).toHaveLength(2);
+            expect(flat.value[0]).toEqual(c);
+            // The differing-operator group stays nested (structure, not identity).
+            expect(flat.value[1]).toEqual(innerOr);
+            expect((flat.value[1] as Filters).operator).toBe(FilterCompoundOperator.OR);
+        });
+
+        it('should hoist recursively across multiple same-operator levels', () => {
+            const a = new Filter(FilterFieldOperator.EQUAL, 'a', 1);
+            const b = new Filter(FilterFieldOperator.EQUAL, 'b', 2);
+            const c = new Filter(FilterFieldOperator.EQUAL, 'c', 3);
+
+            const innermost = new Filters(FilterCompoundOperator.AND, [a]);
+            const middle = new Filters(FilterCompoundOperator.AND, [b, innermost]);
+            const outer = new Filters(FilterCompoundOperator.AND, [c, middle]);
+
+            const flat = outer.flatten();
+            expect(flat.value).toEqual([c, b, a]);
+        });
+
+        it('should leave a flat group unchanged', () => {
+            const a = new Filter(FilterFieldOperator.EQUAL, 'a', 1);
+            const b = new Filter(FilterFieldOperator.EQUAL, 'b', 2);
+
+            const filters = new Filters(FilterCompoundOperator.AND, [a, b]);
+            const flat = filters.flatten();
+
+            expect(flat.value).toEqual([a, b]);
+        });
+    });
+});

--- a/packages/core/test/unit/schema/registry.spec.ts
+++ b/packages/core/test/unit/schema/registry.spec.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SchemaRegistry, defineSchema } from '../../../src';
+import { registry } from '../../data/schema';
+
+describe('src/schema/registry/*.ts', () => {
+    describe('add / get / getOrFail / drop', () => {
+        it('should store and retrieve a schema by name', () => {
+            const local = new SchemaRegistry();
+            const schema = defineSchema({ name: 'foo' });
+            local.add(schema);
+
+            expect(local.get('foo')).toBe(schema);
+            expect(local.getOrFail('foo')).toBe(schema);
+        });
+
+        it('should throw when adding a schema without a name', () => {
+            const local = new SchemaRegistry();
+            expect(() => local.add(defineSchema({}))).toThrow();
+        });
+
+        it('should return undefined for an unknown name', () => {
+            const local = new SchemaRegistry();
+            expect(local.get('missing')).toBeUndefined();
+        });
+
+        it('should throw in getOrFail for an unknown name', () => {
+            const local = new SchemaRegistry();
+            expect(() => local.getOrFail('missing')).toThrow();
+        });
+
+        it('should return a passed Schema instance unchanged', () => {
+            const local = new SchemaRegistry();
+            const schema = defineSchema({ name: 'foo' });
+            expect(local.get(schema)).toBe(schema);
+        });
+
+        it('should drop a registered schema', () => {
+            const local = new SchemaRegistry();
+            local.add(defineSchema({ name: 'foo' }));
+            local.drop('foo');
+            expect(local.get('foo')).toBeUndefined();
+        });
+    });
+
+    describe('resolve', () => {
+        it('should resolve a single registered name', () => {
+            expect(registry.resolve('user')?.name).toBe('user');
+        });
+
+        it('should resolve a dotted path honoring schemaMapping', () => {
+            // user.schemaMapping maps the `items` relation to the `item` schema.
+            expect(registry.resolve('user.items')?.name).toBe('item');
+        });
+
+        it('should treat separate arguments like dotted segments', () => {
+            expect(registry.resolve('user', 'items')?.name).toBe('item');
+        });
+
+        it('should resolve a relation without a schema mapping by its own name', () => {
+            expect(registry.resolve('user.realm')?.name).toBe('realm');
+        });
+
+        it('should return undefined for an unknown root', () => {
+            expect(registry.resolve('does-not-exist')).toBeUndefined();
+        });
+
+        it('should return undefined for an unknown relation segment', () => {
+            expect(registry.resolve('user.unknown-relation')).toBeUndefined();
+        });
+    });
+});

--- a/packages/core/test/unit/schema/schema.spec.ts
+++ b/packages/core/test/unit/schema/schema.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    FieldsSchema,
+    FiltersSchema,
+    PaginationSchema,
+    RelationsSchema,
+    SortSchema,
+    defineFieldsSchema,
+    defineSchema,
+} from '../../../src';
+import type { User } from '../../data/type';
+
+describe('src/schema/*.ts', () => {
+    describe('normalization', () => {
+        it('should instantiate a sub-schema per parameter', () => {
+            const schema = defineSchema<User>({});
+
+            expect(schema.fields).toBeInstanceOf(FieldsSchema);
+            expect(schema.filters).toBeInstanceOf(FiltersSchema);
+            expect(schema.pagination).toBeInstanceOf(PaginationSchema);
+            expect(schema.relations).toBeInstanceOf(RelationsSchema);
+            expect(schema.sort).toBeInstanceOf(SortSchema);
+        });
+
+        it('should normalize plain parameter options into sub-schemas', () => {
+            const schema = defineSchema<User>({
+                fields: { allowed: ['id', 'name'] },
+                pagination: { maxLimit: 50 },
+            });
+
+            expect(schema.fields.allowed).toEqual(['id', 'name']);
+            expect(schema.fields.allowedIsUndefined).toBe(false);
+            expect(schema.pagination.maxLimit).toBe(50);
+        });
+
+        it('should pass a pre-built sub-schema instance through by reference', () => {
+            const fields = defineFieldsSchema<User>({ allowed: ['id'] });
+            const schema = defineSchema<User>({ fields });
+
+            expect(schema.fields).toBe(fields);
+        });
+
+        it('should derive the sort allow-list from default keys', () => {
+            const schema = defineSchema<User>({
+                sort: { default: { name: 'DESC' } },
+            });
+
+            expect(schema.sort.defaultKeys).toEqual(['name']);
+            expect(schema.sort.allowedIsUndefined).toBe(false);
+            expect(schema.sort.allowed).toContain('name');
+        });
+    });
+
+    describe('extendSchemasOptions', () => {
+        it('should propagate the schema name to every sub-schema', () => {
+            const schema = defineSchema<User>({ name: 'user' });
+
+            expect(schema.fields.name).toBe('user');
+            expect(schema.filters.name).toBe('user');
+            expect(schema.pagination.name).toBe('user');
+            expect(schema.relations.name).toBe('user');
+            expect(schema.sort.name).toBe('user');
+        });
+
+        it('should propagate throwOnFailure to sub-schemas that do not set it', () => {
+            const schema = defineSchema<User>({ throwOnFailure: true });
+
+            expect(schema.fields.throwOnFailure).toBe(true);
+            expect(schema.filters.throwOnFailure).toBe(true);
+            expect(schema.sort.throwOnFailure).toBe(true);
+        });
+
+        it('should not override a throwOnFailure explicitly set on a sub-schema', () => {
+            const fields = defineFieldsSchema<User>({ throwOnFailure: false });
+            const schema = defineSchema<User>({ throwOnFailure: true, fields });
+
+            expect(schema.fields.throwOnFailure).toBe(false);
+            expect(schema.filters.throwOnFailure).toBe(true);
+        });
+
+        it('should leave throwOnFailure undefined when unset at the schema level', () => {
+            const schema = defineSchema<User>({});
+
+            expect(schema.fields.throwOnFailure).toBeUndefined();
+            expect(schema.sort.throwOnFailure).toBeUndefined();
+        });
+    });
+});

--- a/packages/parser-expression/test/unit/parser/filters.spec.ts
+++ b/packages/parser-expression/test/unit/parser/filters.spec.ts
@@ -25,6 +25,37 @@ describe('filters/expr-parser', () => {
         expect(output).toEqual(new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'));
     });
 
+    describe('parse (top-level wrapping)', () => {
+        it('should wrap a single leaf condition in a root AND group', () => {
+            const output = parser.parse('eq(name, \'admin\')');
+
+            expect(output).toEqual(new Filters(
+                FilterCompoundOperator.AND,
+                [new Filter(FilterFieldOperator.EQUAL, 'name', 'admin')],
+            ));
+        });
+
+        it('should return an existing compound group without re-wrapping it', () => {
+            const output = parser.parse('and(eq(name, \'admin\'), eq(age, \'18\'))');
+
+            // Must stay a single AND level — not Filters(AND, [Filters(AND, [...])]).
+            expect(output).toEqual(new Filters(
+                FilterCompoundOperator.AND,
+                [
+                    new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+                    new Filter(FilterFieldOperator.EQUAL, 'age', 18),
+                ],
+            ));
+        });
+
+        it('should keep an OR group at the root without wrapping in AND', () => {
+            const output = parser.parse('or(eq(name, \'admin\'), eq(name, \'guest\'))');
+
+            expect(output.operator).toBe(FilterCompoundOperator.OR);
+            expect(output.value).toHaveLength(2);
+        });
+    });
+
     it('should parse not eq expression', () => {
         const output = parser.parseExact('not(eq(name, \'admin\'))');
 


### PR DESCRIPTION
## Summary

Adds a boundary-test baseline for `@rapiq/core` (it had a single spec/one test) and fixes two real bugs that writing those expected-behavior tests surfaced.

## Fixes

- **`isFilters` never matched** (`parameter/filters/collection/check.ts`) — it called `Array.isArray` on an `IFilters`, which is a plain object, so it always returned `false`. Consequences: `Filters.flatten` silently never hoisted nested same-operator groups, and `ExpressionFiltersParser.parse` double-wrapped every compound (`Filters(AND, [Filters(AND, [...])])`). Now discriminates on the compound-only `flatten` method via `isObject`.
- **`Relations.extract` prefix collision** (`parameter/relations/collection/module.ts`) — the prefix check had no dot boundary, so `extract('item')` wrongly consumed a sibling `items`. Now requires a `root.` boundary.

## Tests

Core suite grows from 1 spec/1 test to 6 specs/61 tests:

- `parameter/fields.spec.ts` — `Fields.execute` include/exclude/explicate + default/allowed fallbacks
- `parameter/filters.spec.ts` — `Filter.accept` per-operator dispatch + `visitFilter` fallback; `Filters.flatten` associativity
- `parameter/relations.spec.ts` — `Relations.extract` mutation + dot boundary
- `schema/schema.spec.ts` — `Schema` normalization + `extendSchemasOptions` propagation
- `schema/registry.spec.ts` — `SchemaRegistry` add/get/getOrFail/drop + `resolve` schemaMapping traversal

Also adds `parser-expression` coverage for `ExpressionFiltersParser.parse` top-level wrapping — the path the `isFilters` fix actually changes, previously untested (all assertions used `parseExact`). The "return an existing compound group without re-wrapping" case would have failed before the fix.

## Verification

- `@rapiq/core`: 61/61 green.
- Rebuilt core; all downstream packages (parser-simple, parser-expression, codec-url-simple, sql, typeorm) green — both fixes are safe across the monorepo.
- Lint clean on all changed source and test files.

## Notes

Both fixes are workarounds for a deeper smell: the filter AST has no discriminant field distinguishing a leaf `IFilter` from a compound `IFilters` (both are `{ operator, value }`), so `isFilters` must duck-type. Resolving that root cause belongs to the upcoming schema-resolution / AST work rather than this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filter type validation to correctly identify compound filter structures.

* **Tests**
  * Added comprehensive test coverage for field selection behavior, filter operations, schema registry, schema definition and normalization, and expression parser functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->