### PR TITLE
fix: compound wrapping, anchored regex patterns, empty IN lists, sqlite preset

### DIFF
--- a/.agents/migration-notes.md
+++ b/.agents/migration-notes.md
@@ -46,3 +46,11 @@ Known pre-existing issue (out of scope here, plan 006): `BaseParser.expandObject
 - **Error taxonomy** (plan 008 item 5): core exports `AdapterError` with `operatorUnsupported`/`featureUnsupported` factories and `ErrorCode.OPERATOR_UNSUPPORTED`/`FEATURE_UNSUPPORTED`; the raw `Error` throws in @rapiq/sql are migrated.
 - Relations adapter no longer duplicates parent path entries (`add('a.b'); add('a.c')` previously pushed `{path:'a'}` twice).
 - `AdapterOptions` accepts `rootAlias`, forwarded to the fields/filters/sort sub-adapters.
+
+## Post-review fixes (PR #741 audit)
+
+- **Compound wrapping**: `FiltersBaseAdapter.merge()` now parenthesizes by condition count instead of the `sql[0] !== '('` heuristic. Previously a nested compound whose first condition was itself parenthesized (e.g. the null-rewrite fragments) was merged unwrapped, producing wrong AND/OR precedence; a top-level multi-condition group is now always wrapped too.
+- **Anchored regex patterns** (`@rapiq/core`): `createFilterRegexPattern` used `&&` instead of `&` for the CONTAINS check, so `startsWith`/`endsWith` produced *unanchored* patterns on regexp dialects (pg/mysql/oracle) — they behaved like `contains`. Patterns are now anchored (`^foo`, `foo$`), matching the LIKE-fallback semantics on regexp-less dialects. A pattern built without an anchor flag is now unanchored (was: accidental `input$`).
+- **Empty `in`/`nin` lists**: `in(field, [])` renders `1 = 0` (matches nothing) and `nin(field, [])` renders `1 = 1` — previously the invalid SQL `field in()`.
+- **sqlite preset** no longer inherits mysql's `regexp` callback (stock SQLite has no `REGEXP` function): anchored operators fall back to `LIKE`, the `regex` operator throws a typed `AdapterError`.
+- `FiltersVisitor`: `visitFilterNotEndsWith`/`visitFilterNotContains` signatures used wrong operator type parameters (copy-paste); in/nin and the six anchored-operator methods now share `whereIn`/`whereAnchored` helpers.

--- a/.agents/migration-notes.md
+++ b/.agents/migration-notes.md
@@ -54,3 +54,5 @@ Known pre-existing issue (out of scope here, plan 006): `BaseParser.expandObject
 - **Empty `in`/`nin` lists**: `in(field, [])` renders `1 = 0` (matches nothing) and `nin(field, [])` renders `1 = 1` — previously the invalid SQL `field in()`.
 - **sqlite preset** no longer inherits mysql's `regexp` callback (stock SQLite has no `REGEXP` function): anchored operators fall back to `LIKE`, the `regex` operator throws a typed `AdapterError`.
 - `FiltersVisitor`: `visitFilterNotEndsWith`/`visitFilterNotContains` signatures used wrong operator type parameters (copy-paste); in/nin and the six anchored-operator methods now share `whereIn`/`whereAnchored` helpers.
+- **Literal matching for anchored operators** (from PR #742 review): `createFilterRegexPattern` escapes regex metacharacters — the input is a filter value, not a regex. Previously `contains(name, 'a.b')` matched `axb` on regexp dialects (while the LIKE fallback matched literally) and values like `'('` threw a raw `SyntaxError`. The `regex` operator is unaffected (takes a real `RegExp`).
+- `notStartsWith` on regexp dialects now matches the empty string (`^(?!foo).*`, was `.+`), consistent with `NOT LIKE 'foo%'`.

--- a/packages/core/src/parameter/filters/regex.ts
+++ b/packages/core/src/parameter/filters/regex.ts
@@ -27,23 +27,25 @@ export function createFilterRegexPattern(
 ) : string {
     let pattern : string;
     if (flag & FilterRegexFlag.NEGATION) {
-        if (flag & FilterRegexFlag.CONTAINS) {
-            pattern = `^(?!.*${input}).*`;
-        } else if (flag & FilterRegexFlag.STARTS_WITH) {
+        if (flag & FilterRegexFlag.STARTS_WITH) {
             pattern = `^(?!${input}).+`;
-        } else {
+        } else if (flag & FilterRegexFlag.ENDS_WITH) {
             pattern = `^(?!.*${input}$).*`;
+        } else {
+            // CONTAINS or no anchor flag
+            pattern = `^(?!.*${input}).*`;
         }
 
         return pattern;
     }
 
-    if (flag && FilterRegexFlag.CONTAINS) {
-        pattern = `${input}`;
-    } else if (flag & FilterRegexFlag.STARTS_WITH) {
+    if (flag & FilterRegexFlag.STARTS_WITH) {
         pattern = `^${input}`;
-    } else {
+    } else if (flag & FilterRegexFlag.ENDS_WITH) {
         pattern = `${input}$`;
+    } else {
+        // CONTAINS or no anchor flag
+        pattern = `${input}`;
     }
 
     return pattern;

--- a/packages/core/src/parameter/filters/regex.ts
+++ b/packages/core/src/parameter/filters/regex.ts
@@ -25,27 +25,31 @@ export function createFilterRegexPattern(
     input: string,
     flag: number = 0,
 ) : string {
+    // the input is a literal filter value, not a regex:
+    // escape metacharacters so it matches verbatim.
+    const escaped = input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
     let pattern : string;
     if (flag & FilterRegexFlag.NEGATION) {
         if (flag & FilterRegexFlag.STARTS_WITH) {
-            pattern = `^(?!${input}).+`;
+            pattern = `^(?!${escaped}).*`;
         } else if (flag & FilterRegexFlag.ENDS_WITH) {
-            pattern = `^(?!.*${input}$).*`;
+            pattern = `^(?!.*${escaped}$).*`;
         } else {
             // CONTAINS or no anchor flag
-            pattern = `^(?!.*${input}).*`;
+            pattern = `^(?!.*${escaped}).*`;
         }
 
         return pattern;
     }
 
     if (flag & FilterRegexFlag.STARTS_WITH) {
-        pattern = `^${input}`;
+        pattern = `^${escaped}`;
     } else if (flag & FilterRegexFlag.ENDS_WITH) {
-        pattern = `${input}$`;
+        pattern = `${escaped}$`;
     } else {
         // CONTAINS or no anchor flag
-        pattern = `${input}`;
+        pattern = `${escaped}`;
     }
 
     return pattern;

--- a/packages/core/test/unit/parameter/filters-regex.spec.ts
+++ b/packages/core/test/unit/parameter/filters-regex.spec.ts
@@ -40,7 +40,7 @@ describe('src/parameter/filters/regex.ts', () => {
         const cases : [number, string, string, string][] = [
             [
                 FilterRegexFlag.STARTS_WITH | FilterRegexFlag.NEGATION,
-                '^(?!foo).+',
+                '^(?!foo).*',
                 'xxfoo',
                 'foobar',
             ],
@@ -71,5 +71,27 @@ describe('src/parameter/filters/regex.ts', () => {
         const regex = createFilterRegex('foo', FilterRegexFlag.STARTS_WITH);
 
         expect(regex.test('FOObar')).toBeTruthy();
+    });
+
+    it('matches the empty string for negated STARTS_WITH', () => {
+        const regex = createFilterRegex('foo', FilterRegexFlag.STARTS_WITH | FilterRegexFlag.NEGATION);
+
+        expect(regex.test('')).toBeTruthy();
+    });
+
+    it('escapes regex metacharacters so the input matches verbatim', () => {
+        expect(createFilterRegexPattern('a.b', FilterRegexFlag.STARTS_WITH)).toEqual('^a\\.b');
+
+        const dot = createFilterRegex('a.b', FilterRegexFlag.CONTAINS);
+        expect(dot.test('xa.bx')).toBeTruthy();
+        expect(dot.test('xaxbx')).toBeFalsy();
+
+        const alternation = createFilterRegex('a|b', FilterRegexFlag.CONTAINS);
+        expect(alternation.test('a|b')).toBeTruthy();
+        expect(alternation.test('a')).toBeFalsy();
+
+        // previously threw a SyntaxError (invalid regex)
+        const parenthesis = createFilterRegex('(', FilterRegexFlag.STARTS_WITH);
+        expect(parenthesis.test('(x')).toBeTruthy();
     });
 });

--- a/packages/core/test/unit/parameter/filters-regex.spec.ts
+++ b/packages/core/test/unit/parameter/filters-regex.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    FilterRegexFlag,
+    createFilterRegex,
+    createFilterRegexPattern,
+} from '../../../src';
+
+describe('src/parameter/filters/regex.ts', () => {
+    it('anchors the pattern for STARTS_WITH', () => {
+        expect(createFilterRegexPattern('foo', FilterRegexFlag.STARTS_WITH)).toEqual('^foo');
+
+        const regex = createFilterRegex('foo', FilterRegexFlag.STARTS_WITH);
+        expect(regex.test('foobar')).toBeTruthy();
+        expect(regex.test('xxfoo')).toBeFalsy();
+    });
+
+    it('anchors the pattern for ENDS_WITH', () => {
+        expect(createFilterRegexPattern('foo', FilterRegexFlag.ENDS_WITH)).toEqual('foo$');
+
+        const regex = createFilterRegex('foo', FilterRegexFlag.ENDS_WITH);
+        expect(regex.test('xxfoo')).toBeTruthy();
+        expect(regex.test('foobar')).toBeFalsy();
+    });
+
+    it('builds an unanchored pattern for CONTAINS', () => {
+        expect(createFilterRegexPattern('foo', FilterRegexFlag.CONTAINS)).toEqual('foo');
+
+        const regex = createFilterRegex('foo', FilterRegexFlag.CONTAINS);
+        expect(regex.test('xxfooxx')).toBeTruthy();
+        expect(regex.test('bar')).toBeFalsy();
+    });
+
+    it('builds negated patterns', () => {
+        const cases : [number, string, string, string][] = [
+            [
+                FilterRegexFlag.STARTS_WITH | FilterRegexFlag.NEGATION,
+                '^(?!foo).+',
+                'xxfoo',
+                'foobar',
+            ],
+            [
+                FilterRegexFlag.ENDS_WITH | FilterRegexFlag.NEGATION,
+                '^(?!.*foo$).*',
+                'foobar',
+                'xxfoo',
+            ],
+            [
+                FilterRegexFlag.CONTAINS | FilterRegexFlag.NEGATION,
+                '^(?!.*foo).*',
+                'bar',
+                'xxfooxx',
+            ],
+        ];
+
+        for (const [flag, pattern, matching, notMatching] of cases) {
+            expect(createFilterRegexPattern('foo', flag), `${flag}`).toEqual(pattern);
+
+            const regex = createFilterRegex('foo', flag);
+            expect(regex.test(matching), `${flag}`).toBeTruthy();
+            expect(regex.test(notMatching), `${flag}`).toBeFalsy();
+        }
+    });
+
+    it('matches case-insensitive', () => {
+        const regex = createFilterRegex('foo', FilterRegexFlag.STARTS_WITH);
+
+        expect(regex.test('FOObar')).toBeTruthy();
+    });
+});

--- a/packages/docs/integrations/sql.md
+++ b/packages/docs/integrations/sql.md
@@ -25,7 +25,7 @@ import { mysql, pg } from '@rapiq/sql';
 ```
 
 ::: warning
-The `mssql` preset omits `regexp` — SQL Server has no regexp operator. On dialects without `regexp`, the `contains` / `startsWith` / `endsWith` filter operators (and their negations) fall back to `LIKE ... ESCAPE '\'` with wildcard escaping; only the `regex` filter operator is unavailable and throws a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`).
+The `mssql` and `sqlite` presets omit `regexp` — SQL Server has no regexp operator, and stock SQLite ships without a `REGEXP` function. On dialects without `regexp`, the `contains` / `startsWith` / `endsWith` filter operators (and their negations) fall back to `LIKE ... ESCAPE '\'` with wildcard escaping; only the `regex` filter operator is unavailable and throws a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`).
 :::
 
 ## Rendering filters
@@ -58,6 +58,8 @@ A `null` filter value is rewritten to the SQL null predicates instead of being b
 | `ne(field, null)` | `field IS NOT NULL` |
 | `in(field, [a, null])` | `(field IN (...) OR field IS NULL)` |
 | `nin(field, [a, null])` | `(field NOT IN (...) AND field IS NOT NULL)` |
+
+An empty list never matches: `in(field, [])` renders `1 = 0` and `nin(field, [])` renders `1 = 1` (instead of the invalid `IN ()`).
 
 ## The root adapter
 

--- a/packages/docs/integrations/sql.md
+++ b/packages/docs/integrations/sql.md
@@ -61,6 +61,10 @@ A `null` filter value is rewritten to the SQL null predicates instead of being b
 
 An empty list never matches: `in(field, [])` renders `1 = 0` and `nin(field, [])` renders `1 = 1` (instead of the invalid `IN ()`).
 
+### String matching
+
+The `contains` / `startsWith` / `endsWith` operators (and their negations) match their value **literally** on every dialect: regex metacharacters are escaped on regexp dialects, LIKE wildcards are escaped on the LIKE fallback. Only the `regex` operator interprets its value as a pattern.
+
 ## The root adapter
 
 Each parameter has an adapter/visitor pair (`FieldsAdapter`/`FieldsVisitor`, `SortAdapter`/`SortsVisitor`, `PaginationAdapter`/`PaginationVisitor`, `RelationsAdapter`/`RelationsVisitor`) that collects the walked state — selected columns, order map, limit/offset, relation paths. A root `Adapter` bundles all five, `QueryVisitor` walks a whole `Query` into it, and `build()` returns the accumulated clause fragments:

--- a/packages/sql/src/adapter/filters/base.ts
+++ b/packages/sql/src/adapter/filters/base.ts
@@ -149,7 +149,10 @@ export abstract class FiltersBaseAdapter<
         if (query.conditions.length > 0) {
             let sql = query.conditions.join(` ${operator} `);
 
-            if (sql[0] !== '(') {
+            // single conditions are atomic terms or already wrapped compounds;
+            // a leading '(' says nothing about the whole expression
+            // (e.g. '(a or b) or c'), so wrap by condition count.
+            if (query.conditions.length > 1) {
                 sql = `(${sql})`;
             }
 

--- a/packages/sql/src/dialect/sqlite.ts
+++ b/packages/sql/src/dialect/sqlite.ts
@@ -8,4 +8,11 @@
 import { mysql } from './mysql';
 import type { DialectOptions } from './types';
 
-export const sqlite : DialectOptions = { ...mysql };
+// no regexp: stock SQLite ships without a REGEXP function (it must be
+// registered by the application), so anchored operators (startsWith,
+// endsWith, contains) fall back to LIKE and the regex operator raises
+// a typed AdapterError.
+export const sqlite : DialectOptions = {
+    paramPlaceholder: mysql.paramPlaceholder,
+    escapeField: mysql.escapeField,
+};

--- a/packages/sql/src/visitor/filters.ts
+++ b/packages/sql/src/visitor/filters.ts
@@ -73,48 +73,11 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     }
 
     visitFilterIn(expr: Filter<FilterFieldOperator.IN, unknown[]>): IFiltersAdapter {
-        const values = expr.value.filter((value) => value !== null);
-        if (values.length === expr.value.length) {
-            return this.adapter.whereRaw(
-                `${this.adapter.buildField(
-                    expr.field,
-                )} in(${this.adapter.buildParamsPlaceholders(expr.value).join(', ')})`,
-                ...expr.value,
-            );
-        }
-
-        // a null element means: match the values OR the absence of one.
-        const field = this.adapter.buildField(expr.field);
-        if (values.length === 0) {
-            return this.adapter.whereRaw(`${field} is null`);
-        }
-
-        return this.adapter.whereRaw(
-            `(${field} in(${this.adapter.buildParamsPlaceholders(values).join(', ')}) or ${field} is null)`,
-            ...values,
-        );
+        return this.whereIn(expr.field, expr.value, false);
     }
 
     visitFilterNotIn(expr: Filter<FilterFieldOperator.NOT_IN, unknown[]>): IFiltersAdapter {
-        const values = expr.value.filter((value) => value !== null);
-        if (values.length === expr.value.length) {
-            return this.adapter.whereRaw(
-                `${this.adapter.buildField(
-                    expr.field,
-                )} not in(${this.adapter.buildParamsPlaceholders(expr.value).join(', ')})`,
-                ...expr.value,
-            );
-        }
-
-        const field = this.adapter.buildField(expr.field);
-        if (values.length === 0) {
-            return this.adapter.whereRaw(`${field} is not null`);
-        }
-
-        return this.adapter.whereRaw(
-            `(${field} not in(${this.adapter.buildParamsPlaceholders(values).join(', ')}) and ${field} is not null)`,
-            ...values,
-        );
+        return this.whereIn(expr.field, expr.value, true);
     }
 
     visitFilterMod(expr: Filter<FilterFieldOperator.MOD, [number, number]>): IFiltersAdapter {
@@ -136,63 +99,27 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     }
 
     visitFilterStartsWith(expr: Filter<FilterFieldOperator.STARTS_WITH, unknown>): IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            return this.whereLike(expr.field, `${escapeLikePattern(`${expr.value}`)}%`);
-        }
-
-        const regex = createFilterRegex(`${expr.value}`, FilterRegexFlag.STARTS_WITH);
-
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, expr.field, regex));
+        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.STARTS_WITH);
     }
 
     visitFilterNotStartsWith(expr: Filter<FilterFieldOperator.NOT_STARTS_WITH, unknown>): IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            return this.whereLike(expr.field, `${escapeLikePattern(`${expr.value}`)}%`, true);
-        }
-
-        const regex = createFilterRegex(`${expr.value}`, FilterRegexFlag.STARTS_WITH | FilterRegexFlag.NEGATION);
-
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, expr.field, regex));
+        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.STARTS_WITH | FilterRegexFlag.NEGATION);
     }
 
     visitFilterEndsWith(expr: Filter<FilterFieldOperator.ENDS_WITH, unknown>): IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            return this.whereLike(expr.field, `%${escapeLikePattern(`${expr.value}`)}`);
-        }
-
-        const regex = createFilterRegex(`${expr.value}`, FilterRegexFlag.ENDS_WITH);
-
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, expr.field, regex));
+        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.ENDS_WITH);
     }
 
-    visitFilterNotEndsWith(expr: Filter<FilterFieldOperator.NOT_STARTS_WITH, unknown>): IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            return this.whereLike(expr.field, `%${escapeLikePattern(`${expr.value}`)}`, true);
-        }
-
-        const regex = createFilterRegex(`${expr.value}`, FilterRegexFlag.ENDS_WITH | FilterRegexFlag.NEGATION);
-
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, expr.field, regex));
+    visitFilterNotEndsWith(expr: Filter<FilterFieldOperator.NOT_ENDS_WITH, unknown>): IFiltersAdapter {
+        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.ENDS_WITH | FilterRegexFlag.NEGATION);
     }
 
     visitFilterContains(expr: Filter<FilterFieldOperator.CONTAINS, unknown>): IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            return this.whereLike(expr.field, `%${escapeLikePattern(`${expr.value}`)}%`);
-        }
-
-        const regex = createFilterRegex(`${expr.value}`, FilterRegexFlag.CONTAINS);
-
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, expr.field, regex));
+        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.CONTAINS);
     }
 
-    visitFilterNotContains(expr: Filter<FilterFieldOperator.CONTAINS, unknown>): IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            return this.whereLike(expr.field, `%${escapeLikePattern(`${expr.value}`)}%`, true);
-        }
-
-        const regex = createFilterRegex(`${expr.value}`, FilterRegexFlag.CONTAINS | FilterRegexFlag.NEGATION);
-
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, expr.field, regex));
+    visitFilterNotContains(expr: Filter<FilterFieldOperator.NOT_CONTAINS, unknown>): IFiltersAdapter {
+        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.CONTAINS | FilterRegexFlag.NEGATION);
     }
 
     visitFilterRegex(expr: Filter<FilterFieldOperator.REGEX, RegExp>): IFiltersAdapter {
@@ -263,6 +190,59 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     }
 
     // -----------------------------------------------------------
+
+    /**
+     * Render an IN/NOT IN condition.
+     * A null element also matches the absence of a value (IS NULL);
+     * an empty list matches no row (every row when negated).
+     */
+    protected whereIn(fieldName: string, input: unknown[], negated: boolean) : IFiltersAdapter {
+        if (input.length === 0) {
+            return this.adapter.whereRaw(negated ? '1 = 1' : '1 = 0');
+        }
+
+        const values = input.filter((value) => value !== null);
+        const field = this.adapter.buildField(fieldName);
+        const nullCondition = `${field} is ${negated ? 'not ' : ''}null`;
+        if (values.length === 0) {
+            return this.adapter.whereRaw(nullCondition);
+        }
+
+        const inCondition = `${field} ${negated ? 'not ' : ''}in(${this.adapter.buildParamsPlaceholders(values).join(', ')})`;
+        if (values.length === input.length) {
+            return this.adapter.whereRaw(inCondition, ...values);
+        }
+
+        return this.adapter.whereRaw(
+            `(${inCondition} ${negated ? 'and' : 'or'} ${nullCondition})`,
+            ...values,
+        );
+    }
+
+    /**
+     * Render a startsWith/endsWith/contains condition (or its negation)
+     * as a regexp condition, falling back to LIKE on regexp-less dialects.
+     */
+    protected whereAnchored(field: string, value: unknown, flag: number) : IFiltersAdapter {
+        if (!this.adapter.isRegexpSupported()) {
+            const escaped = escapeLikePattern(`${value}`);
+
+            let pattern : string;
+            if (flag & FilterRegexFlag.STARTS_WITH) {
+                pattern = `${escaped}%`;
+            } else if (flag & FilterRegexFlag.ENDS_WITH) {
+                pattern = `%${escaped}`;
+            } else {
+                pattern = `%${escaped}%`;
+            }
+
+            return this.whereLike(field, pattern, !!(flag & FilterRegexFlag.NEGATION));
+        }
+
+        const regex = createFilterRegex(`${value}`, flag);
+
+        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, field, regex));
+    }
 
     protected whereLike(field: string, pattern: string, negated = false) : IFiltersAdapter {
         return this.adapter.whereRaw(

--- a/packages/sql/test/unit/interpreters/compound.spec.ts
+++ b/packages/sql/test/unit/interpreters/compound.spec.ts
@@ -110,12 +110,30 @@ describe('compound operators', () => {
 
         const [sql, params] = adapter.getQueryAndParameters();
 
-        expect(sql).toEqual([
+        expect(sql).toEqual(`(${[
             '("age" = $1 or "age" = $2)',
             'or ("qty" > $3 and "qty" < $4)',
             'or not ("qty" > $5 or "qty" < $6)',
             'or not ("active" = $7 and "age" > $8)',
-        ].join(' '));
+        ].join(' ')})`);
         expect(params).toStrictEqual([1, 2, 1, 20, 10, 20, false, 18]);
+    });
+
+    it('wraps a nested compound even when its first condition is parenthesized', () => {
+        const condition = new Filters('and', [
+            new Filter('eq', 'name', 'x'),
+            new Filters('or', [
+                new Filter('in', 'realm_id', ['a', null]),
+                new Filter('eq', 'age', 18),
+            ]),
+        ]);
+        condition.accept(visitor);
+
+        const [sql, params] = adapter.getQueryAndParameters();
+
+        expect(sql).toEqual(
+            '("name" = $1 and (("realm_id" in($2) or "realm_id" is null) or "age" = $3))',
+        );
+        expect(params).toStrictEqual(['x', 'a', 18]);
     });
 });

--- a/packages/sql/test/unit/interpreters/in.spec.ts
+++ b/packages/sql/test/unit/interpreters/in.spec.ts
@@ -62,4 +62,30 @@ describe('in (within, nin)', () => {
         expect(sql).toEqual(`${options.escapeField(condition.field)} not in($1, $2)`);
         expect(params).toStrictEqual(condition.value);
     });
+
+    it('generates a never-matching condition for "in" with an empty list', () => {
+        new Filter('in', 'age', []).accept(visitor);
+
+        expect(adapter.getQueryAndParameters()).toEqual(['1 = 0', []]);
+    });
+
+    it('generates an always-matching condition for "nin" with an empty list', () => {
+        new Filter('nin', 'age', []).accept(visitor);
+
+        expect(adapter.getQueryAndParameters()).toEqual(['1 = 1', []]);
+    });
+
+    it('keeps placeholder numbering continuous around an empty list', () => {
+        const condition = new Filters('and', [
+            new Filter('eq', 'name', 'John'),
+            new Filter('in', 'age', []),
+            new Filter('eq', 'active', true),
+        ]);
+        condition.accept(visitor);
+
+        expect(adapter.getQueryAndParameters()).toEqual([
+            '("name" = $1 and 1 = 0 and "active" = $2)',
+            ['John', true],
+        ]);
+    });
 });

--- a/packages/sql/test/unit/interpreters/regex.spec.ts
+++ b/packages/sql/test/unit/interpreters/regex.spec.ts
@@ -14,6 +14,7 @@ import {
     mysql,
     oracle,
     pg,
+    sqlite,
 } from '../../../src';
 
 describe('regex', () => {
@@ -129,5 +130,48 @@ describe('regex', () => {
 
         const [, params] = adapter.getQueryAndParameters();
         expect(params).toStrictEqual(['%100\\%\\_\\[a]%']);
+    });
+
+    it('falls back to LIKE for anchored operators on SQLite', () => {
+        const adapter = new FiltersAdapter(new RelationsAdapter(), sqlite);
+        const visitor = new FiltersVisitor(adapter);
+
+        new Filter('startsWith', 'name', 'foo').accept(visitor);
+
+        expect(adapter.getQueryAndParameters()).toEqual([
+            '`name` like ? escape \'\\\'',
+            ['foo%'],
+        ]);
+    });
+
+    it('throws a typed error for the regex operator on SQLite', () => {
+        const adapter = new FiltersAdapter(new RelationsAdapter(), sqlite);
+        const visitor = new FiltersVisitor(adapter);
+
+        expect(() => {
+            new Filter('regex', 'email', /@/).accept(visitor);
+        }).toThrow(AdapterError);
+    });
+
+    it('generates anchored patterns for anchored operators on regexp dialects', () => {
+        const cases : [string, string][] = [
+            ['startsWith', '^foo'],
+            ['endsWith', 'foo$'],
+            ['contains', 'foo'],
+            ['notStartsWith', '^(?!foo).+'],
+            ['notEndsWith', '^(?!.*foo$).*'],
+            ['notContains', '^(?!.*foo).*'],
+        ];
+
+        for (const [operator, pattern] of cases) {
+            const adapter = new FiltersAdapter(new RelationsAdapter(), pg);
+            const visitor = new FiltersVisitor(adapter);
+
+            new Filter(operator, 'name', 'foo').accept(visitor);
+
+            const [sql, params] = adapter.getQueryAndParameters();
+            expect(sql, operator).toEqual('"name" ~* $1');
+            expect(params, operator).toStrictEqual([pattern]);
+        }
     });
 });

--- a/packages/sql/test/unit/interpreters/regex.spec.ts
+++ b/packages/sql/test/unit/interpreters/regex.spec.ts
@@ -158,7 +158,7 @@ describe('regex', () => {
             ['startsWith', '^foo'],
             ['endsWith', 'foo$'],
             ['contains', 'foo'],
-            ['notStartsWith', '^(?!foo).+'],
+            ['notStartsWith', '^(?!foo).*'],
             ['notEndsWith', '^(?!.*foo$).*'],
             ['notContains', '^(?!.*foo).*'],
         ];


### PR DESCRIPTION
Fixes the four confirmed correctness findings from the #741 review audit, plus the copy-paste cleanups that let them regress silently.

## Correctness fixes

- **Compound wrapping** (`@rapiq/sql`): `FiltersBaseAdapter.merge()` decided parenthesization via `sql[0] !== '('`, so a nested compound whose *first* condition was itself parenthesized — e.g. the null-rewrite fragment `("realm_id" in($2) or "realm_id" is null)` — was merged unwrapped, producing wrong AND/OR precedence: `and(eq, or(in-with-null, eq))` rendered as `(name AND in-group) OR age` instead of `name AND (in-group OR age)`. Wrapping is now decided by condition count (single conditions are atomic terms or self-wrapped compounds). A top-level multi-condition OR group is now always wrapped too — the old expectation in `compound.spec.ts` was itself an instance of the bug.
- **Anchored regex patterns** (`@rapiq/core`): `createFilterRegexPattern` used `&&` instead of `&` for the CONTAINS check, so `startsWith`/`endsWith` produced **unanchored** patterns on regexp dialects — `startsWith(name, 'foo')` on pg emitted `"name" ~* 'foo'` and matched `xxfoo`, while the LIKE fallback on MSSQL correctly emitted `LIKE 'foo%'`. Patterns are now `^foo` / `foo$`; negated variants were already correct. (A pattern built without any anchor flag is now unanchored — previously it accidentally rendered `input$`.)
- **Empty `in`/`nin` lists** (`@rapiq/sql`): `Filter('in', field, [])` emitted the invalid SQL `field in()` — reachable from real client input through both parsers (`filter[id]=,` in parser-simple, `in(id)` in parser-expression). Now renders `1 = 0` (`nin`: `1 = 1`), with placeholder numbering kept continuous around it.
- **sqlite preset** (`@rapiq/sql`): was `{ ...mysql }`, inheriting a `regexp` callback although stock SQLite ships without a `REGEXP` function — `contains` emitted SQL that fails at runtime with `no such function: REGEXP`, while the LIKE fallback sat unreachable. The preset now omits `regexp`, routing anchored operators to LIKE (natively supported, incl. `ESCAPE`) and the `regex` operator to a typed `AdapterError`.

## Cleanups (same review)

- Fixed wrong operator type parameters on `visitFilterNotEndsWith` (`NOT_STARTS_WITH` → `NOT_ENDS_WITH`) and `visitFilterNotContains` (`CONTAINS` → `NOT_CONTAINS`).
- Collapsed the near-identical `visitFilterIn`/`visitFilterNotIn` bodies into a `whereIn` helper and the six anchored-operator bodies into a `whereAnchored` helper (matching the existing `whereLike` pattern), so future fixes land in one place.

## Tests

- New `packages/core/test/unit/parameter/filters-regex.spec.ts`: pattern + match assertions for all six flag combinations and case-insensitivity.
- `compound.spec.ts`: regression test for the precedence bug; complex-compound expectation updated to include the (correct) outer wrap.
- `in.spec.ts`: empty-list `in`/`nin` + placeholder continuity around them.
- `regex.spec.ts`: sqlite LIKE fallback + typed error, and anchored-pattern assertions for all six anchored operators on pg.

Docs (`integrations/sql.md`) updated for the sqlite preset and empty-list semantics; behavior log appended to `.agents/migration-notes.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SQL handling for combined conditions, anchored string matching, and empty `in` / `nin` lists.
  * Improved fallback behavior for databases without regex support, including clearer errors for unsupported regex filters.
  * Fixed parenthesis placement in complex filter expressions.

* **Tests**
  * Added coverage for regex anchoring, negation, SQLite fallback behavior, and empty list conditions.

* **Documentation**
  * Updated SQL integration notes to reflect current filter behavior and dialect support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->