### PR TITLE
feat(typeorm)!: dialect detection, left-join default, onJoin hook, idempotent joins, pagination echo

### DIFF
--- a/.agents/references/typeorm.md
+++ b/.agents/references/typeorm.md
@@ -10,5 +10,9 @@
 | TypeORM | rapiq | Notes |
 |---------|-------|-------|
 | `SelectQueryBuilder` (`src/query-builder/SelectQueryBuilder.ts`) | `TypeormAdapter<QUERY extends SelectQueryBuilder>` (`packages/typeorm/src/adapter/module.ts`) | Adapter mutates the builder via `withQuery(qb)` → visit → `execute()` |
+| `RelationMetadata.inverseEntityMetadata` (`src/metadata/RelationMetadata.ts`) | `RelationsAdapter.join()` (`packages/typeorm/src/adapter/relations.ts`) | Metadata of the entity **targeted** by a relation — used to walk nested relation paths. `entityMetadata` is the *owning* entity (using it silently drops nested paths whose segment doesn't also exist on the root entity). |
+| `connection.options.type` (`src/data-source/DataSourceOptions.ts`) | `resolveQueryDialect()` (`packages/typeorm/src/dialect.ts`) → `resolveDialect()` (`packages/sql/src/dialect/resolve.ts`) | Connection type name → `DialectOptions` preset; postgres preset is the last-resort fallback. |
+| `DataSource.buildMetadatas()` (`src/data-source/DataSource.ts`, protected) | `createUnconnectedDataSource()` (`packages/typeorm/test/data/factory.ts`) | Builds entity metadata without opening a connection — enables dialect specs (incl. `mysql`, needs `mysql2` devDep for driver construction) with no live database. |
+| `SelectQueryBuilder.expressionMap.joinAttributes` | `RelationsAdapter.join()` dedup | Pre-existing joins are matched by `joinAttribute.alias.name`; matching joins are skipped (idempotency). |
 
 <!-- Append new mappings as they are discovered. Include behavioral differences. -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -4205,6 +4205,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/aws-ssl-profiles": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/aws-ssl-profiles/-/aws-ssl-profiles-1.1.2.tgz",
+            "integrity": "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
         "node_modules/axios": {
             "version": "1.16.0",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
@@ -5065,6 +5075,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/denque": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+            "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=0.10"
             }
         },
         "node_modules/dequal": {
@@ -6056,6 +6076,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/generate-function": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+            "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-property": "^1.0.2"
+            }
+        },
         "node_modules/get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6429,7 +6459,6 @@
             "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -6718,6 +6747,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/is-typed-array": {
             "version": "1.1.15",
@@ -7356,6 +7392,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/lru-cache": {
             "version": "11.5.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
@@ -7364,6 +7407,22 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": "20 || >=22"
+            }
+        },
+        "node_modules/lru.min": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/lru.min/-/lru.min-1.1.4.tgz",
+            "integrity": "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1.0.0",
+                "deno": ">=1.30.0",
+                "node": ">=8.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wellwelwel"
             }
         },
         "node_modules/magic-string": {
@@ -7832,6 +7891,42 @@
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/mysql2": {
+            "version": "3.22.5",
+            "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.22.5.tgz",
+            "integrity": "sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "aws-ssl-profiles": "^1.1.2",
+                "denque": "^2.1.0",
+                "generate-function": "^2.3.1",
+                "iconv-lite": "^0.7.2",
+                "long": "^5.3.2",
+                "lru.min": "^1.1.4",
+                "named-placeholders": "^1.1.6",
+                "sql-escaper": "^1.3.3"
+            },
+            "engines": {
+                "node": ">= 8.0"
+            },
+            "peerDependencies": {
+                "@types/node": ">= 8"
+            }
+        },
+        "node_modules/named-placeholders": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.6.tgz",
+            "integrity": "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lru.min": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
         },
         "node_modules/nanoid": {
             "version": "3.3.14",
@@ -9350,8 +9445,7 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
-            "license": "MIT",
-            "optional": true
+            "license": "MIT"
         },
         "node_modules/search-insights": {
             "version": "2.17.3",
@@ -9717,6 +9811,22 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sql-escaper": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/sql-escaper/-/sql-escaper-1.3.3.tgz",
+            "integrity": "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "bun": ">=1.0.0",
+                "deno": ">=2.0.0",
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/mysqljs/sql-escaper?sponsor=1"
             }
         },
         "node_modules/sql-highlight": {
@@ -11590,6 +11700,7 @@
                 "@swc/core": "^1.15.43",
                 "ansis": "^4.2.0",
                 "better-sqlite3": "^12.6.0",
+                "mysql2": "^3.22.5",
                 "reflect-metadata": "^0.2.2",
                 "typeorm": "^0.3.28",
                 "unplugin-swc": "^1.5.9"

--- a/packages/docs/integrations/sql.md
+++ b/packages/docs/integrations/sql.md
@@ -24,6 +24,14 @@ Presets ship for `pg`, `mysql`, `sqlite`, `mssql` and `oracle`:
 import { mysql, pg } from '@rapiq/sql';
 ```
 
+`resolveDialect(name)` maps a driver/connection type name (e.g. TypeORM's `connection.options.type` or a knex client name) to the matching preset — `postgres`, `mariadb`, `better-sqlite3`, `oracledb`, … — and returns `undefined` for unknown names:
+
+```typescript
+import { resolveDialect } from '@rapiq/sql';
+
+resolveDialect('mariadb'); // mysql preset
+```
+
 ::: warning
 The `mssql` and `sqlite` presets omit `regexp` — SQL Server has no regexp operator, and stock SQLite ships without a `REGEXP` function. On dialects without `regexp`, the `contains` / `startsWith` / `endsWith` filter operators (and their negations) fall back to `LIKE ... ESCAPE '\'` with wildcard escaping; only the `regex` filter operator is unavailable and throws a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`).
 :::

--- a/packages/docs/integrations/typeorm.md
+++ b/packages/docs/integrations/typeorm.md
@@ -57,6 +57,10 @@ new TypeormAdapter({
 
 Relations are validated against the entity metadata of the attached query builder — a requested relation that doesn't exist on the entity is ignored. Joins are applied idempotently: relations already joined on the query builder (by the adapter or by your own code, matched by alias) are skipped, so applying a query twice does not duplicate joins.
 
+::: warning Alias convention
+Joins are aliased by the relation path's **last segment**: `role.realm` joins as alias `realm` — the same convention filter/sort/field references resolve against. Two relation paths ending in the same segment (e.g. `realm` and `role.realm`) therefore collide: the later join is skipped and references resolve against the first one. Path-qualified aliases are tracked in [#744](https://github.com/tada5hi/rapiq/issues/744).
+:::
+
 ::: info Migrating from typeorm-extension
 `applyQuery` used `leftJoinAndSelect` and returned the parsed pagination — `joinType: 'left'` (the default) and the `execute()` return value mirror that contract. The `onJoin` hook is the equivalent of typeorm-extension's `relations.onJoin`.
 :::

--- a/packages/docs/integrations/typeorm.md
+++ b/packages/docs/integrations/typeorm.md
@@ -20,7 +20,7 @@ const adapter = new TypeormAdapter({
 adapter.withQuery(queryBuilder);
 
 query.accept(new QueryVisitor(adapter));
-adapter.execute();
+const { pagination } = adapter.execute();
 
 const [entities, total] = await queryBuilder.getManyAndCount();
 ```
@@ -29,7 +29,11 @@ The flow is always the same:
 
 1. `withQuery(queryBuilder)` — attach the builder.
 2. `query.accept(new QueryVisitor(adapter))` — walk the AST; the adapter collects state.
-3. `adapter.execute()` — apply everything to the builder in one go.
+3. `adapter.execute()` — apply everything to the builder in one go; it returns the applied pagination (e.g. for the response `meta` block).
+
+## Dialect detection
+
+The adapter resolves the SQL dialect from the attached query builder's connection type (`postgres`, `mysql`/`mariadb`, `sqlite`/`better-sqlite3`, `mssql`, `oracle`, …). Field escaping is delegated to the query builder itself; regexp conditions use the matching [dialect preset](/integrations/sql#dialects) — on regexp-less dialects (SQLite, SQL Server) the `contains` / `startsWith` / `endsWith` operators fall back to `LIKE`, and the `regex` operator throws a typed `AdapterError`. When no query builder is bound (or the connection type is unknown), the postgres preset is the documented last-resort default.
 
 ## Options
 
@@ -37,15 +41,25 @@ The flow is always the same:
 new TypeormAdapter({
     relations: {
         joinAndSelect: true,
+        joinType: 'left',
+        onJoin: (path, alias, queryBuilder) => {
+            queryBuilder.addGroupBy(`${alias}.id`);
+        },
     },
 });
 ```
 
 | Option | Description |
 |---|---|
-| `relations.joinAndSelect` | Use `innerJoinAndSelect` (hydrate the related entities) instead of `innerJoin` (join for filtering/sorting only). |
+| `relations.joinAndSelect` | Join **and select** (hydrate the related entities) instead of joining for filtering/sorting only. |
+| `relations.joinType` | `'left'` (default) or `'inner'`. Left joins keep records whose relation is absent. |
+| `relations.onJoin` | Invoked as `(path, alias, queryBuilder)` for every join the adapter applies — e.g. to `addGroupBy` per join when the root query is grouped. Skipped (pre-existing) joins don't trigger it. |
 
-Relations are validated against the entity metadata of the attached query builder — a requested relation that doesn't exist on the entity is ignored.
+Relations are validated against the entity metadata of the attached query builder — a requested relation that doesn't exist on the entity is ignored. Joins are applied idempotently: relations already joined on the query builder (by the adapter or by your own code, matched by alias) are skipped, so applying a query twice does not duplicate joins.
+
+::: info Migrating from typeorm-extension
+`applyQuery` used `leftJoinAndSelect` and returned the parsed pagination — `joinType: 'left'` (the default) and the `execute()` return value mirror that contract. The `onJoin` hook is the equivalent of typeorm-extension's `relations.onJoin`.
+:::
 
 ## Applying a single parameter
 
@@ -92,7 +106,7 @@ export async function getUsers(req: Request, res: Response) {
     const adapter = new TypeormAdapter({ relations: { joinAndSelect: true } });
     adapter.withQuery(queryBuilder);
     query.accept(new QueryVisitor(adapter));
-    adapter.execute();
+    const { pagination } = adapter.execute();
 
     const [entities, total] = await queryBuilder.getManyAndCount();
 
@@ -100,8 +114,8 @@ export async function getUsers(req: Request, res: Response) {
         data: entities,
         meta: {
             total,
-            limit: query.pagination.limit,
-            offset: query.pagination.offset,
+            limit: pagination.limit,
+            offset: pagination.offset,
         },
     });
 }

--- a/packages/sql/src/dialect/index.ts
+++ b/packages/sql/src/dialect/index.ts
@@ -9,5 +9,6 @@ export * from './mssql';
 export * from './mysql';
 export * from './oracle';
 export * from './pg';
+export * from './resolve';
 export * from './sqlite';
 export * from './types';

--- a/packages/sql/src/dialect/resolve.ts
+++ b/packages/sql/src/dialect/resolve.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { mssql } from './mssql';
+import { mysql } from './mysql';
+import { oracle } from './oracle';
+import { pg } from './pg';
+import { sqlite } from './sqlite';
+import type { DialectOptions } from './types';
+
+const presets : Record<string, DialectOptions> = {
+    // postgres family
+    pg,
+    postgres: pg,
+    postgresql: pg,
+    'aurora-postgres': pg,
+    cockroachdb: pg,
+
+    // mysql family
+    mysql,
+    mysql2: mysql,
+    mariadb: mysql,
+    'aurora-mysql': mysql,
+
+    // sqlite family (embedded drivers share sqlite semantics)
+    sqlite,
+    sqlite3: sqlite,
+    'better-sqlite3': sqlite,
+    sqljs: sqlite,
+    capacitor: sqlite,
+    cordova: sqlite,
+    'react-native': sqlite,
+    nativescript: sqlite,
+    expo: sqlite,
+
+    // others
+    mssql,
+    oracle,
+    oracledb: oracle,
+};
+
+/**
+ * Resolve a driver/connection type name (e.g. TypeORM's
+ * `connection.options.type` or a knex client name) to the
+ * matching {@link DialectOptions} preset.
+ */
+export function resolveDialect(name: string) : DialectOptions | undefined {
+    return presets[name.toLowerCase()];
+}

--- a/packages/sql/test/unit/dialect.spec.ts
+++ b/packages/sql/test/unit/dialect.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    mssql,
+    mysql,
+    oracle,
+    pg,
+    resolveDialect,
+    sqlite,
+} from '../../src';
+
+describe('src/dialect/resolve.ts', () => {
+    it.each([
+        ['postgres', pg],
+        ['postgresql', pg],
+        ['cockroachdb', pg],
+        ['aurora-postgres', pg],
+        ['mysql', mysql],
+        ['mysql2', mysql],
+        ['mariadb', mysql],
+        ['aurora-mysql', mysql],
+        ['sqlite', sqlite],
+        ['better-sqlite3', sqlite],
+        ['sqljs', sqlite],
+        ['mssql', mssql],
+        ['oracle', oracle],
+    ])('should resolve %s', (name, preset) => {
+        expect(resolveDialect(name)).toBe(preset);
+    });
+
+    it('should resolve case-insensitively', () => {
+        expect(resolveDialect('MySQL')).toBe(mysql);
+    });
+
+    it('should not resolve unknown names', () => {
+        expect(resolveDialect('mongodb')).toBeUndefined();
+        expect(resolveDialect('spanner')).toBeUndefined();
+    });
+});

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -22,6 +22,7 @@
         "@swc/core": "^1.15.43",
         "ansis": "^4.2.0",
         "better-sqlite3": "^12.6.0",
+        "mysql2": "^3.22.5",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^0.3.28",
         "unplugin-swc": "^1.5.9"

--- a/packages/typeorm/src/adapter/fields.ts
+++ b/packages/typeorm/src/adapter/fields.ts
@@ -7,7 +7,6 @@
 
 import { FieldsBaseAdapter } from '@rapiq/sql';
 import type { SelectQueryBuilder } from 'typeorm';
-import { FieldOperator } from '@rapiq/core';
 import type { RelationsAdapter } from './relations';
 
 export class FieldsAdapter<
@@ -26,23 +25,20 @@ export class FieldsAdapter<
     }
 
     escapeField(field: string) {
+        // selection keys must stay `alias.property` — TypeORM resolves
+        // them against its alias map and escapes on its own; pre-escaped
+        // names break column resolution and entity hydration.
         return field;
     }
 
     execute() {
-        if (!this.query || this.value.length === 0) {
+        if (!this.query) {
             return;
         }
 
-        const names = this.value
-            .filter(
-                (el) => !el.operator ||
-                    el.operator === FieldOperator.INCLUDE,
-            )
-            .map((el) => el.name);
-
-        if (names.length > 0) {
-            this.query.select(names);
+        const columns = this.getColumns();
+        if (columns.length > 0) {
+            this.query.select(columns);
         }
     }
 }

--- a/packages/typeorm/src/adapter/filters.ts
+++ b/packages/typeorm/src/adapter/filters.ts
@@ -6,20 +6,30 @@
  */
 
 import { AdapterError } from '@rapiq/core';
-import { FiltersBaseAdapter, pg } from '@rapiq/sql';
+import type { DialectOptions } from '@rapiq/sql';
+import { FiltersBaseAdapter } from '@rapiq/sql';
 import type { SelectQueryBuilder } from 'typeorm';
+import { resolveQueryDialect } from '../dialect';
 import type { RelationsAdapter } from './relations';
 
 export class FiltersAdapter<
     QUERY extends SelectQueryBuilder<any> = SelectQueryBuilder<any>,
 > extends FiltersBaseAdapter<QUERY, RelationsAdapter<QUERY>> {
+    protected dialect : DialectOptions;
+
     constructor(relations: RelationsAdapter<QUERY>) {
         super(relations);
+
+        this.dialect = resolveQueryDialect();
+    }
+
+    override withQuery(query?: QUERY) {
+        this.dialect = resolveQueryDialect(query);
+
+        return super.withQuery(query);
     }
 
     rootAlias(): string | undefined {
-        // todo: get this.query.connection.options.type -> dialect
-
         if (this.query) {
             return this.query.alias;
         }
@@ -31,20 +41,23 @@ export class FiltersAdapter<
         if (this.query) {
             return this.query.escape(field);
         }
-        return pg.escapeField(field);
+
+        return this.dialect.escapeField(field);
     }
 
     paramPlaceholder(index: number) : string {
         return `:${index - 1}`;
     }
 
+    override isRegexpSupported() : boolean {
+        return typeof this.dialect.regexp !== 'undefined';
+    }
+
     regexp(field: string, placeholder: string, ignoreCase: boolean): string {
-        // todo: get this.query.connection.options.type -> dialect
-        if (pg.regexp) {
-            return pg.regexp(field, placeholder, ignoreCase);
+        if (this.dialect.regexp) {
+            return this.dialect.regexp(field, placeholder, ignoreCase);
         }
 
-        /* istanbul ignore next -- pg always defines regexp */
         throw AdapterError.featureUnsupported('regexp');
     }
 

--- a/packages/typeorm/src/adapter/index.ts
+++ b/packages/typeorm/src/adapter/index.ts
@@ -8,5 +8,7 @@
 export * from './fields';
 export * from './filters';
 export * from './module';
+export * from './pagination';
 export * from './relations';
 export * from './sort';
+export * from './types';

--- a/packages/typeorm/src/adapter/module.ts
+++ b/packages/typeorm/src/adapter/module.ts
@@ -11,7 +11,7 @@ import { RelationsAdapter } from './relations';
 import { FieldsAdapter } from './fields';
 import { FiltersAdapter } from './filters';
 import { SortAdapter } from './sort';
-import type { TypeormAdapterOptions } from './types';
+import type { TypeormAdapterOptions, TypeormAdapterOutput } from './types';
 import { PaginationAdapter } from './pagination';
 
 export class TypeormAdapter<
@@ -29,7 +29,7 @@ export class TypeormAdapter<
 
     protected query : QUERY | undefined;
 
-    constructor(options: TypeormAdapterOptions = {}) {
+    constructor(options: TypeormAdapterOptions<QUERY> = {}) {
         this.relations = new RelationsAdapter<QUERY>(options.relations);
         this.fields = new FieldsAdapter<QUERY>(this.relations);
         this.filters = new FiltersAdapter<QUERY>(this.relations);
@@ -55,11 +55,18 @@ export class TypeormAdapter<
         this.relations.clear();
     }
 
-    execute() {
+    execute() : TypeormAdapterOutput {
         this.fields.execute();
         this.filters.execute();
         this.pagination.execute();
         this.sort.execute();
         this.relations.execute();
+
+        return {
+            pagination: {
+                limit: this.pagination.limit,
+                offset: this.pagination.offset,
+            },
+        };
     }
 }

--- a/packages/typeorm/src/adapter/pagination.ts
+++ b/packages/typeorm/src/adapter/pagination.ts
@@ -5,27 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { PaginationBaseAdapter, pg } from '@rapiq/sql';
+import { PaginationBaseAdapter } from '@rapiq/sql';
 import type { SelectQueryBuilder } from 'typeorm';
 
 export class PaginationAdapter<
     QUERY extends SelectQueryBuilder<any> = SelectQueryBuilder<any>,
 > extends PaginationBaseAdapter<QUERY> {
-    rootAlias(): string | undefined {
-        if (this.query) {
-            return this.query.alias;
-        }
-
-        return undefined;
-    }
-
-    escapeField(field: string) {
-        if (this.query) {
-            return this.query.escape(field);
-        }
-        return pg.escapeField(field);
-    }
-
     override execute() {
         if (!this.query) {
             return;

--- a/packages/typeorm/src/adapter/relations.ts
+++ b/packages/typeorm/src/adapter/relations.ts
@@ -5,16 +5,16 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { RelationsAdapterBaseOptions } from '@rapiq/sql';
 import { RelationsBaseAdapter, splitFirst } from '@rapiq/sql';
 import type { SelectQueryBuilder } from 'typeorm';
+import type { RelationsAdapterOptions } from './types';
 
 export class RelationsAdapter<
     QUERY extends SelectQueryBuilder<any> = SelectQueryBuilder<any>,
 > extends RelationsBaseAdapter<QUERY> {
-    protected options : RelationsAdapterBaseOptions;
+    protected options : RelationsAdapterOptions<QUERY>;
 
-    constructor(options: RelationsAdapterBaseOptions = {}) {
+    constructor(options: RelationsAdapterOptions<QUERY> = {}) {
         super();
 
         this.options = options;
@@ -25,10 +25,14 @@ export class RelationsAdapter<
             return;
         }
 
-        // todo: mark items applied
         for (const relation of this.value) {
-            // todo: sub paths might already applied ...
-            this.join(relation.path);
+            if (relation.executed) {
+                continue;
+            }
+
+            if (this.join(relation.path)) {
+                relation.executed = true;
+            }
         }
     }
 
@@ -38,6 +42,7 @@ export class RelationsAdapter<
         }
 
         let relationFullName : string | undefined = input;
+        let path : string | undefined;
         let meta = this.query.expressionMap.mainAlias!.metadata;
         let { alias } = this.query;
 
@@ -47,28 +52,51 @@ export class RelationsAdapter<
             let relationName : string;
             [relationName, relationFullName] = splitFirst(relationFullName);
 
+            path = path ?
+                `${path}.${relationName}` :
+                relationName;
+
             const relation = meta.findRelationWithPropertyPath(relationName);
-
-            if (relation) {
-                const joined = joinAttributes.findIndex(
-                    (joinAttribute) => joinAttribute.alias.name === relationName,
-                );
-
-                if (joined === -1) {
-                    if (this.options.joinAndSelect) {
-                        this.query.innerJoinAndSelect(`${alias}.${relationName}`, relationName);
-                    } else {
-                        this.query.innerJoin(`${alias}.${relationName}`, relationName);
-                    }
-                }
-
-                meta = relation.entityMetadata;
-                alias = relationName;
-            } else {
+            if (!relation) {
                 return false;
             }
+
+            const joined = joinAttributes.some(
+                (joinAttribute) => joinAttribute.alias.name === relationName,
+            );
+
+            if (!joined) {
+                this.applyJoin(`${alias}.${relationName}`, relationName);
+
+                if (this.options.onJoin) {
+                    this.options.onJoin(path, relationName, this.query);
+                }
+            }
+
+            meta = relation.inverseEntityMetadata;
+            alias = relationName;
         }
 
         return true;
+    }
+
+    protected applyJoin(property: string, alias: string) : void {
+        if (!this.query) {
+            return;
+        }
+
+        const inner = this.options.joinType === 'inner';
+
+        if (this.options.joinAndSelect) {
+            if (inner) {
+                this.query.innerJoinAndSelect(property, alias);
+            } else {
+                this.query.leftJoinAndSelect(property, alias);
+            }
+        } else if (inner) {
+            this.query.innerJoin(property, alias);
+        } else {
+            this.query.leftJoin(property, alias);
+        }
     }
 }

--- a/packages/typeorm/src/adapter/types.ts
+++ b/packages/typeorm/src/adapter/types.ts
@@ -6,7 +6,41 @@
  */
 
 import type { RelationsAdapterBaseOptions } from '@rapiq/sql';
+import type { SelectQueryBuilder } from 'typeorm';
 
-export type TypeormAdapterOptions = {
-    relations?: RelationsAdapterBaseOptions
+export type RelationsAdapterJoinType = 'left' | 'inner';
+
+export type RelationsAdapterOptions<
+    QUERY extends SelectQueryBuilder<any> = SelectQueryBuilder<any>,
+> = RelationsAdapterBaseOptions & {
+    /**
+     * Join strategy for relations.
+     * Defaults to 'left' so records with absent relations are kept
+     * (matches typeorm-extension's leftJoinAndSelect behavior).
+     */
+    joinType?: RelationsAdapterJoinType,
+
+    /**
+     * Invoked for every join this adapter applies (skipped joins,
+     * e.g. pre-existing ones, do not trigger it). Useful to extend
+     * the query per join, e.g. `query.addGroupBy(`${alias}.id`)`.
+     */
+    onJoin?: (path: string, alias: string, query: QUERY) => void,
+};
+
+export type TypeormAdapterOptions<
+    QUERY extends SelectQueryBuilder<any> = SelectQueryBuilder<any>,
+> = {
+    relations?: RelationsAdapterOptions<QUERY>
+};
+
+export type TypeormAdapterOutput = {
+    /**
+     * The pagination actually applied to the query builder,
+     * e.g. for the response meta block.
+     */
+    pagination: {
+        limit: number | undefined,
+        offset: number | undefined,
+    }
 };

--- a/packages/typeorm/src/dialect.ts
+++ b/packages/typeorm/src/dialect.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { DialectOptions } from '@rapiq/sql';
+import { pg, resolveDialect } from '@rapiq/sql';
+import type { SelectQueryBuilder } from 'typeorm';
+
+/**
+ * Resolve the {@link DialectOptions} preset matching the bound query
+ * builder's connection type. The postgres preset is the documented
+ * last-resort default when no query builder is bound (yet) or the
+ * connection type has no matching preset.
+ */
+export function resolveQueryDialect(
+    query?: SelectQueryBuilder<any>,
+) : DialectOptions {
+    if (query) {
+        const dialect = resolveDialect(query.connection.options.type);
+        if (dialect) {
+            return dialect;
+        }
+    }
+
+    return pg;
+}

--- a/packages/typeorm/src/index.ts
+++ b/packages/typeorm/src/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './adapter';
+export * from './dialect';

--- a/packages/typeorm/test/data/entity/role-detail.ts
+++ b/packages/typeorm/test/data/entity/role-detail.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+
+@Entity()
+export class RoleDetail {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ nullable: true })
+    description: string;
+}

--- a/packages/typeorm/test/data/entity/role.ts
+++ b/packages/typeorm/test/data/entity/role.ts
@@ -12,6 +12,7 @@ import {
     PrimaryGeneratedColumn,
 } from 'typeorm';
 import { Realm } from './realm';
+import { RoleDetail } from './role-detail';
 
 @Entity()
 export class Role {
@@ -27,4 +28,11 @@ export class Role {
     @ManyToOne(() => Realm, (role: Realm) => role.id, { nullable: true })
     @JoinColumn({ name: 'realm_id' })
     realm: Realm;
+
+    @Column({ nullable: true })
+    detail_id: number | null;
+
+    @ManyToOne(() => RoleDetail, { nullable: true })
+    @JoinColumn({ name: 'detail_id' })
+    detail: RoleDetail;
 }

--- a/packages/typeorm/test/data/factory.ts
+++ b/packages/typeorm/test/data/factory.ts
@@ -9,17 +9,38 @@ import type { DataSourceOptions } from 'typeorm';
 import { DataSource } from 'typeorm';
 import { Realm } from './entity/realm';
 import { Role } from './entity/role';
+import { RoleDetail } from './entity/role-detail';
 import { User } from './entity/user';
 
 export function createDataSourceOptions() : DataSourceOptions {
     return {
         type: 'better-sqlite3',
-        entities: [Role, User, Realm],
+        entities: [Role, RoleDetail, User, Realm],
         database: ':memory:',
         extra: { charset: 'UTF8_GENERAL_CI' },
     };
 }
 
+export function createMysqlDataSourceOptions() : DataSourceOptions {
+    return {
+        type: 'mysql',
+        entities: [Role, RoleDetail, User, Realm],
+        database: 'test',
+    };
+}
+
 export function createDataSource(options?: DataSourceOptions) : DataSource {
     return new DataSource(options || createDataSourceOptions());
+}
+
+/**
+ * Build entity metadata without opening a connection — enough for
+ * query-builder SQL generation in dialect specs (no live database).
+ */
+export async function createUnconnectedDataSource(options?: DataSourceOptions) : Promise<DataSource> {
+    const dataSource = createDataSource(options);
+
+    await (dataSource as unknown as { buildMetadatas: () => Promise<void> }).buildMetadatas();
+
+    return dataSource;
 }

--- a/packages/typeorm/test/unit/adapter/filters.spec.ts
+++ b/packages/typeorm/test/unit/adapter/filters.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    AdapterError,
+    Filter,
+    FilterFieldOperator,
+} from '@rapiq/core';
+import { FiltersVisitor } from '@rapiq/sql';
+import type { DataSource } from 'typeorm';
+import { TypeormAdapter } from '../../../src';
+import { User } from '../../data/entity/user';
+import {
+    createMysqlDataSourceOptions,
+    createUnconnectedDataSource,
+} from '../../data/factory';
+
+describe('src/adapter/filters.ts', () => {
+    let sqlite : DataSource;
+    let mysql : DataSource;
+
+    beforeAll(async () => {
+        sqlite = await createUnconnectedDataSource();
+        mysql = await createUnconnectedDataSource(createMysqlDataSourceOptions());
+    });
+
+    const apply = (
+        dataSource: DataSource,
+        condition: Filter,
+    ) : [string, unknown[]] => {
+        const queryBuilder = dataSource
+            .getRepository(User)
+            .createQueryBuilder('user');
+
+        const adapter = new TypeormAdapter();
+        adapter.withQuery(queryBuilder);
+
+        condition.accept(new FiltersVisitor(adapter.filters));
+
+        return adapter.filters.getQueryAndParameters();
+    };
+
+    it('should escape fields per dialect', () => {
+        const condition = new Filter(FilterFieldOperator.EQUAL, 'age', 18);
+
+        const [sqliteSql, sqliteParams] = apply(sqlite, condition);
+        expect(sqliteSql).toEqual('"user"."age" = :0');
+        expect(sqliteParams).toEqual([18]);
+
+        const [mysqlSql, mysqlParams] = apply(mysql, condition);
+        expect(mysqlSql).toEqual('`user`.`age` = :0');
+        expect(mysqlParams).toEqual([18]);
+    });
+
+    it('should build mysql regexp conditions', () => {
+        const condition = new Filter(FilterFieldOperator.REGEX, 'first_name', /^Aston/);
+
+        const [sql, params] = apply(mysql, condition);
+        expect(sql).toEqual('`user`.`first_name` regexp :0 = 1');
+        expect(params).toEqual(['^Aston']);
+    });
+
+    it('should reject regexp conditions on sqlite', () => {
+        const condition = new Filter(FilterFieldOperator.REGEX, 'first_name', /^Aston/);
+
+        expect(() => apply(sqlite, condition)).toThrow(AdapterError);
+    });
+
+    it('should fall back to like for anchored operators on sqlite', () => {
+        const condition = new Filter(FilterFieldOperator.STARTS_WITH, 'first_name', 'Aston');
+
+        const [sql, params] = apply(sqlite, condition);
+        expect(sql).toEqual('"user"."first_name" like :0 escape \'\\\'');
+        expect(params).toEqual(['Aston%']);
+    });
+
+    it('should build anchored operators as regexp on mysql', () => {
+        const condition = new Filter(FilterFieldOperator.STARTS_WITH, 'first_name', 'Aston');
+
+        const [sql, params] = apply(mysql, condition);
+        expect(sql).toEqual('`user`.`first_name` regexp :0 = 1');
+        expect(params).toEqual(['^Aston']);
+    });
+
+    it('should render null-aware in conditions', () => {
+        const condition = new Filter(FilterFieldOperator.IN, 'realm_id', [1, null]);
+
+        const [sql, params] = apply(mysql, condition);
+        expect(sql).toEqual('(`user`.`realm_id` in(:0) or `user`.`realm_id` is null)');
+        expect(params).toEqual([1]);
+    });
+
+    it('should fall back to the postgres preset without a bound query', () => {
+        const adapter = new TypeormAdapter();
+
+        const condition = new Filter(FilterFieldOperator.EQUAL, 'age', 18);
+        condition.accept(new FiltersVisitor(adapter.filters));
+
+        const [sql, params] = adapter.filters.getQueryAndParameters();
+        expect(sql).toEqual('"age" = :0');
+        expect(params).toEqual([18]);
+    });
+});

--- a/packages/typeorm/test/unit/adapter/module.spec.ts
+++ b/packages/typeorm/test/unit/adapter/module.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { DataSource } from 'typeorm';
+import { TypeormAdapter } from '../../../src';
+import { User } from '../../data/entity/user';
+import { createUnconnectedDataSource } from '../../data/factory';
+
+describe('src/adapter/module.ts', () => {
+    let dataSource : DataSource;
+
+    beforeAll(async () => {
+        dataSource = await createUnconnectedDataSource();
+    });
+
+    it('should return the applied pagination', () => {
+        const queryBuilder = dataSource
+            .getRepository(User)
+            .createQueryBuilder('user');
+
+        const adapter = new TypeormAdapter();
+        adapter.withQuery(queryBuilder);
+        adapter.pagination.setLimit(10);
+        adapter.pagination.setOffset(20);
+
+        const output = adapter.execute();
+
+        expect(output.pagination).toEqual({ limit: 10, offset: 20 });
+        expect(queryBuilder.expressionMap.take).toEqual(10);
+        expect(queryBuilder.expressionMap.skip).toEqual(20);
+    });
+
+    it('should return undefined pagination when none applies', () => {
+        const queryBuilder = dataSource
+            .getRepository(User)
+            .createQueryBuilder('user');
+
+        const adapter = new TypeormAdapter();
+        adapter.withQuery(queryBuilder);
+
+        const output = adapter.execute();
+
+        expect(output.pagination).toEqual({ limit: undefined, offset: undefined });
+    });
+});

--- a/packages/typeorm/test/unit/adapter/module.spec.ts
+++ b/packages/typeorm/test/unit/adapter/module.spec.ts
@@ -34,7 +34,7 @@ describe('src/adapter/module.ts', () => {
         expect(queryBuilder.expressionMap.skip).toEqual(20);
     });
 
-    it('should return undefined pagination when none applies', () => {
+    it('should return unset pagination values when none apply', () => {
         const queryBuilder = dataSource
             .getRepository(User)
             .createQueryBuilder('user');

--- a/packages/typeorm/test/unit/adapter/relations.spec.ts
+++ b/packages/typeorm/test/unit/adapter/relations.spec.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { Relation, Relations } from '@rapiq/core';
+import { RelationsVisitor } from '@rapiq/sql';
+import type { DataSource, SelectQueryBuilder } from 'typeorm';
+import type { RelationsAdapterOptions } from '../../../src';
+import { TypeormAdapter } from '../../../src';
+import { User } from '../../data/entity/user';
+import { createUnconnectedDataSource } from '../../data/factory';
+
+describe('src/adapter/relations.ts', () => {
+    let dataSource : DataSource;
+
+    beforeAll(async () => {
+        dataSource = await createUnconnectedDataSource();
+    });
+
+    const setup = (options?: RelationsAdapterOptions) => {
+        const queryBuilder = dataSource
+            .getRepository(User)
+            .createQueryBuilder('user');
+
+        const adapter = new TypeormAdapter({ relations: options });
+        adapter.withQuery(queryBuilder);
+
+        return { queryBuilder, adapter };
+    };
+
+    const visit = (
+        adapter: TypeormAdapter,
+        ...relations: string[]
+    ) => {
+        const nodes = new Relations(relations.map((name) => new Relation(name)));
+        nodes.accept(new RelationsVisitor(adapter.relations));
+    };
+
+    it('should left join by default', () => {
+        const { queryBuilder, adapter } = setup();
+
+        visit(adapter, 'realm');
+        adapter.execute();
+
+        expect(queryBuilder.getSql()).toContain('LEFT JOIN');
+        expect(queryBuilder.expressionMap.joinAttributes).toHaveLength(1);
+    });
+
+    it('should inner join on request', () => {
+        const { queryBuilder, adapter } = setup({ joinType: 'inner' });
+
+        visit(adapter, 'realm');
+        adapter.execute();
+
+        expect(queryBuilder.getSql()).toContain('INNER JOIN');
+    });
+
+    it('should join and select on request', () => {
+        const { queryBuilder, adapter } = setup({ joinAndSelect: true });
+
+        visit(adapter, 'realm');
+        adapter.execute();
+
+        expect(queryBuilder.getSql()).toContain('LEFT JOIN');
+        expect(
+            queryBuilder.expressionMap.selects.some(
+                (select) => select.selection === 'realm',
+            ),
+        ).toBeTruthy();
+    });
+
+    it('should not join twice on repeated execution', () => {
+        const { queryBuilder, adapter } = setup();
+
+        visit(adapter, 'realm');
+        adapter.execute();
+        adapter.execute();
+
+        expect(queryBuilder.expressionMap.joinAttributes).toHaveLength(1);
+    });
+
+    it('should skip pre-existing joins', () => {
+        const { queryBuilder, adapter } = setup();
+        queryBuilder.leftJoinAndSelect('user.realm', 'realm');
+
+        visit(adapter, 'realm');
+        adapter.execute();
+
+        expect(queryBuilder.expressionMap.joinAttributes).toHaveLength(1);
+    });
+
+    it('should join nested relation paths', () => {
+        const { queryBuilder, adapter } = setup();
+
+        // `detail` only exists on Role, not on User — resolvable
+        // only when the walk descends into the related entity metadata.
+        visit(adapter, 'role.detail');
+        adapter.execute();
+
+        const paths = queryBuilder.expressionMap.joinAttributes.map(
+            (join) => join.entityOrProperty,
+        );
+        expect(paths).toEqual(['user.role', 'role.detail']);
+    });
+
+    it('should drop unknown relations', () => {
+        const { queryBuilder, adapter } = setup();
+
+        visit(adapter, 'nonexistent');
+        adapter.execute();
+
+        expect(queryBuilder.expressionMap.joinAttributes).toHaveLength(0);
+    });
+
+    it('should invoke the onJoin hook per applied join', () => {
+        const calls : [string, string][] = [];
+
+        const { queryBuilder, adapter } = setup({
+            onJoin: (path, alias, query: SelectQueryBuilder<any>) => {
+                calls.push([path, alias]);
+                query.addGroupBy(`${alias}.id`);
+            },
+        });
+
+        visit(adapter, 'role.detail');
+        adapter.execute();
+
+        expect(calls).toEqual([
+            ['role', 'role'],
+            ['role.detail', 'detail'],
+        ]);
+        expect(queryBuilder.getSql()).toContain('GROUP BY');
+    });
+
+    it('should not invoke the onJoin hook for skipped joins', () => {
+        const calls : string[] = [];
+
+        const { queryBuilder, adapter } = setup({
+            onJoin: (path) => {
+                calls.push(path);
+            },
+        });
+        queryBuilder.leftJoin('user.realm', 'realm');
+
+        visit(adapter, 'realm');
+        adapter.execute();
+
+        expect(calls).toHaveLength(0);
+    });
+});

--- a/packages/typeorm/test/unit/query.spec.ts
+++ b/packages/typeorm/test/unit/query.spec.ts
@@ -17,6 +17,7 @@ import { createUserSeed } from '../data/seeder/user';
 
 describe('src/query', () => {
     let dataSource : DataSource;
+    let masterRealmId : number;
 
     beforeAll(async () => {
         dataSource = createDataSource();
@@ -28,6 +29,8 @@ describe('src/query', () => {
 
         aston.realm = master;
         await dataSource.getRepository(User).save(aston);
+
+        masterRealmId = master.id;
     });
 
     afterAll(async () => {
@@ -75,5 +78,50 @@ describe('src/query', () => {
         for (const entity of entities) {
             expect(entity.age).toBeGreaterThanOrEqual(18);
         }
+    });
+
+    it('should apply an authup-style repository query', async () => {
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema({
+            name: 'user',
+            filters: { allowed: ['id', 'realm_id'] },
+            relations: { allowed: ['role'] },
+            pagination: { maxLimit: 10 },
+        }));
+
+        const parser = new SimpleParser(registry);
+
+        // realm scoping: match records of a realm *or* without one;
+        // requested limit exceeds maxLimit and is clamped.
+        const query = parser.parse({
+            filters: { realm_id: [`${masterRealmId}`, 'null'] },
+            relations: ['role'],
+            pagination: { limit: 50 },
+        }, { schema: 'user' });
+
+        const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
+        queryBuilder.groupBy('user.id');
+
+        const adapter = new TypeormAdapter({
+            relations: {
+                joinAndSelect: true,
+                onJoin: (path, alias, join) => {
+                    join.addGroupBy(`${alias}.id`);
+                },
+            },
+        });
+        adapter.withQuery(queryBuilder);
+        query.accept(new QueryVisitor(adapter));
+
+        const { pagination } = adapter.execute();
+        expect(pagination.limit).toEqual(10);
+
+        const sql = queryBuilder.getSql();
+        expect(sql).toContain('LEFT JOIN');
+        expect(sql).toContain('GROUP BY');
+
+        // aston (realm master) + caleb (no realm) both match
+        const entities = await queryBuilder.getMany();
+        expect(entities.length).toEqual(2);
     });
 });


### PR DESCRIPTION
## Summary

Completes `@rapiq/typeorm` (plan 004, roadmap M2) with the expanded acceptance criteria from the typeorm-extension migration contract.

### @rapiq/sql
- New `resolveDialect(name)` export: maps driver/connection type names (TypeORM's `connection.options.type`, knex client names) to the `DialectOptions` presets.

### @rapiq/typeorm
- **Dialect detection** — adapters resolve the dialect preset from the bound query builder's connection type. Regexp conditions use the matching preset (`mysql` → `field regexp :0 = 1`); regexp-less dialects (sqlite, mssql) fall back to `LIKE` for anchored operators and throw a typed `AdapterError` for the `regex` operator. No hardcoded `pg.` usage remains in `src/adapter/`; the postgres preset is only the documented last-resort default when no query builder is bound.
- **Left-join default** — relations now join with `LEFT JOIN` (typeorm-extension `leftJoinAndSelect` parity); `relations.joinType: 'inner'` restores inner joins.
- **`onJoin` hook** — `relations.onJoin(path, alias, queryBuilder)` fires per applied join (not for skipped/pre-existing ones), enabling the `addGroupBy(\`${alias}.id\`)` pattern used across authup/hub repositories.
- **Idempotent joins** — applied relation items are marked, pre-existing joins (matched by alias) are skipped; applying a query twice no longer duplicates joins. Nested relation walks now descend via `RelationMetadata.inverseEntityMetadata` — previously a nested path segment that did not also exist on the root entity was silently dropped.
- **Pagination echo** — `TypeormAdapter.execute()` returns `{ pagination: { limit, offset } }` for the response `meta` block (`applyQuery` parity).
- Fields/sort adapters keep raw `alias.property` names by design (TypeORM resolves and escapes them itself); documented inline.

### Tests
- Isolated per-dialect adapter specs run against **unconnected** DataSources (better-sqlite3 + mysql via `mysql2` devDep and metadata-only build) — no live database.
- Consumer-derived acceptance test: authup-style repository query (realm `[id, null]` filter, `maxLimit` clamp, grouped root query with per-join `addGroupBy`).

### Docs
- `integrations/typeorm.md`: dialect detection, new options, execute return value, typeorm-extension migration callout.
- `integrations/sql.md`: `resolveDialect` section.

## Breaking changes
- Relations join with `LEFT JOIN` by default instead of `INNER JOIN` — records with absent relations are kept. Pass `relations.joinType: 'inner'` to restore the previous behavior.
- `TypeormAdapter.execute()` now returns `TypeormAdapterOutput` instead of `void`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dialect detection and resolution across supported SQL drivers, including common aliases and a fallback preset.
  * Improved TypeORM adapter handling for pagination, relations, joins, and regex-aware filters.
  * Added support for nested relation paths, configurable join types, and join callbacks.
* **Bug Fixes**
  * Prevented duplicate joins and made repeated adapter execution idempotent.
  * Improved behavior when unknown dialects or unsupported regex filters are encountered.
* **Documentation**
  * Updated SQL and TypeORM docs with the new dialect and adapter behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->