### PR TITLE
feat(parser-mongo): mongodb query parser dialect

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -28,7 +28,7 @@ URLEncoder (@rapiq/codec-url-simple)
 
 The `Query` AST is an **intermediate representation (IR)**. Every package plays exactly one role around it:
 
-1. **Define & interact** — client-side construction (plan 012): `defineQuery<RECORD>(QueryBuildInput)` + per-parameter `define*` fragment factories desugar typed input (scalars → `eq`, bare arrays → `in` with `null` legal, `$`-operator objects, condition-helper trees) straight to the AST — schema-free, no parsing. Condition helpers (`parameter/filters/helpers/`, one per `FilterFieldOperator`; `in` → `inArray` since `in` is reserved) build `Filter`/`Filters` nodes directly. Queries compose immutably via `mergeQueries` (left-priority; fields/relations/sorts keyed by name, pagination per-property) and the `Filters` combinators: `merge()` = per-field replace, flat root-AND only (typed `MergeError`, `ErrorCode.FILTERS_NOT_FLAT`); `and()`/`or()` = wrap & inject (server scoping — injected conditions can't be displaced by later merges). `$and`/`$or` object keys stay reserved for a future mongo parser dialect. `QueryBuilder` was removed — `defineQuery` replaces it.
+1. **Define & interact** — client-side construction (plan 012): `defineQuery<RECORD>(QueryBuildInput)` + per-parameter `define*` fragment factories desugar typed input (scalars → `eq`, bare arrays → `in` with `null` legal, `$`-operator objects, condition-helper trees) straight to the AST — schema-free, no parsing. Condition helpers (`parameter/filters/helpers/`, one per `FilterFieldOperator`; `in` → `inArray` since `in` is reserved) build `Filter`/`Filters` nodes directly. Queries compose immutably via `mergeQueries` (left-priority; fields/relations/sorts keyed by name, pagination per-property) and the `Filters` combinators: `merge()` = per-field replace, flat root-AND only (typed `MergeError`, `ErrorCode.FILTERS_NOT_FLAT`); `and()`/`or()` = wrap & inject (server scoping — injected conditions can't be displaced by later merges). `$and`/`$or` object keys stay reserved for the mongo parser dialect (`@rapiq/parser-mongo`). `QueryBuilder` was removed — `defineQuery` replaces it.
 2. **Parse to IR** — parsers transform *dialect* input (a spec for how parameters are written: "simple" object shapes, "expression" strings) into the IR, validated against a `Schema`. Parsers are **transport-agnostic**: they read only the canonical `Parameter` keys (`fields`, `filters`, `pagination`, `relations`, `sort`) and know nothing about how the input crossed a process boundary.
 3. **Consume the IR** — either interpret/walk it directly (`@rapiq/sql`, `@rapiq/typeorm` via visitors), or…
 4. **Transport the IR between application boundaries via a codec** — `@rapiq/codec-url-simple` is *one* such codec (HTTP URI scheme). The codec owns the complete wire format: the parameter wire names (`URLParameter`: `filter`, `page`, `include`, …) live **only** there, and `URLDecoder` is the boundary adapter — it accepts a raw query string *or* a pre-parsed query object (express `req.query`), maps wire names to canonical parameters and delegates to a schema-aware `SimpleParser`. App2 then works with the same IR. `@rapiq/codec-url-expression` is the sibling codec for the expression dialect (nested filter compounds in a single `filter=and(...)` param; the other four parameters share the simple wire machinery).
@@ -128,7 +128,7 @@ Parameter quirks (sort tuple groups, fields `execute()`, filter value parsing) s
 
 ### Parsers (dialects of input)
 
-Both parsers extend `BaseParser<OPTIONS, OUTPUT>` from core and compose one sub-parser per parameter:
+All parsers extend `BaseParser<OPTIONS, OUTPUT>` from core and compose one sub-parser per parameter:
 
 - **`SimpleParser`** (`packages/parser-simple/src/module.ts`) — plain object input, URL-query-like:
   ```typescript
@@ -143,6 +143,12 @@ Both parsers extend `BaseParser<OPTIONS, OUTPUT>` from core and compose one sub-
 - **`ExpressionParser`** (`packages/parser-expression/src/module.ts`) — function-call filter expressions (values always single-quoted), tokenizer + recursive-descent parser producing the same `Filters`/`Filter` AST:
   ```
   or(and(eq(name, 'John'), gte(age, '18')), in(status, 'active', 'pending'))
+  ```
+- **`MongoParser`** (`packages/parser-mongo/src/module.ts`) — MongoDB-style filter documents with typed values (`$`-operator objects, `$and`/`$or`/`$nor` compounds, De Morgan `$not`/`$nor` negation, `$elemMatch`; six `$contains`-family operators are rapiq extensions). Only `filters` is mongo-flavored — the other four parameters reuse the simple sub-parsers. Two-class failure model: grammar errors (unknown/misplaced `$`-operators, malformed values) always throw `FiltersParseError`; field-key/allow-list failures follow the schema drop-vs-throw policy:
+  ```typescript
+  parser.parse({
+      filters: { $or: [{ name: 'John' }, { age: { $gte: 18, $lt: 65 } }] },
+  }, { schema: 'user' });
   ```
 
 ### Backend adapters

--- a/.agents/references/ucast.md
+++ b/.agents/references/ucast.md
@@ -1,0 +1,50 @@
+# ucast
+
+Repository: https://github.com/stalniy/ucast — "universal conditions AST": parses MongoDB-style
+query objects into a condition AST and interprets it against various targets (JS objects, SQL, …).
+Conceptually very close to rapiq (parse → condition AST → interpret/visit); its `@ucast/mongo`
+package is the reference implementation for rapiq's mongo parser dialect
+(`@rapiq/parser-mongo`, issue #701).
+
+## Condition AST (`@ucast/core`)
+
+| ucast (`packages/core/src/Condition.ts`) | rapiq (`packages/core/src/parameter/filters/`) | Differences |
+|---|---|---|
+| `FieldCondition { operator, field, value }` | `Filter { operator, field, value }` (`record/module.ts`) | rapiq operator names are unprefixed enum values (`FilterFieldOperator`); ucast strips the `$` via `operatorToConditionName` |
+| `CompoundCondition { operator, value: Condition[] }` | `Filters { operator, value: ICondition[] }` (`collection/module.ts`) | ucast supports arbitrary compound names (`and`, `or`, `nor`, `not`); rapiq only `FilterCompoundOperator.AND/OR` |
+| `DocumentCondition` (e.g. `$where`) | — | rapiq has no document-level conditions (and `$where` is a code-execution foot-gun; deliberately unsupported) |
+| `NULL_CONDITION` sentinel (dropped by `pushIfNonNullCondition`) | — | rapiq parsers just don't emit a node (e.g. `$options` is consumed by its `$regex` sibling) |
+| `optimizedCompoundCondition()` (`core/src/utils.ts`) — flattens same-operator nesting, unwraps single-child compounds | `Filters.flatten()` | rapiq's flatten does not unwrap single-child compounds |
+| `ITSELF` field sentinel (elemMatch on scalar arrays) | — | rapiq `elemMatch` values are conditions with fields relative to the array element |
+
+## Parsing (`@ucast/core` ObjectQueryParser + `@ucast/mongo`)
+
+| ucast | rapiq | Differences |
+|---|---|---|
+| `ObjectQueryParser.parse()` (`core/src/parsers/ObjectQueryParser.ts`): per top-level key — registered compound/document instruction ⇒ recurse; value `hasOperators()` ⇒ per-`$op` field conditions; otherwise ⇒ `defaultOperatorName` (`$eq`); results merged with `buildAnd` | `MongoFiltersParser` (`packages/parser-mongo/src/parameter/filters/module.ts`) follows the same walk | rapiq resolves/validates every field path against a `Schema` via `ResolutionScope` (allow-lists, aliases, relation traversal, drop-vs-throw); ucast has no schema concept |
+| Parsing "instructions" registry: `{ type: 'compound' \| 'field' \| 'document', validate?, parse? }` (`mongo/src/instructions.ts`), extensible by consumers | fixed operator tables in the parser (`$`-name → `FilterFieldOperator` + per-operator value validation) | rapiq's operator set is closed over `FilterFieldOperator` (visitor interfaces are typed per operator), so no user-extensible instruction registry |
+| `hasOperators(value)` (`mongo/src/utils.ts`): object with at least one registered `$`-key | same idea: any own key starting with `$` marks an operator object | ucast checks against registered instructions; mixing operator and plain keys is an error in both |
+| `MongoQueryParser.parse(query, { field })` — parse a field-operator object directly | — | rapiq parses whole filter parameters only |
+| `MongoQuery<T>` recursive input type (`mongo/src/types.ts`) | `MongoFiltersParserInput<RECORD>` (`packages/parser-mongo/src/parameter/filters/types.ts`) | both type field keys/values from the record generic; rapiq keys come from `NestedKeys<T>` (depth-limited) |
+
+## Operator semantics (`mongo/src/instructions.ts`)
+
+- `$and`/`$or`: compound over a non-empty array of sub-queries (each must be a plain object);
+  `$and`/`$or` use `optimizedCompoundCondition` (flatten), `$nor` builds a plain compound.
+  rapiq: `$and`/`$or` map to `Filters(and|or)`; `$nor` has no AST form.
+- `$not` (field level): value is a RegExp (→ negated `regex`) or operator object → parsed and
+  wrapped in a `not` compound. rapiq has no `not` compound — the expression dialect's precedent
+  is De Morgan operator negation (`eq↔ne`, `lt↔gte`, `in↔nin`, …).
+- `$regex` + sibling `$options`: string is compiled to `new RegExp(value, $options)`; `$options`
+  itself parses to `NULL_CONDITION` (consumed by the `$regex` instruction via `context.query`).
+- `$elemMatch`: `hasOperators(value)` ? parse as field operators on `ITSELF` : parse as nested
+  query; result nested inside a `FieldCondition`.
+- Value validation throws plain `Error` (`ensureIs*` helpers); rapiq uses typed
+  `FiltersParseError` + `ErrorCode` members instead.
+- Operators with no rapiq AST equivalent: `$size`, `$all`, `$where`, `$type`.
+
+## Interpretation
+
+ucast interprets its AST with per-operator interpreter functions (`@ucast/js`, `@ucast/sql`,
+`createInterpreter`); rapiq's equivalent is the visitor pattern (`IFilterVisitor` with optional
+per-operator methods) consumed by `@rapiq/sql` / `@rapiq/typeorm`.

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -9,6 +9,7 @@ npm-workspaces monorepo (`packages/*`) orchestrated by Nx. Every publishable pac
 | [@rapiq/core](../packages/core)                           | Library  | Query AST (fields/filters/pagination/relations/sorts), visitor interfaces, schema system + registry, parser base classes, errors |
 | [@rapiq/parser-simple](../packages/parser-simple)         | Library  | Parses plain object/array input (URL-query-like "simple" dialect) into a `Query` |
 | [@rapiq/parser-expression](../packages/parser-expression) | Library  | Parses a function-call expression language (e.g. `and(eq(name, 'John'), gte(age, '18'))`) into a `Query` |
+| [@rapiq/parser-mongo](../packages/parser-mongo)           | Library  | Parses MongoDB-style filter documents (e.g. `{ age: { $gte: 18 } }`, `$and`/`$or`/`$not`) into a `Query` |
 | [@rapiq/codec-url-simple](../packages/codec-url-simple)   | Library  | URL query-string encoder (`URLEncoder`) & decoder (`URLDecoder`) for the simple dialect; uses `qs` |
 | [@rapiq/codec-url-expression](../packages/codec-url-expression) | Library | URL codec for the expression dialect: nested filter compounds in a single `filter=and(...)` param; other parameters shared with codec-url-simple |
 | [@rapiq/codec-url](../packages/codec-url)                 | Library  | `URLCodecRegistry` dispatching between URL codec dialects via the in-band reserved `codec` parameter (default: simple) |
@@ -30,6 +31,7 @@ Layer 1 (depend on core):
 
 Layer 2:
   @rapiq/parser-expression   (core + parser-simple)
+  @rapiq/parser-mongo        (core + parser-simple)
   @rapiq/codec-url-simple    (core + parser-simple)
   @rapiq/typeorm             (core + sql + typeorm)
 
@@ -71,9 +73,9 @@ packages/core/src/
 Parser packages mirror core's parameter split:
 
 ```
-packages/parser-{simple,expression}/src/
+packages/parser-{simple,expression,mongo}/src/
 ├── parameter/{fields,filters,pagination,relations,sorts}/   # one parser class per parameter
-└── module.ts             # SimpleParser / ExpressionParser composing them
+└── module.ts             # SimpleParser / ExpressionParser / MongoParser composing them
 ```
 
 Backend/codec packages:

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ export async function getUsers(req: Request, res: Response) {
 | [@rapiq/core](packages/core) | Query AST, typed build layer (`defineQuery`, condition helpers, `mergeQueries`), schema system & registry |
 | [@rapiq/parser-simple](packages/parser-simple) | Parses plain object/array input (the "simple" dialect) into a `Query` |
 | [@rapiq/parser-expression](packages/parser-expression) | Parses filter expressions like `and(eq(name, 'John'), gte(age, '18'))` |
+| [@rapiq/parser-mongo](packages/parser-mongo) | Parses MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
 | [@rapiq/codec-url-simple](packages/codec-url-simple) | URL query-string encoder & decoder for the simple dialect |
 | [@rapiq/codec-url-expression](packages/codec-url-expression) | URL codec carrying nested filter compounds in a single `filter=and(...)` parameter |
 | [@rapiq/codec-url](packages/codec-url) | Registry dispatching between URL codec dialects via the reserved `codec` parameter |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1779,6 +1779,10 @@
             "resolved": "packages/parser-expression",
             "link": true
         },
+        "node_modules/@rapiq/parser-mongo": {
+            "resolved": "packages/parser-mongo",
+            "link": true
+        },
         "node_modules/@rapiq/parser-simple": {
             "resolved": "packages/parser-simple",
             "link": true
@@ -11704,6 +11708,19 @@
         },
         "packages/parser-expression": {
             "name": "@rapiq/parser-expression",
+            "version": "1.0.0",
+            "license": "MIT",
+            "devDependencies": {
+                "@rapiq/core": "^1.0.0",
+                "@rapiq/parser-simple": "^1.0.0"
+            },
+            "peerDependencies": {
+                "@rapiq/core": "^1.0.0",
+                "@rapiq/parser-simple": "^1.0.0"
+            }
+        },
+        "packages/parser-mongo": {
+            "name": "@rapiq/parser-mongo",
             "version": "1.0.0",
             "license": "MIT",
             "devDependencies": {

--- a/packages/core/src/errors/parse.ts
+++ b/packages/core/src/errors/parse.ts
@@ -69,4 +69,18 @@ export class ParseError extends BaseError {
             code: ErrorCode.KEY_VALUE_INVALID,
         });
     }
+
+    static operatorUnsupported(operator: string) {
+        return new this({
+            message: `The operator ${operator} is not supported.`,
+            code: ErrorCode.OPERATOR_UNSUPPORTED,
+        });
+    }
+
+    static featureUnsupported(feature: string) {
+        return new this({
+            message: `The feature ${feature} is not supported.`,
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
+    }
 }

--- a/packages/docs/.vitepress/config.mjs
+++ b/packages/docs/.vitepress/config.mjs
@@ -92,6 +92,7 @@ export default defineConfig({
                         { text: 'Overview', link: '/integrations/' },
                         { text: 'Simple Parser', link: '/integrations/simple' },
                         { text: 'Expression Parser', link: '/integrations/expression' },
+                        { text: 'Mongo Parser', link: '/integrations/mongo' },
                         { text: 'URL Codec', link: '/integrations/url' },
                         { text: 'SQL', link: '/integrations/sql' },
                         { text: 'TypeORM', link: '/integrations/typeorm' },

--- a/packages/docs/getting-started/installation.md
+++ b/packages/docs/getting-started/installation.md
@@ -40,6 +40,7 @@ npm install @rapiq/sql @rapiq/typeorm
 |---|---|
 | `@rapiq/parser-simple` | your input already uses the canonical parameter keys (`filters`, `pagination`, …) instead of URL wire names — the layer `@rapiq/codec-url-simple` builds on |
 | `@rapiq/parser-expression` | you want to accept function-call filter expressions like `and(eq(name, 'John'), gte(age, '18'))` |
+| `@rapiq/parser-mongo` | you want to accept MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
 | `@rapiq/codec-url-expression` | you want the expression dialect on the wire — a nested filter compound in a single `filter=and(...)` parameter |
 | `@rapiq/codec-url` | you accept more than one URL codec dialect and want dispatch via the reserved `codec` parameter |
 

--- a/packages/docs/guide/build.md
+++ b/packages/docs/guide/build.md
@@ -60,7 +60,7 @@ condition. Unknown `$` keys throw a `BuildError`
 (`ErrorCode.OPERATOR_UNSUPPORTED`) — input is never guessed at.
 
 ::: warning Reserved: `$and` / `$or`
-Compound object keys are reserved for a future MongoDB-notation parser dialect and deliberately **not** part of the build layer. Compound trees are written with the condition helpers instead: `filters: or(...)`.
+Compound object keys are reserved for the MongoDB-notation parser dialect ([Mongo Parser](/integrations/mongo)) and deliberately **not** part of the build layer. Compound trees are written with the condition helpers instead: `filters: or(...)`.
 :::
 
 ## Condition helpers

--- a/packages/docs/integrations/index.md
+++ b/packages/docs/integrations/index.md
@@ -8,6 +8,7 @@ Everything outside `@rapiq/core` is an integration: parsers turn input *into* th
 |---|---|---|
 | `@rapiq/parser-simple` | Plain objects & arrays (URL-query-like) | [Simple Parser](/integrations/simple) |
 | `@rapiq/parser-expression` | Expression strings (`and(eq(name, 'John'), gte(age, '18'))`) | [Expression Parser](/integrations/expression) |
+| `@rapiq/parser-mongo` | MongoDB-style filter documents (`{ age: { $gte: 18 } }`) | [Mongo Parser](/integrations/mongo) |
 | `@rapiq/codec-url-simple` | Raw URL query strings (decode) | [URL Codec](/integrations/url) |
 | `@rapiq/codec-url-expression` | Raw URL query strings, expression filter dialect (decode) | [URL Codec](/integrations/url#expression-dialect) |
 

--- a/packages/docs/integrations/mongo.md
+++ b/packages/docs/integrations/mongo.md
@@ -1,0 +1,102 @@
+# Mongo Parser
+
+`@rapiq/parser-mongo` parses MongoDB-style filter documents — useful when filters travel as structured JSON (request bodies, stored filters) or the calling application already speaks the [MongoDB query language](https://www.mongodb.com/docs/manual/reference/operator/query/). The dialect is input syntax only: the result is the same [`Query`](/guide/query) AST every backend adapter consumes — the receiving application does not need to run MongoDB.
+
+```sh
+npm install @rapiq/core @rapiq/parser-simple @rapiq/parser-mongo
+```
+
+## The dialect
+
+Filters are plain objects with typed values — numbers stay numbers, there is no wire-string coercion (`Date` instances pass through into the AST as-is; ISO strings are **not** coerced to dates):
+
+```typescript
+{ name: 'John' }                                    // bare scalar → $eq
+{ status: ['active', 'pending'] }                   // bare array → $in
+{ name: /^jo/i }                                    // bare RegExp → $regex
+{ age: { $gte: 18, $lt: 65 } }                      // operator object (implicit AND)
+{ $or: [{ name: 'John' }, { age: { $lt: 18 } }] }   // compound
+{ 'realm.name': 'master' }                          // dotted relation path
+{ items: { $elemMatch: { id: { $gt: 5 } } } }       // array-element match
+```
+
+Multiple document entries combine with an implicit AND. `$and` / `$or` / `$nor` take a non-empty array of sub-documents; `$nor` and `$not` desugar via De Morgan operator negation (`$eq` ↔ `$ne`, `$lt` ↔ `$gte`, AND ↔ OR, …).
+
+| Operator | AST operator | Negated (`$not` / `$nor`) | Value |
+|---|---|---|---|
+| `$eq` | `EQUAL` | `NOT_EQUAL` | scalar, `null` or `Date` |
+| `$ne` | `NOT_EQUAL` | `EQUAL` | scalar, `null` or `Date` |
+| `$lt` / `$lte` / `$gt` / `$gte` | `LESS_THAN`, … | flipped bound (`$lt` ↔ `$gte`, `$lte` ↔ `$gt`) | string, number or `Date` |
+| `$in` | `IN` | `NOT_IN` | non-empty array of scalar/`null`/`Date` |
+| `$nin` | `NOT_IN` | `IN` | non-empty array of scalar/`null`/`Date` |
+| `$startsWith` † | `STARTS_WITH` | `NOT_STARTS_WITH` | string |
+| `$notStartsWith` † | `NOT_STARTS_WITH` | `STARTS_WITH` | string |
+| `$endsWith` † | `ENDS_WITH` | `NOT_ENDS_WITH` | string |
+| `$notEndsWith` † | `NOT_ENDS_WITH` | `ENDS_WITH` | string |
+| `$contains` † | `CONTAINS` | `NOT_CONTAINS` | string |
+| `$notContains` † | `NOT_CONTAINS` | `CONTAINS` | string |
+| `$regex` | `REGEX` | — (throws) | `RegExp` instance or pattern string |
+| `$options` | — (modifier) | — | flag string; only beside a string-valued `$regex` |
+| `$mod` | `MOD` | — (throws) | `[divisor, remainder]`, divisor ≠ 0 |
+| `$exists` | `EXISTS` | boolean flag flipped | boolean |
+| `$elemMatch` | `ELEM_MATCH` | — (throws) | nested filter document, fields relative to the array element |
+| `$not` | negation | — (no nesting) | object of field-level operators |
+
+† **rapiq extension — not valid MongoDB.** These cover the substring matches MongoDB only reaches through `$regex`, mapping 1:1 to the AST operators every rapiq dialect shares.
+
+::: warning Deviations from MongoDB
+- Nested plain objects expand to dotted key paths — `{ realm: { name: 'x' } }` ≡ `{ 'realm.name': 'x' }` — instead of MongoDB's exact-embedded-document match.
+- A bare array value means `$in` instead of MongoDB's exact-array match.
+- Negation is algebraic (De Morgan operator flipping) — it does not replicate MongoDB's missing-field semantics, where `$not` also matches documents lacking the field.
+- `$elemMatch` supports the nested-document form only; element-level operators (`{ $elemMatch: { $gt: 5 } }`) throw.
+- `$where`, `$size`, `$all`, `$type` and the other evaluation/geo/bitwise operators are unsupported and throw.
+- MongoDB's `x` regex flag has no JavaScript equivalent — `$options: 'x'` is rejected.
+- An empty sub-document `{}` inside a compound (MongoDB's match-all branch) is a grammar error.
+:::
+
+## Failure model
+
+Failures fall into two classes:
+
+- **Grammar errors always throw** `FiltersParseError`, independent of the schema failure policy — unknown or misplaced `$`-operators, malformed operator values, invalid compound arrays, mixed operator and plain keys, non-object top-level input, documents nested deeper than 32 levels. A `$`-prefixed key is never a field name, so there is no silent-drop reading for a broken document; map these to a `400` response.
+- **Field-key / allow-list failures follow the schema policy** — dropped silently by default, thrown when `throwOnFailure` is set. A dropped field drops its whole entry, an `$elemMatch` subtree included.
+
+Absent input, `{}` and an all-dropped document are not failures — the schema's `filters.default` applies, like with the other parsers.
+
+## Usage
+
+```typescript
+import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import { MongoParser } from '@rapiq/parser-mongo';
+
+const registry = new SchemaRegistry();
+registry.add(defineSchema<User>({
+    name: 'user',
+    fields: { allowed: ['id', 'name', 'age'] },
+    filters: { allowed: ['id', 'name', 'age'] },
+    relations: { allowed: ['realm'] },
+    sort: { allowed: ['id', 'age'] },
+}));
+
+const parser = new MongoParser(registry);
+
+const query = parser.parse({
+    filters: {
+        $or: [
+            { name: { $contains: 'jo' } },
+            { age: { $gte: 18, $lt: 65 } },
+        ],
+    },
+    relations: ['realm'],
+    sort: '-age',
+    pagination: { limit: 25 },
+}, { schema: 'user' });
+```
+
+Only the `filters` parameter uses the mongo dialect — fields, relations, pagination and sort accept the same input as the [simple parser](/integrations/simple), and the whole thing returns the same [`Query`](/guide/query) AST.
+
+There is also a standalone `MongoFiltersParser` returning just the `Filters` node; its `parseTyped(input, options)` accepts a `MongoFiltersParserInput<RECORD>`, so field keys and operator values are type-checked against the record type.
+
+## Errors
+
+Grammar errors throw `FiltersParseError` immediately: malformed documents carry `ErrorCode.SYNTAX_INVALID`, invalid operator values `ErrorCode.KEY_VALUE_INVALID`, non-object top-level input `ErrorCode.INPUT_INVALID`. Known MongoDB operators without an AST counterpart (`$where`, `$size`, …) carry `ErrorCode.OPERATOR_UNSUPPORTED`; the element-level `$elemMatch` form carries `ErrorCode.FEATURE_UNSUPPORTED`. Schema violations carry the key-related codes (`keyNotAllowed`, `keyPathInvalid`, …) and throw only under `throwOnFailure`.

--- a/packages/parser-mongo/README.md
+++ b/packages/parser-mongo/README.md
@@ -1,0 +1,46 @@
+# @rapiq/parser-mongo
+
+Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+
+Parses MongoDB-style filter objects — `$and`/`$or`/`$nor` compounds, field operators like `$eq`, `$gte`, `$in`, `$not`, `$regex` and `$elemMatch` — into the rapiq `Query` AST. Useful when clients submit filters as JSON documents (request bodies, saved queries):
+
+```typescript
+{
+    $or: [
+        { name: 'John', age: { $gte: 18, $lt: 65 } },
+        { 'realm.name': { $startsWith: 'mas' } },
+    ],
+}
+```
+
+## Installation
+
+```sh
+npm install @rapiq/core @rapiq/parser-simple @rapiq/parser-mongo
+```
+
+## Usage
+
+```typescript
+import { MongoParser } from '@rapiq/parser-mongo';
+
+const parser = new MongoParser(registry);
+
+const query = parser.parse({
+    filters: { age: { $gte: 18 }, 'realm.name': 'master' },
+    sort: '-age',
+    pagination: { limit: 25 },
+}, { schema: 'user' });
+```
+
+Only the `filters` parameter uses the mongo dialect — fields, relations, pagination and sort accept the same input as [@rapiq/parser-simple](https://www.npmjs.com/package/@rapiq/parser-simple), and the whole thing returns the same [`Query`](https://rapiq.tada5hi.net/guide/query) AST.
+
+Grammar errors (unknown `$`-operators, misplaced operators, malformed operator arguments) always throw `FiltersParseError`; field keys that fail the schema allow-list are dropped by default and throw when `throwOnFailure` is set.
+
+## Documentation
+
+Full guide (operator table & deviations from MongoDB): [rapiq.tada5hi.net/integrations/mongo](https://rapiq.tada5hi.net/integrations/mongo)
+
+## License
+
+Published under the [MIT License](https://github.com/tada5hi/rapiq/blob/master/LICENSE).

--- a/packages/parser-mongo/package.json
+++ b/packages/parser-mongo/package.json
@@ -1,0 +1,64 @@
+{
+    "name": "@rapiq/parser-mongo",
+    "version": "1.0.0",
+    "description": "A package containing a mongodb style parser",
+    "type": "module",
+    "main": "dist/index.mjs",
+    "types": "dist/index.d.mts",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        }
+    },
+    "files": [
+        "dist/"
+    ],
+    "devDependencies": {
+        "@rapiq/core": "^1.0.0",
+        "@rapiq/parser-simple": "^1.0.0"
+    },
+    "peerDependencies": {
+        "@rapiq/core": "^1.0.0",
+        "@rapiq/parser-simple": "^1.0.0"
+    },
+    "scripts": {
+        "build:types": "tsc --noEmit -p tsconfig.build.json",
+        "build:js": "tsdown",
+        "build": "npm run build:types && npm run build:js",
+        "test": "vitest --config test/vitest.config.ts --run",
+        "test:coverage": "vitest --config test/vitest.config.ts --run --coverage",
+        "prepublishOnly": "npm run build"
+    },
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "MIT",
+    "keywords": [
+        "query",
+        "json",
+        "json-api",
+        "api",
+        "rest",
+        "api-utils",
+        "include",
+        "pagination",
+        "sort",
+        "fields",
+        "filter",
+        "relations",
+        "typescript"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Tada5hi/rapiq.git",
+        "directory": "packages/parser-mongo"
+    },
+    "bugs": {
+        "url": "https://github.com/Tada5hi/rapiq/issues"
+    },
+    "homepage": "https://github.com/Tada5hi/rapiq#readme"
+}

--- a/packages/parser-mongo/src/index.ts
+++ b/packages/parser-mongo/src/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';
+export * from './parameter';

--- a/packages/parser-mongo/src/module.ts
+++ b/packages/parser-mongo/src/module.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { SchemaRegistry } from '@rapiq/core';
+import { BaseQueryParser } from '@rapiq/core';
+import {
+    MongoFieldsParser,
+    MongoFiltersParser,
+    MongoPaginationParser,
+    MongoRelationsParser,
+    MongoSortParser,
+} from './parameter';
+
+export class MongoParser extends BaseQueryParser {
+    protected fieldsParser : MongoFieldsParser;
+
+    protected filtersParser : MongoFiltersParser;
+
+    protected paginationParser : MongoPaginationParser;
+
+    protected relationsParser : MongoRelationsParser;
+
+    protected sortParser : MongoSortParser;
+
+    // -----------------------------------------------------
+
+    constructor(input?: SchemaRegistry) {
+        super(input);
+
+        this.fieldsParser = new MongoFieldsParser(this.registry);
+        this.filtersParser = new MongoFiltersParser(this.registry);
+        this.paginationParser = new MongoPaginationParser(this.registry);
+        this.relationsParser = new MongoRelationsParser(this.registry);
+        this.sortParser = new MongoSortParser(this.registry);
+    }
+}

--- a/packages/parser-mongo/src/parameter/fields/index.ts
+++ b/packages/parser-mongo/src/parameter/fields/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';

--- a/packages/parser-mongo/src/parameter/fields/module.ts
+++ b/packages/parser-mongo/src/parameter/fields/module.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SimpleFieldsParser } from '@rapiq/parser-simple';
+
+export class MongoFieldsParser extends SimpleFieldsParser {
+
+}

--- a/packages/parser-mongo/src/parameter/filters/constants.ts
+++ b/packages/parser-mongo/src/parameter/filters/constants.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { FilterFieldOperator } from '@rapiq/core';
+
+/**
+ * Compound (document-level) operators of the mongo dialect.
+ */
+export const MONGO_COMPOUND_OPERATORS = [
+    '$and',
+    '$or',
+    '$nor',
+] as const;
+
+export type MongoCompoundOperator = typeof MONGO_COMPOUND_OPERATORS[number];
+
+/**
+ * Field-level operators with a direct AST mapping, keyed by their
+ * `$`-prefixed wire name: [operator, negated counterpart]. Negation
+ * (via `$not` or a `$nor` context) flips to the counterpart.
+ */
+export const MONGO_COMPARISON_OPERATORS = {
+    $eq: [FilterFieldOperator.EQUAL, FilterFieldOperator.NOT_EQUAL],
+    $ne: [FilterFieldOperator.NOT_EQUAL, FilterFieldOperator.EQUAL],
+    $lt: [FilterFieldOperator.LESS_THAN, FilterFieldOperator.GREATER_THAN_EQUAL],
+    $lte: [FilterFieldOperator.LESS_THAN_EQUAL, FilterFieldOperator.GREATER_THAN],
+    $gt: [FilterFieldOperator.GREATER_THAN, FilterFieldOperator.LESS_THAN_EQUAL],
+    $gte: [FilterFieldOperator.GREATER_THAN_EQUAL, FilterFieldOperator.LESS_THAN],
+    $in: [FilterFieldOperator.IN, FilterFieldOperator.NOT_IN],
+    $nin: [FilterFieldOperator.NOT_IN, FilterFieldOperator.IN],
+    $startsWith: [FilterFieldOperator.STARTS_WITH, FilterFieldOperator.NOT_STARTS_WITH],
+    $notStartsWith: [FilterFieldOperator.NOT_STARTS_WITH, FilterFieldOperator.STARTS_WITH],
+    $endsWith: [FilterFieldOperator.ENDS_WITH, FilterFieldOperator.NOT_ENDS_WITH],
+    $notEndsWith: [FilterFieldOperator.NOT_ENDS_WITH, FilterFieldOperator.ENDS_WITH],
+    $contains: [FilterFieldOperator.CONTAINS, FilterFieldOperator.NOT_CONTAINS],
+    $notContains: [FilterFieldOperator.NOT_CONTAINS, FilterFieldOperator.CONTAINS],
+} as const;
+
+export type MongoComparisonOperator = keyof typeof MONGO_COMPARISON_OPERATORS;
+
+/**
+ * The complete field-level operator vocabulary — a key of this list at
+ * document level is a grammar error (and vice versa for compounds).
+ */
+export const MONGO_FIELD_OPERATORS : readonly string[] = [
+    ...Object.keys(MONGO_COMPARISON_OPERATORS),
+    '$regex',
+    '$options',
+    '$mod',
+    '$exists',
+    '$elemMatch',
+    '$not',
+];
+
+/**
+ * Known mongo operators without an AST counterpart — they throw a typed
+ * operatorUnsupported error instead of the generic unknown-operator error.
+ */
+export const MONGO_UNSUPPORTED_OPERATORS : readonly string[] = [
+    '$size',
+    '$all',
+    '$type',
+    '$where',
+    '$text',
+    '$expr',
+    '$jsonSchema',
+    '$geoWithin',
+    '$geoIntersects',
+    '$near',
+    '$nearSphere',
+    '$bitsAllSet',
+    '$bitsAllClear',
+    '$bitsAnySet',
+    '$bitsAnyClear',
+    '$comment',
+    '$slice',
+];

--- a/packages/parser-mongo/src/parameter/filters/index.ts
+++ b/packages/parser-mongo/src/parameter/filters/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './constants';
+export * from './module';
+export * from './types';

--- a/packages/parser-mongo/src/parameter/filters/module.ts
+++ b/packages/parser-mongo/src/parameter/filters/module.ts
@@ -1,0 +1,842 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    FiltersParseOptions,
+    FiltersSchema,
+    ICondition,
+    IFilters,
+    ObjectLiteral,
+} from '@rapiq/core';
+import {
+    BaseParser,
+    ErrorCode,
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+    FiltersParseError,
+    KeyResolutionErrorCode,
+    Parameter,
+    ParseError,
+    ResolutionScope,
+    isFilters,
+    isObject,
+} from '@rapiq/core';
+import type { MongoComparisonOperator, MongoCompoundOperator } from './constants';
+import {
+    MONGO_COMPARISON_OPERATORS,
+    MONGO_COMPOUND_OPERATORS,
+    MONGO_FIELD_OPERATORS,
+    MONGO_UNSUPPORTED_OPERATORS,
+} from './constants';
+import type { MongoFiltersParserInput } from './types';
+
+type FiltersScope = ResolutionScope<`${Parameter.FILTERS}`>;
+
+type FieldResolution = {
+    field: string,
+    name: string,
+    scope: FiltersScope,
+};
+
+/**
+ * Nesting cap for document/compound/field recursion (mirrors the
+ * resolver's traversal cap): beyond it a crafted deeply nested JSON
+ * body would escape as an untyped stack overflow instead of a
+ * grammar error.
+ */
+const MAX_DEPTH = 32;
+
+/**
+ * Parses MongoDB-style filter documents into the rapiq Filters AST.
+ *
+ * The dialect enforces a two-class failure model: grammar errors
+ * (unknown or misplaced operators, malformed operator arguments,
+ * invalid compound arrays) always throw, independent of the schema
+ * failure policy; field-key/allow-list failures follow the schema
+ * policy — drop by default, throw under throwOnFailure.
+ *
+ * @see https://www.mongodb.com/docs/manual/reference/operator/query/
+ */
+export class MongoFiltersParser extends BaseParser<
+    FiltersParseOptions,
+    IFilters
+> {
+    parse<RECORD extends ObjectLiteral = ObjectLiteral>(
+        input: unknown,
+        options: FiltersParseOptions<RECORD> = {},
+    ) : IFilters {
+        const scope = ResolutionScope.for(this.registry, Parameter.FILTERS, options.schema, {
+            relations: options.relations,
+            throwOnFailure: options.throwOnFailure,
+            strict: options.strict,
+        }) as FiltersScope;
+
+        // absent input is not a failure — schema defaults still apply.
+        if (typeof input === 'undefined' || input === null) {
+            return new Filters(
+                FilterCompoundOperator.AND,
+                this.buildDefaults(scope.schema),
+            );
+        }
+
+        // the dialect travels as a JSON document — anything that is not
+        // a plain object is a grammar error, independent of policy.
+        if (!isPlainObject(input)) {
+            throw FiltersParseError.inputInvalid();
+        }
+
+        // if allowed is an empty array nothing is permitted — the input
+        // is not walked and only the schema defaults apply.
+        if (
+            !scope.schema.allowedIsUndefined &&
+            scope.schema.allowed.length === 0
+        ) {
+            return new Filters(
+                FilterCompoundOperator.AND,
+                this.buildDefaults(scope.schema),
+            );
+        }
+
+        const conditions = this.parseDocument(input, scope, false, 0);
+        if (conditions.length === 0) {
+            return new Filters(
+                FilterCompoundOperator.AND,
+                this.buildDefaults(scope.schema),
+            );
+        }
+
+        // an explicit root compound is returned as-is;
+        // everything else wraps in a root AND.
+        const [first] = conditions;
+        if (conditions.length === 1 && first && isFilters(first)) {
+            return first;
+        }
+
+        return new Filters(FilterCompoundOperator.AND, conditions);
+    }
+
+    parseTyped<RECORD extends ObjectLiteral = ObjectLiteral>(
+        input: MongoFiltersParserInput<RECORD>,
+        options: FiltersParseOptions<RECORD> = {},
+    ) : IFilters {
+        return this.parse(input, options);
+    }
+
+    // ---------------------------------------------------------
+
+    protected buildDefaults(schema: FiltersSchema) : ICondition[] {
+        if (!schema.default) {
+            return [];
+        }
+
+        if (Array.isArray(schema.default)) {
+            return schema.default;
+        }
+
+        return [schema.default];
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Parse a document object (the root, a compound child or an
+     * $elemMatch interior). Multiple entries are an implicit AND —
+     * under negation the implicit AND becomes an OR (De Morgan);
+     * the combination itself is owned by the caller.
+     */
+    protected parseDocument(
+        input: Record<string, any>,
+        scope: FiltersScope,
+        negated: boolean,
+        depth: number,
+    ) : ICondition[] {
+        if (depth > MAX_DEPTH) {
+            throw FiltersParseError.syntaxInvalid('The maximum nesting depth was exceeded.');
+        }
+
+        const output : ICondition[] = [];
+
+        const keys = Object.keys(input);
+        for (const key of keys) {
+            if (isMongoCompoundOperator(key)) {
+                const compound = this.parseCompound(key, input[key], scope, negated, depth);
+                if (compound) {
+                    output.push(compound);
+                }
+
+                continue;
+            }
+
+            // a $-prefixed key is never a field name.
+            if (key.startsWith('$')) {
+                throw this.buildDocumentOperatorError(key);
+            }
+
+            output.push(...this.parseFieldEntry(key, input[key], scope, negated, depth));
+        }
+
+        return output;
+    }
+
+    protected buildDocumentOperatorError(key: string) : FiltersParseError {
+        if (MONGO_FIELD_OPERATORS.includes(key)) {
+            return FiltersParseError.syntaxInvalid(
+                `The field operator ${key} is not permitted at document level.`,
+            );
+        }
+
+        if (MONGO_UNSUPPORTED_OPERATORS.includes(key)) {
+            return FiltersParseError.operatorUnsupported(key);
+        }
+
+        return FiltersParseError.syntaxInvalid(`The operator ${key} is unknown.`);
+    }
+
+    /**
+     * Parse an explicit compound ($and/$or/$nor). Compounds are always
+     * materialized — no single-child unwrapping, no cross-level
+     * flattening. $nor desugars per De Morgan: an AND of negated
+     * children (an OR of children when itself negated).
+     */
+    protected parseCompound(
+        key: MongoCompoundOperator,
+        input: unknown,
+        scope: FiltersScope,
+        negated: boolean,
+        depth: number,
+    ) : ICondition | undefined {
+        if (!Array.isArray(input) || input.length === 0) {
+            throw FiltersParseError.syntaxInvalid(
+                `The value of the operator ${key} must be a non-empty array.`,
+            );
+        }
+
+        const childNegated = key === '$nor' ? !negated : negated;
+
+        let operator : `${FilterCompoundOperator}`;
+        if (key === '$or') {
+            operator = negated ?
+                FilterCompoundOperator.AND :
+                FilterCompoundOperator.OR;
+        } else {
+            // $and and $nor share the same effective operator.
+            operator = negated ?
+                FilterCompoundOperator.OR :
+                FilterCompoundOperator.AND;
+        }
+
+        const children : ICondition[] = [];
+        for (const element of input) {
+            if (
+                !isPlainObject(element) ||
+                Object.keys(element).length === 0
+            ) {
+                throw FiltersParseError.syntaxInvalid(
+                    `The children of the operator ${key} must be non-empty objects.`,
+                );
+            }
+
+            const conditions = this.parseDocument(element, scope, childNegated, depth + 1);
+
+            // children dropped by the schema policy are skipped.
+            const condition = this.combineDocument(conditions, childNegated);
+            if (condition) {
+                children.push(condition);
+            }
+        }
+
+        if (children.length === 0) {
+            return undefined;
+        }
+
+        return new Filters(operator, children);
+    }
+
+    /**
+     * Combine the conditions of one document into a single condition:
+     * none → nothing, one → unwrapped, several → an implicit AND
+     * (an OR under negation).
+     */
+    protected combineDocument(
+        conditions: ICondition[],
+        negated: boolean,
+    ) : ICondition | undefined {
+        if (conditions.length === 0) {
+            return undefined;
+        }
+
+        if (conditions.length === 1) {
+            return conditions[0];
+        }
+
+        return new Filters(
+            negated ?
+                FilterCompoundOperator.OR :
+                FilterCompoundOperator.AND,
+            conditions,
+        );
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Parse one `key: value` field entry. The key may be dotted.
+     * Grammar (operator vocabulary & value shapes) is validated first
+     * and always throws; the field key is resolved second and follows
+     * the schema failure policy.
+     */
+    protected parseFieldEntry(
+        key: string,
+        value: unknown,
+        scope: FiltersScope,
+        negated: boolean,
+        depth: number,
+    ) : ICondition[] {
+        if (depth > MAX_DEPTH) {
+            throw FiltersParseError.syntaxInvalid('The maximum nesting depth was exceeded.');
+        }
+
+        if (isPlainObject(value)) {
+            const keys = Object.keys(value);
+
+            // mongo's exact-empty-document match is inexpressible —
+            // silently dropping a client-sent condition would widen
+            // the result set.
+            if (keys.length === 0) {
+                throw FiltersParseError.keyValueInvalid(key);
+            }
+
+            const operators = keys.filter((child) => child.startsWith('$'));
+
+            if (operators.length === keys.length) {
+                return this.parseOperatorObject(key, value, scope, negated, depth);
+            }
+
+            if (operators.length > 0) {
+                throw FiltersParseError.syntaxInvalid(
+                    `The value of the key ${key} mixes operator and field keys.`,
+                );
+            }
+
+            // nested plain objects expand to dotted key paths
+            // (deviation from mongo's exact-embedded-document match).
+            const output : ICondition[] = [];
+            for (const child of keys) {
+                output.push(...this.parseFieldEntry(
+                    `${key}.${child}`,
+                    value[child],
+                    scope,
+                    negated,
+                    depth + 1,
+                ));
+            }
+
+            return output;
+        }
+
+        // bare RegExp desugars to $regex — which has no negated form.
+        if (value instanceof RegExp) {
+            if (negated) {
+                throw FiltersParseError.operatorUnsupported('$regex');
+            }
+
+            return this.buildLeaf(key, scope, FilterFieldOperator.REGEX, value);
+        }
+
+        // bare array desugars to $in
+        // (deviation from mongo's exact-array match).
+        if (Array.isArray(value)) {
+            this.validateInValue(key, value);
+
+            return this.buildLeaf(
+                key,
+                scope,
+                negated ?
+                    FilterFieldOperator.NOT_IN :
+                    FilterFieldOperator.IN,
+                value,
+            );
+        }
+
+        // bare scalar, null or Date desugars to $eq.
+        if (isComparableValue(value)) {
+            return this.buildLeaf(
+                key,
+                scope,
+                negated ?
+                    FilterFieldOperator.NOT_EQUAL :
+                    FilterFieldOperator.EQUAL,
+                value,
+            );
+        }
+
+        throw FiltersParseError.keyValueInvalid(key);
+    }
+
+    protected buildLeaf(
+        key: string,
+        scope: FiltersScope,
+        operator: `${FilterFieldOperator}`,
+        value: unknown,
+    ) : ICondition[] {
+        const resolved = this.resolveField(key, scope);
+        if (!resolved) {
+            return [];
+        }
+
+        return [new Filter(operator, resolved.field, value)];
+    }
+
+    /**
+     * Resolve a (possibly dotted) field key against the scope.
+     * Returns undefined when the entry is dropped by the schema policy —
+     * under throwOnFailure the scope itself has already thrown.
+     */
+    protected resolveField(
+        key: string,
+        scope: FiltersScope,
+    ) : FieldResolution | undefined {
+        const resolved = scope.resolveKey(key);
+        if (!resolved.success) {
+            return undefined;
+        }
+
+        return {
+            field: [...resolved.path, resolved.name].join('.'),
+            name: resolved.name,
+            scope: resolved.scope,
+        };
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Parse an operator object (all own keys $-prefixed). The field is
+     * resolved once; every operator reuses the resolution. Multiple
+     * operators combine through the enclosing document.
+     */
+    protected parseOperatorObject(
+        key: string,
+        input: Record<string, any>,
+        scope: FiltersScope,
+        negated: boolean,
+        depth: number,
+    ) : ICondition[] {
+        // grammar first — always throws, independent of policy.
+        const regex = this.validateOperatorObject(key, input, negated);
+
+        // field resolution second — follows the schema policy;
+        // a dropped field drops the whole entry/subtree.
+        const resolved = this.resolveField(key, scope);
+        if (!resolved) {
+            return [];
+        }
+
+        return this.buildOperatorObject(input, resolved, negated, depth, regex);
+    }
+
+    /**
+     * Validate the operator vocabulary & value shapes of an operator
+     * object. Returns the RegExp a $regex entry desugars to.
+     */
+    protected validateOperatorObject(
+        key: string,
+        input: Record<string, any>,
+        negated: boolean,
+    ) : RegExp | undefined {
+        const keys = Object.keys(input);
+
+        // $options is only legal beside a string-valued $regex.
+        if (keys.includes('$options') && !keys.includes('$regex')) {
+            throw FiltersParseError.syntaxInvalid(
+                `The operator $options of the key ${key} requires a $regex sibling.`,
+            );
+        }
+
+        let regex : RegExp | undefined;
+
+        for (const operator of keys) {
+            if (isMongoCompoundOperator(operator)) {
+                throw FiltersParseError.syntaxInvalid(
+                    `The compound operator ${operator} is not permitted at field level.`,
+                );
+            }
+
+            if (MONGO_UNSUPPORTED_OPERATORS.includes(operator)) {
+                throw FiltersParseError.operatorUnsupported(operator);
+            }
+
+            switch (operator) {
+                case '$eq':
+                case '$ne': {
+                    if (!isComparableValue(input[operator])) {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$lt':
+                case '$lte':
+                case '$gt':
+                case '$gte': {
+                    if (!isOrderableValue(input[operator])) {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$in':
+                case '$nin': {
+                    this.validateInValue(key, input[operator]);
+
+                    break;
+                }
+                case '$startsWith':
+                case '$notStartsWith':
+                case '$endsWith':
+                case '$notEndsWith':
+                case '$contains':
+                case '$notContains': {
+                    if (typeof input[operator] !== 'string') {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$regex': {
+                    regex = this.validateRegex(key, input, negated);
+
+                    break;
+                }
+                case '$options': {
+                    if (typeof input[operator] !== 'string') {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$mod': {
+                    if (negated) {
+                        throw FiltersParseError.operatorUnsupported('$mod');
+                    }
+
+                    const value = input[operator];
+                    if (
+                        !Array.isArray(value) ||
+                        value.length !== 2 ||
+                        typeof value[0] !== 'number' ||
+                        typeof value[1] !== 'number' ||
+                        value[0] === 0
+                    ) {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$exists': {
+                    if (typeof input[operator] !== 'boolean') {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$elemMatch': {
+                    if (negated) {
+                        throw FiltersParseError.operatorUnsupported('$elemMatch');
+                    }
+
+                    // a match-all elemMatch ({}) is inexpressible.
+                    if (
+                        !isPlainObject(input[operator]) ||
+                        Object.keys(input[operator]).length === 0
+                    ) {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
+                case '$not': {
+                    if (negated) {
+                        throw FiltersParseError.syntaxInvalid(
+                            'The operator $not can not be nested or negated.',
+                        );
+                    }
+
+                    const value = input[operator];
+
+                    // mongo's $not: /re/ shorthand — regex is non-negatable.
+                    if (value instanceof RegExp) {
+                        throw FiltersParseError.operatorUnsupported('$regex');
+                    }
+
+                    if (
+                        !isPlainObject(value) ||
+                        Object.keys(value).length === 0
+                    ) {
+                        throw FiltersParseError.syntaxInvalid(
+                            `The value of the operator $not of the key ${key} must be a non-empty object of field operators.`,
+                        );
+                    }
+
+                    this.validateOperatorObject(key, value, true);
+
+                    break;
+                }
+                default:
+                    throw FiltersParseError.syntaxInvalid(
+                        `The operator ${operator} is unknown.`,
+                    );
+            }
+        }
+
+        return regex;
+    }
+
+    protected validateRegex(
+        key: string,
+        input: Record<string, any>,
+        negated: boolean,
+    ) : RegExp {
+        // regex has no negated counterpart.
+        if (negated) {
+            throw FiltersParseError.operatorUnsupported('$regex');
+        }
+
+        const value = input.$regex;
+        if (value instanceof RegExp) {
+            // mongo rejects $options beside a RegExp-valued $regex.
+            if (typeof input.$options !== 'undefined') {
+                throw FiltersParseError.syntaxInvalid(
+                    `The operator $options of the key ${key} can not be combined with a RegExp valued $regex.`,
+                );
+            }
+
+            return value;
+        }
+
+        if (typeof value !== 'string') {
+            throw FiltersParseError.keyValueInvalid(key);
+        }
+
+        let flags = '';
+        if (typeof input.$options !== 'undefined') {
+            if (typeof input.$options !== 'string') {
+                throw FiltersParseError.keyValueInvalid(key);
+            }
+
+            flags = input.$options;
+        }
+
+        try {
+            return new RegExp(value, flags);
+        } catch {
+            throw FiltersParseError.keyValueInvalid(key);
+        }
+    }
+
+    protected validateInValue(key: string, input: unknown) : void {
+        if (!Array.isArray(input) || input.length === 0) {
+            throw FiltersParseError.keyValueInvalid(key);
+        }
+
+        for (const element of input) {
+            if (!isComparableValue(element)) {
+                throw FiltersParseError.keyValueInvalid(key);
+            }
+        }
+    }
+
+    /**
+     * Build the conditions of a validated operator object.
+     */
+    protected buildOperatorObject(
+        input: Record<string, any>,
+        resolved: FieldResolution,
+        negated: boolean,
+        depth: number,
+        regex?: RegExp,
+    ) : ICondition[] {
+        const output : ICondition[] = [];
+
+        const keys = Object.keys(input);
+        for (const operator of keys) {
+            if (isMongoComparisonOperator(operator)) {
+                const [base, flipped] = MONGO_COMPARISON_OPERATORS[operator];
+
+                output.push(new Filter(
+                    negated ? flipped : base,
+                    resolved.field,
+                    input[operator],
+                ));
+
+                continue;
+            }
+
+            switch (operator) {
+                case '$regex': {
+                    output.push(new Filter(
+                        FilterFieldOperator.REGEX,
+                        resolved.field,
+                        regex as RegExp,
+                    ));
+
+                    break;
+                }
+                case '$options': {
+                    // modifier — consumed by the $regex entry.
+                    break;
+                }
+                case '$mod': {
+                    output.push(new Filter(
+                        FilterFieldOperator.MOD,
+                        resolved.field,
+                        input[operator],
+                    ));
+
+                    break;
+                }
+                case '$exists': {
+                    output.push(new Filter(
+                        FilterFieldOperator.EXISTS,
+                        resolved.field,
+                        negated ? !input[operator] : input[operator],
+                    ));
+
+                    break;
+                }
+                case '$elemMatch': {
+                    const condition = this.buildElemMatch(input[operator], resolved, depth);
+                    if (condition) {
+                        output.push(condition);
+                    }
+
+                    break;
+                }
+                case '$not': {
+                    const conditions = this.buildOperatorObject(
+                        input[operator],
+                        resolved,
+                        !negated,
+                        depth,
+                    );
+
+                    // the conditions of one negated operator object are
+                    // OR-combined locally — the enclosing document
+                    // combines with AND.
+                    const condition = this.combineDocument(conditions, !negated);
+                    if (condition) {
+                        output.push(condition);
+                    }
+
+                    break;
+                }
+                /* istanbul ignore next -- validation rejected everything else */
+                default:
+                    break;
+            }
+        }
+
+        return output;
+    }
+
+    /**
+     * Build an $elemMatch condition: the value re-enters document
+     * context, fields relative to the array element. The interior scope
+     * is the related schema when resolvable, otherwise an unbound scope
+     * inheriting the current policy (e.g. a JSON array column).
+     */
+    protected buildElemMatch(
+        input: Record<string, any>,
+        resolved: FieldResolution,
+        depth: number,
+    ) : ICondition | undefined {
+        // the element-level operator form (matching the scalar element
+        // itself) has no self-reference marker in the AST.
+        const keys = Object.keys(input);
+        for (const key of keys) {
+            if (MONGO_FIELD_OPERATORS.includes(key)) {
+                throw FiltersParseError.featureUnsupported('$elemMatch (element-level operators)');
+            }
+        }
+
+        let child : FiltersScope | undefined;
+        try {
+            const verdict = resolved.scope.descend(resolved.name);
+            if (verdict instanceof ResolutionScope) {
+                child = verdict;
+            } else if (verdict.code !== KeyResolutionErrorCode.SCHEMA_UNRESOLVABLE) {
+                // relations gating (pathNotPermitted) is a schema-policy
+                // failure for the entry — drop it.
+                return undefined;
+            }
+        } catch (e) {
+            // $elemMatch on a non-relation field is legal — a missing
+            // related schema (thrown as keyPathInvalid under
+            // throwOnFailure) falls back to the unbound scope;
+            // every other failure propagates.
+            if (
+                !(e instanceof ParseError) ||
+                e.code !== ErrorCode.KEY_PATH_INVALID
+            ) {
+                throw e;
+            }
+        }
+
+        if (!child) {
+            child = ResolutionScope.for(this.registry, Parameter.FILTERS, undefined, {
+                throwOnFailure: resolved.scope.throwOnFailure,
+                strict: resolved.scope.strict,
+            }) as FiltersScope;
+        }
+
+        const conditions = this.parseDocument(input, child, false, depth + 1);
+
+        // an interior with no conditions drops the whole entry.
+        const condition = this.combineDocument(conditions, false);
+        if (!condition) {
+            return undefined;
+        }
+
+        return new Filter(FilterFieldOperator.ELEM_MATCH, resolved.field, condition);
+    }
+}
+
+// ---------------------------------------------------------
+
+function isPlainObject(input: unknown) : input is Record<string, any> {
+    if (!isObject(input)) {
+        return false;
+    }
+
+    const prototype = Object.getPrototypeOf(input);
+
+    return prototype === null || prototype === Object.prototype;
+}
+
+function isComparableValue(input: unknown) : boolean {
+    return input === null ||
+        typeof input === 'string' ||
+        typeof input === 'number' ||
+        typeof input === 'boolean' ||
+        input instanceof Date;
+}
+
+function isOrderableValue(input: unknown) : boolean {
+    return typeof input === 'string' ||
+        typeof input === 'number' ||
+        input instanceof Date;
+}
+
+function isMongoCompoundOperator(input: string) : input is MongoCompoundOperator {
+    return (MONGO_COMPOUND_OPERATORS as readonly string[]).includes(input);
+}
+
+function isMongoComparisonOperator(input: string) : input is MongoComparisonOperator {
+    return Object.prototype.hasOwnProperty.call(MONGO_COMPARISON_OPERATORS, input);
+}

--- a/packages/parser-mongo/src/parameter/filters/types.ts
+++ b/packages/parser-mongo/src/parameter/filters/types.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    ArrayItem,
+    FiltersParseOptions,
+    IsArray,
+    IsScalar,
+    NestedKeys,
+    ObjectLiteral,
+    PrevIndex,
+    TypeFromNestedKeyPath,
+} from '@rapiq/core';
+
+export type MongoFiltersParseOptions<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+> = FiltersParseOptions<RECORD>;
+
+/**
+ * Field-level operator object of the mongo dialect
+ * (e.g. `{ $gte: 18, $lt: 65 }`).
+ */
+export type MongoFieldQueryOperators<V = unknown> = {
+    $eq?: V | null,
+    $ne?: V | null,
+    $lt?: V,
+    $lte?: V,
+    $gt?: V,
+    $gte?: V,
+    $in?: (V | null)[],
+    $nin?: (V | null)[],
+    $startsWith?: string,
+    $notStartsWith?: string,
+    $endsWith?: string,
+    $notEndsWith?: string,
+    $contains?: string,
+    $notContains?: string,
+    $regex?: RegExp | string,
+    $options?: string,
+    $mod?: [number, number],
+    $exists?: boolean,
+    $elemMatch?: ObjectLiteral,
+    $not?: Omit<MongoFieldQueryOperators<V>, '$not' | '$regex' | '$options' | '$mod' | '$elemMatch'>,
+};
+
+/**
+ * Legal value shapes of one field entry — bare scalars desugar to `$eq`,
+ * bare arrays to `$in`, bare RegExp instances to `$regex`.
+ */
+export type MongoFiltersParserInputValue<
+    V,
+    DEPTH extends number = 10,
+> = [DEPTH] extends [0] ? never :
+    V extends Array<infer ELEMENT> ?
+        MongoFiltersParserInputValue<ELEMENT, PrevIndex[DEPTH]> :
+        V extends Date ?
+            Date | null | Array<Date | null> | MongoFieldQueryOperators<Date> :
+            V extends string ?
+                V | null | RegExp | Array<V | null> | MongoFieldQueryOperators<V> :
+                V extends IsScalar<V> ?
+                    V | null | Array<V | null> | MongoFieldQueryOperators<V> :
+                    never;
+
+type MongoFiltersParserInputSubLevel<
+    T,
+    DEPTH extends number = 10,
+> = [DEPTH] extends [0] ? never :
+    T extends IsArray<T> ?
+        ArrayItem<T> extends Record<PropertyKey, any> ?
+            MongoFiltersParserInput<ArrayItem<T>, PrevIndex[DEPTH]> |
+            { $elemMatch?: MongoFiltersParserInput<ArrayItem<T>, PrevIndex[DEPTH]> } :
+            MongoFiltersParserInputValue<ArrayItem<T>, PrevIndex[DEPTH]> :
+        T extends Date ?
+            MongoFiltersParserInputValue<T, PrevIndex[DEPTH]> :
+            T extends Record<PropertyKey, any> ?
+                MongoFiltersParserInput<T, PrevIndex[DEPTH]> :
+                MongoFiltersParserInputValue<T, PrevIndex[DEPTH]>;
+
+export type MongoFiltersParserInput<
+    T extends ObjectLiteral = ObjectLiteral,
+    DEPTH extends number = 10,
+> = [DEPTH] extends [0] ? never :
+    {
+        [K in keyof T]?: MongoFiltersParserInputSubLevel<T[K], PrevIndex[DEPTH]>
+    } & {
+        [K in NestedKeys<T>]?: MongoFiltersParserInputValue<TypeFromNestedKeyPath<T, K>, PrevIndex[DEPTH]>
+    } & {
+        $and?: MongoFiltersParserInput<T, PrevIndex[DEPTH]>[],
+        $or?: MongoFiltersParserInput<T, PrevIndex[DEPTH]>[],
+        $nor?: MongoFiltersParserInput<T, PrevIndex[DEPTH]>[],
+    };

--- a/packages/parser-mongo/src/parameter/index.ts
+++ b/packages/parser-mongo/src/parameter/index.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './fields';
+export * from './filters';
+export * from './pagination';
+export * from './relations';
+export * from './sorts';

--- a/packages/parser-mongo/src/parameter/pagination/index.ts
+++ b/packages/parser-mongo/src/parameter/pagination/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';

--- a/packages/parser-mongo/src/parameter/pagination/module.ts
+++ b/packages/parser-mongo/src/parameter/pagination/module.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SimplePaginationParser } from '@rapiq/parser-simple';
+
+export class MongoPaginationParser extends SimplePaginationParser {
+
+}

--- a/packages/parser-mongo/src/parameter/relations/index.ts
+++ b/packages/parser-mongo/src/parameter/relations/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';

--- a/packages/parser-mongo/src/parameter/relations/module.ts
+++ b/packages/parser-mongo/src/parameter/relations/module.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SimpleRelationsParser } from '@rapiq/parser-simple';
+
+export class MongoRelationsParser extends SimpleRelationsParser {
+
+}

--- a/packages/parser-mongo/src/parameter/sorts/index.ts
+++ b/packages/parser-mongo/src/parameter/sorts/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';

--- a/packages/parser-mongo/src/parameter/sorts/module.ts
+++ b/packages/parser-mongo/src/parameter/sorts/module.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SimpleSortParser } from '@rapiq/parser-simple';
+
+export class MongoSortParser extends SimpleSortParser {
+
+}

--- a/packages/parser-mongo/test/data/index.ts
+++ b/packages/parser-mongo/test/data/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './schema';
+export * from './type';

--- a/packages/parser-mongo/test/data/schema.ts
+++ b/packages/parser-mongo/test/data/schema.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import type { Item, Realm, User } from './type';
+
+const userSchema = defineSchema<User>({
+    name: 'user',
+    fields: {
+        allowed: [
+            'id',
+            'name',
+            'email',
+            'age',
+        ],
+    },
+    filters: { allowed: ['id', 'name', 'email'] },
+    relations: {
+        allowed: [
+            'realm',
+            'items',
+        ],
+        mapping: { abc: 'items' },
+    },
+    sort: {
+        allowed: ['id', 'name', 'email'],
+        default: { name: 'DESC' },
+    },
+    schemaMapping: { items: 'item' },
+});
+
+const itemSchema = defineSchema<Item>({
+    name: 'item',
+    fields: {
+        allowed: [
+            'id',
+        ],
+    },
+    filters: { allowed: ['id'] },
+    relations: {
+        allowed: [
+            'user',
+            'realm',
+        ],
+    },
+    sort: { allowed: ['id'] },
+});
+
+const realmSchema = defineSchema<Realm>({
+    name: 'realm',
+    fields: {
+        allowed: [
+            'id',
+            'name',
+            'description',
+        ],
+    },
+    filters: { allowed: ['id', 'name'] },
+    sort: { allowed: ['id', 'name'] },
+});
+
+const registry = new SchemaRegistry();
+registry.add(userSchema);
+registry.add(itemSchema);
+registry.add(realmSchema);
+
+export {
+    registry,
+};

--- a/packages/parser-mongo/test/data/type.ts
+++ b/packages/parser-mongo/test/data/type.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type Realm = {
+    id: number,
+    name: string,
+    description: string,
+};
+
+export type Item = {
+    id: string,
+    name: string,
+    realm: Realm,
+    user: User
+};
+
+export type User = {
+    id: string,
+    name: string,
+    email: string,
+    age: number,
+    realm: Realm,
+    items: Item[]
+};
+
+// -----------------------------------------------------
+
+export type GrandChildEntity = {
+    id: string,
+
+    name: string
+};
+
+export type ChildEntity = {
+    id: number;
+
+    name: string;
+
+    age: number;
+
+    child: GrandChildEntity
+};
+
+export type Entity = {
+    id: number,
+    name: string,
+    created_at: Date,
+    child: ChildEntity,
+    siblings: ChildEntity[]
+};

--- a/packages/parser-mongo/test/unit/parser/filters.spec.ts
+++ b/packages/parser-mongo/test/unit/parser/filters.spec.ts
@@ -1,0 +1,1069 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { FiltersParseOptions } from '@rapiq/core';
+import {
+    ErrorCode,
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+    FiltersParseError,
+    Relation,
+    Relations,
+    SchemaRegistry,
+    defineFiltersSchema,
+    defineSchema,
+} from '@rapiq/core';
+import { registry } from '../../data/schema';
+import type { Entity, User } from '../../data/type';
+import { MongoFiltersParser } from '../../../src';
+
+describe('filters/mongo-parser', () => {
+    let parser : MongoFiltersParser;
+
+    const parseFlat = (input: unknown, options: FiltersParseOptions = {}) => {
+        const output = parser.parse(input, options);
+        if (output.value.length === 1) {
+            return output.value[0];
+        }
+
+        return output;
+    };
+
+    const expectParseError = (fn: () => unknown, code: ErrorCode) => {
+        let error : unknown;
+        try {
+            fn();
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).toBeInstanceOf(FiltersParseError);
+        expect((error as FiltersParseError).code).toEqual(code);
+    };
+
+    beforeAll(() => {
+        parser = new MongoFiltersParser();
+    });
+
+    describe('bare values (desugar)', () => {
+        it('should wrap a bare string condition in a root AND group', () => {
+            const output = parser.parse({ name: 'admin' });
+
+            expect(output).toEqual(new Filters(
+                FilterCompoundOperator.AND,
+                [new Filter(FilterFieldOperator.EQUAL, 'name', 'admin')],
+            ));
+        });
+
+        it('should parse bare scalars and null as equal conditions', () => {
+            expect(parseFlat({ age: 18 }))
+                .toEqual(new Filter(FilterFieldOperator.EQUAL, 'age', 18));
+            expect(parseFlat({ flag: true }))
+                .toEqual(new Filter(FilterFieldOperator.EQUAL, 'flag', true));
+            expect(parseFlat({ id: null }))
+                .toEqual(new Filter(FilterFieldOperator.EQUAL, 'id', null));
+        });
+
+        it('should pass a bare Date through as an equal condition', () => {
+            const date = new Date('2026-01-01T00:00:00.000Z');
+
+            const output = parseFlat({ created_at: date });
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.EQUAL, 'created_at', date));
+            expect((output as Filter).value).toBe(date);
+        });
+
+        it('should parse a bare RegExp as a regex condition', () => {
+            const output = parseFlat({ name: /^adm/i });
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.REGEX, 'name', /^adm/i));
+        });
+
+        it('should parse a bare array as an in condition including null elements', () => {
+            const output = parseFlat({ id: [1, '2', null] });
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.IN, 'id', [1, '2', null]));
+        });
+
+        it('should throw on an empty bare array', () => {
+            expectParseError(() => parser.parse({ id: [] }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should throw on a RegExp element inside a bare array', () => {
+            expectParseError(() => parser.parse({ id: [/x/] }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should throw on an unsupported bare value', () => {
+            expectParseError(() => parser.parse({ id: undefined }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ id: () => {} }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should always throw on an empty object value', () => {
+            expectParseError(() => parser.parse({ id: {} }), ErrorCode.KEY_VALUE_INVALID);
+        });
+    });
+
+    describe('operator objects', () => {
+        it('should parse eq & ne operators', () => {
+            expect(parseFlat({ name: { $eq: 'admin' } }))
+                .toEqual(new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'));
+            expect(parseFlat({ name: { $eq: null } }))
+                .toEqual(new Filter(FilterFieldOperator.EQUAL, 'name', null));
+            expect(parseFlat({ name: { $ne: 'admin' } }))
+                .toEqual(new Filter(FilterFieldOperator.NOT_EQUAL, 'name', 'admin'));
+        });
+
+        it('should throw on invalid eq & ne values', () => {
+            expectParseError(() => parser.parse({ name: { $eq: [1] } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ name: { $eq: /x/ } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ name: { $ne: { nested: true } } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should parse the ordering operators', () => {
+            const date = new Date('2026-01-01T00:00:00.000Z');
+
+            expect(parseFlat({ age: { $lt: 65 } }))
+                .toEqual(new Filter(FilterFieldOperator.LESS_THAN, 'age', 65));
+            expect(parseFlat({ age: { $lte: 65 } }))
+                .toEqual(new Filter(FilterFieldOperator.LESS_THAN_EQUAL, 'age', 65));
+            expect(parseFlat({ age: { $gt: 18 } }))
+                .toEqual(new Filter(FilterFieldOperator.GREATER_THAN, 'age', 18));
+            expect(parseFlat({ age: { $gte: 18 } }))
+                .toEqual(new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 18));
+            expect(parseFlat({ created_at: { $lt: date } }))
+                .toEqual(new Filter(FilterFieldOperator.LESS_THAN, 'created_at', date));
+        });
+
+        it('should throw on non orderable values for the ordering operators', () => {
+            expectParseError(() => parser.parse({ age: { $lt: null } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ age: { $lte: true } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ age: { $gt: null } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ age: { $gte: false } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should parse in & nin operators', () => {
+            expect(parseFlat({ id: { $in: [1, null] } }))
+                .toEqual(new Filter(FilterFieldOperator.IN, 'id', [1, null]));
+            expect(parseFlat({ id: { $nin: ['a', 'b'] } }))
+                .toEqual(new Filter(FilterFieldOperator.NOT_IN, 'id', ['a', 'b']));
+        });
+
+        it('should throw on invalid in & nin values', () => {
+            expectParseError(() => parser.parse({ id: { $in: [] } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ id: { $in: 'a' } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ id: { $nin: [/x/] } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should parse the string extension operators', () => {
+            const cases : [string, `${FilterFieldOperator}`][] = [
+                ['$startsWith', FilterFieldOperator.STARTS_WITH],
+                ['$notStartsWith', FilterFieldOperator.NOT_STARTS_WITH],
+                ['$endsWith', FilterFieldOperator.ENDS_WITH],
+                ['$notEndsWith', FilterFieldOperator.NOT_ENDS_WITH],
+                ['$contains', FilterFieldOperator.CONTAINS],
+                ['$notContains', FilterFieldOperator.NOT_CONTAINS],
+            ];
+
+            for (const [key, operator] of cases) {
+                expect(parseFlat({ name: { [key]: 'Pe' } }))
+                    .toEqual(new Filter(operator, 'name', 'Pe'));
+            }
+        });
+
+        it('should throw on non string values for the string extension operators', () => {
+            const keys = [
+                '$startsWith',
+                '$notStartsWith',
+                '$endsWith',
+                '$notEndsWith',
+                '$contains',
+                '$notContains',
+            ];
+
+            for (const key of keys) {
+                expectParseError(() => parser.parse({ name: { [key]: 5 } }), ErrorCode.KEY_VALUE_INVALID);
+            }
+        });
+
+        it('should parse the mod operator', () => {
+            expect(parseFlat({ age: { $mod: [3, 1] } }))
+                .toEqual(new Filter(FilterFieldOperator.MOD, 'age', [3, 1]));
+        });
+
+        it('should throw on invalid mod values', () => {
+            expectParseError(() => parser.parse({ age: { $mod: [0, 1] } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ age: { $mod: [3] } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ age: { $mod: ['3', 1] } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ age: { $mod: 3 } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should parse the exists operator', () => {
+            expect(parseFlat({ deleted: { $exists: true } }))
+                .toEqual(new Filter(FilterFieldOperator.EXISTS, 'deleted', true));
+            expect(parseFlat({ deleted: { $exists: false } }))
+                .toEqual(new Filter(FilterFieldOperator.EXISTS, 'deleted', false));
+        });
+
+        it('should throw on a non boolean exists value', () => {
+            expectParseError(() => parser.parse({ deleted: { $exists: 'yes' } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should combine a multi operator object with an implicit AND', () => {
+            const output = parser.parse({ age: { $gte: 18, $lt: 65 } });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 18),
+                new Filter(FilterFieldOperator.LESS_THAN, 'age', 65),
+            ]));
+        });
+
+        it('should throw on an unknown operator at field level', () => {
+            expectParseError(() => parser.parse({ age: { $foo: 1 } }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on a known but unsupported operator at field level', () => {
+            const error = FiltersParseError.operatorUnsupported('$size');
+
+            expect(() => parser.parse({ items: { $size: 2 } })).toThrow(error);
+
+            expectParseError(() => parser.parse({ age: { $type: 'number' } }), ErrorCode.OPERATOR_UNSUPPORTED);
+        });
+
+        it('should throw on a compound operator at field level', () => {
+            expectParseError(
+                () => parser.parse({ age: { $or: [{ $gte: 3 }] } }),
+                ErrorCode.SYNTAX_INVALID,
+            );
+        });
+    });
+
+    describe('$regex & $options', () => {
+        it('should parse a RegExp valued $regex', () => {
+            const output = parseFlat({ name: { $regex: /foo/i } });
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.REGEX, 'name', /foo/i));
+        });
+
+        it('should parse a string valued $regex into a RegExp instance', () => {
+            const output = parseFlat({ name: { $regex: 'foo' } });
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.REGEX, 'name', /foo/));
+            expect((output as Filter).value).toBeInstanceOf(RegExp);
+        });
+
+        it('should apply $options as RegExp flags', () => {
+            expect(parseFlat({ name: { $regex: 'foo', $options: 'i' } }))
+                .toEqual(new Filter(FilterFieldOperator.REGEX, 'name', /foo/i));
+
+            // key order must not matter.
+            expect(parseFlat({ name: { $options: 'i', $regex: 'foo' } }))
+                .toEqual(new Filter(FilterFieldOperator.REGEX, 'name', /foo/i));
+        });
+
+        it('should throw on a dangling $options', () => {
+            expectParseError(() => parser.parse({ name: { $options: 'i' } }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on $options beside a RegExp valued $regex', () => {
+            expectParseError(
+                () => parser.parse({ name: { $regex: /foo/, $options: 'i' } }),
+                ErrorCode.SYNTAX_INVALID,
+            );
+        });
+
+        it('should throw on an invalid pattern', () => {
+            expectParseError(() => parser.parse({ name: { $regex: '[' } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should throw on invalid flags', () => {
+            expectParseError(
+                () => parser.parse({ name: { $regex: 'foo', $options: 'x' } }),
+                ErrorCode.KEY_VALUE_INVALID,
+            );
+        });
+
+        it('should throw on a non string, non RegExp $regex value', () => {
+            expectParseError(() => parser.parse({ name: { $regex: 5 } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
+        it('should throw on a non string $options value', () => {
+            expectParseError(
+                () => parser.parse({ name: { $regex: 'foo', $options: 5 } }),
+                ErrorCode.KEY_VALUE_INVALID,
+            );
+        });
+    });
+
+    describe('compounds', () => {
+        it('should materialize a root $and without unwrapping a single child', () => {
+            const output = parser.parse({ $and: [{ name: 'a' }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'a'),
+            ]));
+        });
+
+        it('should return a root $or as the root compound', () => {
+            const output = parser.parse({ $or: [{ name: 'a' }, { name: 'b' }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.OR, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'a'),
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'b'),
+            ]));
+        });
+
+        it('should preserve nested compound structure without flattening', () => {
+            const output = parser.parse({
+                $or: [
+                    { $and: [{ a: 1 }, { b: 2 }] },
+                    { c: 3 },
+                ],
+            });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.OR, [
+                new Filters(FilterCompoundOperator.AND, [
+                    new Filter(FilterFieldOperator.EQUAL, 'a', 1),
+                    new Filter(FilterFieldOperator.EQUAL, 'b', 2),
+                ]),
+                new Filter(FilterFieldOperator.EQUAL, 'c', 3),
+            ]));
+        });
+
+        it('should combine plain keys and compounds with an implicit AND', () => {
+            const output = parser.parse({
+                status: 'active',
+                $or: [{ a: 1 }, { b: 2 }],
+            });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'status', 'active'),
+                new Filters(FilterCompoundOperator.OR, [
+                    new Filter(FilterFieldOperator.EQUAL, 'a', 1),
+                    new Filter(FilterFieldOperator.EQUAL, 'b', 2),
+                ]),
+            ]));
+        });
+
+        it('should combine multiple document entries with an implicit AND', () => {
+            const output = parser.parse({ name: 'a', age: 18 });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'a'),
+                new Filter(FilterFieldOperator.EQUAL, 'age', 18),
+            ]));
+        });
+
+        it('should resolve dotted keys inside compound children', () => {
+            const output = parser.parse({ $or: [{ 'realm.name': 'x' }, { name: 'y' }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.OR, [
+                new Filter(FilterFieldOperator.EQUAL, 'realm.name', 'x'),
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'y'),
+            ]));
+        });
+
+        it('should desugar $nor to an AND of negated children', () => {
+            const output = parser.parse({ $nor: [{ name: 'a' }, { age: { $gt: 5 } }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.NOT_EQUAL, 'name', 'a'),
+                new Filter(FilterFieldOperator.LESS_THAN_EQUAL, 'age', 5),
+            ]));
+        });
+
+        it('should apply De Morgan to a multi entry $nor child', () => {
+            const output = parser.parse({ $nor: [{ name: 'a', age: 5 }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filters(FilterCompoundOperator.OR, [
+                    new Filter(FilterFieldOperator.NOT_EQUAL, 'name', 'a'),
+                    new Filter(FilterFieldOperator.NOT_EQUAL, 'age', 5),
+                ]),
+            ]));
+        });
+
+        it('should flip a nested compound under $nor', () => {
+            const output = parser.parse({ $nor: [{ $or: [{ a: 1 }, { b: 2 }] }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filters(FilterCompoundOperator.AND, [
+                    new Filter(FilterFieldOperator.NOT_EQUAL, 'a', 1),
+                    new Filter(FilterFieldOperator.NOT_EQUAL, 'b', 2),
+                ]),
+            ]));
+        });
+
+        it('should cancel the negation of a $nor inside a $nor', () => {
+            const output = parser.parse({ $nor: [{ $nor: [{ a: 1 }] }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filters(FilterCompoundOperator.OR, [
+                    new Filter(FilterFieldOperator.EQUAL, 'a', 1),
+                ]),
+            ]));
+        });
+
+        it('should throw on an empty compound array', () => {
+            expectParseError(() => parser.parse({ $and: [] }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on a non array compound value', () => {
+            expectParseError(() => parser.parse({ $and: { name: 'a' } }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on a non object compound child', () => {
+            expectParseError(() => parser.parse({ $and: [1] }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on an empty object compound child', () => {
+            expectParseError(() => parser.parse({ $and: [{}] }), ErrorCode.SYNTAX_INVALID);
+        });
+    });
+
+    describe('$not', () => {
+        it('should negate operators via $not', () => {
+            expect(parseFlat({ name: { $not: { $eq: 'a' } } }))
+                .toEqual(new Filter(FilterFieldOperator.NOT_EQUAL, 'name', 'a'));
+            expect(parseFlat({ age: { $not: { $gte: 18 } } }))
+                .toEqual(new Filter(FilterFieldOperator.LESS_THAN, 'age', 18));
+            expect(parseFlat({ age: { $not: { $lt: 18 } } }))
+                .toEqual(new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 18));
+            expect(parseFlat({ name: { $not: { $in: ['a'] } } }))
+                .toEqual(new Filter(FilterFieldOperator.NOT_IN, 'name', ['a']));
+            expect(parseFlat({ name: { $not: { $contains: 'a' } } }))
+                .toEqual(new Filter(FilterFieldOperator.NOT_CONTAINS, 'name', 'a'));
+            expect(parseFlat({ name: { $not: { $startsWith: 'a' } } }))
+                .toEqual(new Filter(FilterFieldOperator.NOT_STARTS_WITH, 'name', 'a'));
+            expect(parseFlat({ deleted: { $not: { $exists: true } } }))
+                .toEqual(new Filter(FilterFieldOperator.EXISTS, 'deleted', false));
+        });
+
+        it('should combine a multi operator $not with a local OR', () => {
+            const output = parser.parse({ age: { $not: { $gte: 18, $lt: 5 } } });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.OR, [
+                new Filter(FilterFieldOperator.LESS_THAN, 'age', 18),
+                new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 5),
+            ]));
+        });
+
+        it('should keep the local OR of a multi operator $not as one condition of the document', () => {
+            const output = parser.parse({
+                name: 'a',
+                age: { $not: { $gte: 18, $lt: 5 } },
+            });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'a'),
+                new Filters(FilterCompoundOperator.OR, [
+                    new Filter(FilterFieldOperator.LESS_THAN, 'age', 18),
+                    new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 5),
+                ]),
+            ]));
+        });
+
+        it('should throw on a nested $not', () => {
+            expectParseError(
+                () => parser.parse({ age: { $not: { $not: { $eq: 1 } } } }),
+                ErrorCode.SYNTAX_INVALID,
+            );
+        });
+
+        it('should throw on $not under $nor', () => {
+            expectParseError(
+                () => parser.parse({ $nor: [{ age: { $not: { $eq: 1 } } }] }),
+                ErrorCode.SYNTAX_INVALID,
+            );
+        });
+
+        it('should throw on the $not RegExp shorthand', () => {
+            const error = FiltersParseError.operatorUnsupported('$regex');
+
+            expect(() => parser.parse({ name: { $not: /a/ } })).toThrow(error);
+        });
+
+        it('should throw on non negatable operators under $not', () => {
+            expectParseError(
+                () => parser.parse({ name: { $not: { $regex: 'a' } } }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+            expectParseError(
+                () => parser.parse({ age: { $not: { $mod: [3, 1] } } }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+            expectParseError(
+                () => parser.parse({ items: { $not: { $elemMatch: { id: 1 } } } }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+        });
+
+        it('should always throw on an empty $not object', () => {
+            expectParseError(() => parser.parse({ age: { $not: {} } }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on a non object $not value', () => {
+            expectParseError(() => parser.parse({ age: { $not: 5 } }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on non negatable operators under $nor', () => {
+            expectParseError(
+                () => parser.parse({ $nor: [{ age: { $mod: [3, 1] } }] }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+            expectParseError(
+                () => parser.parse({ $nor: [{ name: { $regex: 'a' } }] }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+            expectParseError(
+                () => parser.parse({ $nor: [{ name: /a/ }] }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+        });
+
+        it('should negate a bare array under $nor to a not in condition', () => {
+            const output = parser.parse({ $nor: [{ id: [1, 2] }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.NOT_IN, 'id', [1, 2]),
+            ]));
+        });
+
+        it('should flip an exists condition under $nor', () => {
+            const output = parser.parse({ $nor: [{ deleted: { $exists: false } }] });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EXISTS, 'deleted', true),
+            ]));
+        });
+    });
+
+    describe('document grammar', () => {
+        it('should throw on a field operator at document level', () => {
+            expectParseError(() => parser.parse({ $gte: 3 }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on a known but unsupported operator at document level', () => {
+            const error = FiltersParseError.operatorUnsupported('$where');
+
+            expect(() => parser.parse({ $where: 'this.a > 1' })).toThrow(error);
+        });
+
+        it('should throw on an unknown operator at document level', () => {
+            expectParseError(() => parser.parse({ $foo: 1 }), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on non object top level input', () => {
+            expectParseError(() => parser.parse(5), ErrorCode.INPUT_INVALID);
+            expectParseError(() => parser.parse('foo'), ErrorCode.INPUT_INVALID);
+            expectParseError(() => parser.parse([{ name: 'a' }]), ErrorCode.INPUT_INVALID);
+        });
+
+        it('should throw on deeply nested compounds instead of overflowing the stack', () => {
+            let input : Record<string, any> = { name: 'admin' };
+            for (let i = 0; i < 40; i++) {
+                input = { $and: [input] };
+            }
+
+            expectParseError(() => parser.parse(input), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should throw on deeply nested objects instead of overflowing the stack', () => {
+            let input : Record<string, any> = { name: 'admin' };
+            for (let i = 0; i < 40; i++) {
+                input = { a: input };
+            }
+
+            expectParseError(() => parser.parse(input), ErrorCode.SYNTAX_INVALID);
+        });
+
+        it('should parse nesting below the depth cap', () => {
+            let input : Record<string, any> = { name: 'admin' };
+            for (let i = 0; i < 10; i++) {
+                input = { $and: [input] };
+            }
+
+            expect(() => parser.parse(input)).not.toThrow();
+        });
+    });
+
+    describe('path expansion (nested objects)', () => {
+        it('should expand a nested object to a dotted key path', () => {
+            const nested = parser.parse({ realm: { name: 'x' } });
+            const dotted = parser.parse({ 'realm.name': 'x' });
+
+            expect(nested).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'realm.name', 'x'),
+            ]));
+            expect(nested).toEqual(dotted);
+        });
+
+        it('should expand deeply nested objects', () => {
+            const output = parseFlat({ a: { b: { c: { $gte: 3 } } } });
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'a.b.c', 3));
+        });
+
+        it('should expand multiple nested entries into an implicit AND', () => {
+            const output = parser.parse({ realm: { id: 1, name: 'x' } });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'realm.id', 1),
+                new Filter(FilterFieldOperator.EQUAL, 'realm.name', 'x'),
+            ]));
+        });
+
+        it('should throw on mixed operator and field keys', () => {
+            expectParseError(
+                () => parser.parse({ realm: { name: 'x', $eq: 1 } }),
+                ErrorCode.SYNTAX_INVALID,
+            );
+        });
+
+        it('should throw on an empty object at a nested level', () => {
+            expectParseError(() => parser.parse({ realm: { name: {} } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+    });
+
+    describe('parse (schema-constrained)', () => {
+        let constrained : MongoFiltersParser;
+
+        beforeAll(() => {
+            constrained = new MongoFiltersParser(registry);
+        });
+
+        it('should parse an allowed key', () => {
+            const output = constrained.parse({ name: 'admin' }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+            ]));
+        });
+
+        it('should drop a non allowed key silently', () => {
+            const output = constrained.parse({ age: 18, name: 'admin' }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+            ]));
+        });
+
+        it('should throw on a non allowed key with throwOnFailure', () => {
+            const error = FiltersParseError.keyNotPermitted('age');
+
+            expect(() => constrained.parse({ age: 18 }, {
+                schema: 'user',
+                throwOnFailure: true,
+            })).toThrow(error);
+        });
+
+        it('should throw on a non allowed key under a throwOnFailure schema', () => {
+            const schema = defineFiltersSchema({
+                allowed: ['id'],
+                throwOnFailure: true,
+            });
+            const error = FiltersParseError.keyNotPermitted('name');
+
+            expect(() => constrained.parse({ name: 'x' }, { schema })).toThrow(error);
+        });
+
+        it('should walk a relation path through schemaMapping', () => {
+            const output = constrained.parse({ 'items.id': 1 }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'items.id', 1),
+            ]));
+        });
+
+        it('should validate the leaf against the related schema', () => {
+            const output = constrained.parse({ 'items.name': 'foo' }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, []));
+
+            const error = FiltersParseError.keyNotPermitted('name');
+            expect(() => constrained.parse({ 'items.name': 'foo' }, {
+                schema: 'user',
+                throwOnFailure: true,
+            })).toThrow(error);
+        });
+
+        it('should honor the relations context', () => {
+            const dropped = constrained.parse({ 'items.id': 1 }, {
+                schema: 'user',
+                relations: new Relations([new Relation('realm')]),
+            });
+            expect(dropped).toEqual(new Filters(FilterCompoundOperator.AND, []));
+
+            const error = FiltersParseError.keyPathNotPermitted('items');
+            expect(() => constrained.parse({ 'items.id': 1 }, {
+                schema: 'user',
+                relations: new Relations([new Relation('realm')]),
+                throwOnFailure: true,
+            })).toThrow(error);
+
+            const output = constrained.parse({ 'items.id': 1 }, {
+                schema: 'user',
+                relations: new Relations([new Relation('items')]),
+            });
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'items.id', 1),
+            ]));
+        });
+
+        it('should apply mapping aliases', () => {
+            const schema = defineFiltersSchema({
+                allowed: ['id'],
+                mapping: { aliasId: 'id' },
+            });
+
+            const output = constrained.parse({ aliasId: 1 }, { schema });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            ]));
+        });
+
+        it('should throw on grammar errors before applying the field policy', () => {
+            // age is not allowed and would drop — grammar still throws.
+            expectParseError(
+                () => constrained.parse({ age: { $foo: 1 } }, { schema: 'user' }),
+                ErrorCode.SYNTAX_INVALID,
+            );
+            expectParseError(
+                () => constrained.parse({ age: {} }, { schema: 'user' }),
+                ErrorCode.KEY_VALUE_INVALID,
+            );
+            expectParseError(
+                () => constrained.parse({ age: [] }, { schema: 'user' }),
+                ErrorCode.KEY_VALUE_INVALID,
+            );
+        });
+
+        it('should skip compound children dropped by the schema policy', () => {
+            const output = constrained.parse({ $or: [{ age: 18 }, { name: 'a' }] }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.OR, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'a'),
+            ]));
+        });
+
+        it('should drop a compound when all children are dropped', () => {
+            const output = constrained.parse({ $or: [{ age: 18 }] }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, []));
+        });
+    });
+
+    describe('schema defaults', () => {
+        it('should apply schema defaults for absent input', () => {
+            const schema = defineFiltersSchema({ default: new Filter(FilterFieldOperator.EQUAL, 'id', 1) });
+
+            expect(parser.parse(undefined, { schema })).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            ]));
+            expect(parser.parse(null, { schema })).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            ]));
+        });
+
+        it('should apply schema defaults for an empty document', () => {
+            const schema = defineFiltersSchema({ default: new Filter(FilterFieldOperator.EQUAL, 'id', 1) });
+
+            const output = parser.parse({}, { schema });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            ]));
+        });
+
+        it('should apply schema defaults when every condition is dropped', () => {
+            const schema = defineFiltersSchema({
+                allowed: ['id'],
+                default: new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            });
+
+            const output = parser.parse({ name: 'x' }, { schema });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            ]));
+        });
+
+        it('should short-circuit to defaults on an empty allow-list', () => {
+            const schema = defineFiltersSchema({
+                allowed: [],
+                default: new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                throwOnFailure: true,
+            });
+
+            // the input is not walked — nothing throws despite the policy.
+            const output = parser.parse({ name: 'x' }, { schema });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+            ]));
+        });
+    });
+
+    describe('strict mode', () => {
+        it('should drop any key when parsing schemaless with the strict option', () => {
+            const output = parser.parse({ name: 'x' }, { strict: true });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, []));
+        });
+
+        it('should throw for any key under strict with throwOnFailure', () => {
+            const error = FiltersParseError.keyNotPermitted('name');
+
+            expect(() => parser.parse({ name: 'x' }, {
+                strict: true,
+                throwOnFailure: true,
+            })).toThrow(error);
+        });
+
+        it('should keep a declared allow-list working under strict', () => {
+            const schema = defineFiltersSchema({
+                allowed: ['name'],
+                strict: true,
+            });
+
+            const output = parser.parse({ name: 'x' }, { schema });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'x'),
+            ]));
+        });
+    });
+
+    describe('$elemMatch', () => {
+        let constrained : MongoFiltersParser;
+
+        beforeAll(() => {
+            const elemRegistry = new SchemaRegistry();
+            elemRegistry.add(defineSchema({
+                name: 'user',
+                filters: { allowed: ['id', 'name', 'items', 'meta'] },
+                schemaMapping: { items: 'item' },
+            }));
+            elemRegistry.add(defineSchema({
+                name: 'item',
+                filters: { allowed: ['id'] },
+            }));
+
+            constrained = new MongoFiltersParser(elemRegistry);
+        });
+
+        it('should parse the nested document form on a relation field', () => {
+            const output = constrained.parse({ items: { $elemMatch: { id: 1 } } }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(
+                    FilterFieldOperator.ELEM_MATCH,
+                    'items',
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                ),
+            ]));
+        });
+
+        it('should parse a nested elemMatch with element relative fields', () => {
+            const output = parseFlat({ items: { $elemMatch: { parts: { $elemMatch: { id: 7 } } } } });
+
+            expect(output).toEqual(new Filter(
+                FilterFieldOperator.ELEM_MATCH,
+                'items',
+                new Filter(
+                    FilterFieldOperator.ELEM_MATCH,
+                    'parts',
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 7),
+                ),
+            ));
+        });
+
+        it('should validate interior keys against the related schema', () => {
+            const output = constrained.parse({ items: { $elemMatch: { name: 'x' } } }, { schema: 'user' });
+
+            // the emptied interior drops the whole entry.
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, []));
+
+            const error = FiltersParseError.keyNotPermitted('name');
+            expect(() => constrained.parse({ items: { $elemMatch: { name: 'x' } } }, { schema: 'user', throwOnFailure: true })).toThrow(error);
+        });
+
+        it('should combine a multi condition interior with an AND', () => {
+            const output = parseFlat({ items: { $elemMatch: { id: 1, name: 'x' } } });
+
+            expect(output).toEqual(new Filter(
+                FilterFieldOperator.ELEM_MATCH,
+                'items',
+                new Filters(FilterCompoundOperator.AND, [
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                    new Filter(FilterFieldOperator.EQUAL, 'name', 'x'),
+                ]),
+            ));
+        });
+
+        it('should keep an explicit compound interior as the condition', () => {
+            const output = parseFlat({ items: { $elemMatch: { $or: [{ id: 1 }, { id: 2 }] } } });
+
+            expect(output).toEqual(new Filter(
+                FilterFieldOperator.ELEM_MATCH,
+                'items',
+                new Filters(FilterCompoundOperator.OR, [
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 2),
+                ]),
+            ));
+        });
+
+        it('should combine $elemMatch with sibling operators', () => {
+            const output = parser.parse({
+                items: {
+                    $elemMatch: { id: 1 },
+                    $exists: true,
+                },
+            });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(
+                    FilterFieldOperator.ELEM_MATCH,
+                    'items',
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                ),
+                new Filter(FilterFieldOperator.EXISTS, 'items', true),
+            ]));
+        });
+
+        it('should throw on the element operator form', () => {
+            const error = FiltersParseError.featureUnsupported('$elemMatch (element-level operators)');
+
+            expect(() => parser.parse({ items: { $elemMatch: { $gte: 5 } } })).toThrow(error);
+            expect(() => parser.parse({ items: { $elemMatch: { $not: { $eq: 5 } } } })).toThrow(error);
+        });
+
+        it('should always throw on an empty $elemMatch object', () => {
+            expectParseError(
+                () => parser.parse({ items: { $elemMatch: {} } }),
+                ErrorCode.KEY_VALUE_INVALID,
+            );
+        });
+
+        it('should throw on a non object $elemMatch value', () => {
+            expectParseError(
+                () => parser.parse({ items: { $elemMatch: 5 } }),
+                ErrorCode.KEY_VALUE_INVALID,
+            );
+        });
+
+        it('should fall back to an unbound interior scope on a schemaless field', () => {
+            const output = constrained.parse({ meta: { $elemMatch: { value: 5 } } }, { schema: 'user' });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(
+                    FilterFieldOperator.ELEM_MATCH,
+                    'meta',
+                    new Filter(FilterFieldOperator.EQUAL, 'value', 5),
+                ),
+            ]));
+
+            // the missing related schema is never an error — not even
+            // under throwOnFailure.
+            const strictOutput = constrained.parse({ meta: { $elemMatch: { value: 5 } } }, { schema: 'user', throwOnFailure: true });
+
+            expect(strictOutput).toEqual(output);
+        });
+
+        it('should honor the relations context', () => {
+            const dropped = constrained.parse({ items: { $elemMatch: { id: 1 } } }, {
+                schema: 'user',
+                relations: new Relations([new Relation('realm')]),
+            });
+            expect(dropped).toEqual(new Filters(FilterCompoundOperator.AND, []));
+
+            const error = FiltersParseError.keyPathNotPermitted('items');
+            expect(() => constrained.parse({ items: { $elemMatch: { id: 1 } } }, {
+                schema: 'user',
+                relations: new Relations([new Relation('realm')]),
+                throwOnFailure: true,
+            })).toThrow(error);
+
+            const output = constrained.parse({ items: { $elemMatch: { id: 1 } } }, {
+                schema: 'user',
+                relations: new Relations([new Relation('items')]),
+            });
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(
+                    FilterFieldOperator.ELEM_MATCH,
+                    'items',
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                ),
+            ]));
+        });
+
+        it('should throw on a negated $elemMatch', () => {
+            expectParseError(
+                () => parser.parse({ $nor: [{ items: { $elemMatch: { id: 1 } } }] }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+        });
+
+        it('should reject unbound interior keys under a strict schema', () => {
+            const schema = defineFiltersSchema({
+                allowed: ['meta'],
+                strict: true,
+            });
+
+            const output = constrained.parse({ meta: { $elemMatch: { value: 5 } } }, { schema });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, []));
+        });
+
+        it('should parse fully schemaless', () => {
+            const output = parseFlat({ items: { $elemMatch: { name: 'x' } } });
+
+            expect(output).toEqual(new Filter(
+                FilterFieldOperator.ELEM_MATCH,
+                'items',
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'x'),
+            ));
+        });
+    });
+
+    describe('parseTyped', () => {
+        it('should delegate to parse', () => {
+            const output = parser.parseTyped<User>({
+                name: 'admin',
+                age: { $gte: 18 },
+            });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+                new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 18),
+            ]));
+        });
+
+        it('should accept bare null and operator objects on a date field', () => {
+            const date = new Date();
+
+            const output = parser.parseTyped<Entity>({
+                created_at: null,
+                $or: [
+                    { created_at: { $eq: null } },
+                    { created_at: [date, null] },
+                ],
+            });
+
+            expect(output).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'created_at', null),
+                new Filters(FilterCompoundOperator.OR, [
+                    new Filter(FilterFieldOperator.EQUAL, 'created_at', null),
+                    new Filter(FilterFieldOperator.IN, 'created_at', [date, null]),
+                ]),
+            ]));
+        });
+    });
+});

--- a/packages/parser-mongo/test/unit/parser/parser.spec.ts
+++ b/packages/parser-mongo/test/unit/parser/parser.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    Fields,
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+    FiltersParseError,
+    Relation,
+    Relations,
+    Sort,
+    SortDirection,
+    Sorts,
+} from '@rapiq/core';
+import { registry } from '../../data/schema';
+import { MongoParser } from '../../../src';
+
+describe('src/parser', () => {
+    let parser : MongoParser;
+
+    beforeAll(() => {
+        parser = new MongoParser(registry);
+    });
+
+    it('should parse a full query input', () => {
+        const output = parser.parse({
+            fields: ['id', 'name'],
+            filters: {
+                $or: [
+                    { name: 'John' },
+                    { email: { $contains: '@example.com' } },
+                ],
+            },
+            relations: ['realm'],
+            pagination: { limit: 10 },
+        }, { schema: 'user' });
+
+        // the included relation projects the related schema's allowed fields
+        expect(output.fields).toEqual(new Fields([
+            new Field('id'),
+            new Field('name'),
+            new Field('realm.id'),
+            new Field('realm.name'),
+            new Field('realm.description'),
+        ]));
+
+        // an explicit root compound stays the root node.
+        expect(output.filters).toEqual(new Filters(FilterCompoundOperator.OR, [
+            new Filter(FilterFieldOperator.EQUAL, 'name', 'John'),
+            new Filter(FilterFieldOperator.CONTAINS, 'email', '@example.com'),
+        ]));
+
+        expect(output.relations).toEqual(new Relations([
+            new Relation('realm'),
+        ]));
+        expect(output.pagination.limit).toEqual(10);
+
+        // absent sort parameter -> schema default applies
+        expect(output.sorts).toEqual(new Sorts([
+            new Sort('name', SortDirection.DESC),
+        ]));
+    });
+
+    it('should enforce the relations allow-list in full-query parsing', () => {
+        const output = parser.parse({ relations: ['realm', 'owner'] }, { schema: 'user' });
+
+        expect(output.relations).toEqual(new Relations([
+            new Relation('realm'),
+        ]));
+    });
+
+    it('should gate filter relation paths by the relations parameter', () => {
+        const output = parser.parse({
+            relations: ['realm'],
+            filters: {
+                'items.id': 1,
+                'realm.id': 5,
+            },
+        }, { schema: 'user' });
+
+        expect(output.relations).toEqual(new Relations([
+            new Relation('realm'),
+        ]));
+
+        // items is not included -> its filter path is dropped.
+        expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, [
+            new Filter(FilterFieldOperator.EQUAL, 'realm.id', 5),
+        ]));
+    });
+
+    it('should keep relation filter paths ungated without a relations parameter', () => {
+        const output = parser.parse({ filters: { 'items.id': 1 } }, { schema: 'user' });
+
+        expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, [
+            new Filter(FilterFieldOperator.EQUAL, 'items.id', 1),
+        ]));
+    });
+
+    it('should keep dotted fields when parsing without a schema', () => {
+        const composite = new MongoParser();
+
+        const output = composite.parse({ filters: { 'user.friends': 5 } });
+
+        expect(output.filters).toEqual(new Filters(
+            FilterCompoundOperator.AND,
+            [new Filter(FilterFieldOperator.EQUAL, 'user.friends', 5)],
+        ));
+    });
+
+    it('should drop undeclared filter keys when parsing with the strict option', () => {
+        const composite = new MongoParser();
+
+        const output = composite.parse({ filters: { name: 'admin' } }, { strict: true });
+
+        expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, []));
+    });
+
+    it('should always throw on filter grammar errors in full-query parsing', () => {
+        const error = FiltersParseError.operatorUnsupported('$where');
+
+        expect(() => parser.parse({ filters: { $where: 'this.a > 1' } }, { schema: 'user' })).toThrow(error);
+    });
+});

--- a/packages/parser-mongo/test/vitest.config.ts
+++ b/packages/parser-mongo/test/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/unit/**/*.{spec,test}.{ts,js}'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            exclude: ['src/**/*.d.ts'],
+        },
+    },
+});

--- a/packages/parser-mongo/tsconfig.build.json
+++ b/packages/parser-mongo/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src/**/*"]
+}

--- a/packages/parser-mongo/tsconfig.json
+++ b/packages/parser-mongo/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "types": ["node", "vitest/globals"]
+    },
+    "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/parser-mongo/tsdown.config.ts
+++ b/packages/parser-mongo/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: 'src/index.ts',
+    format: 'esm',
+    dts: true,
+    sourcemap: true,
+    tsconfig: 'tsconfig.build.json',
+});

--- a/packages/sql/src/visitor/filters.ts
+++ b/packages/sql/src/visitor/filters.ts
@@ -89,7 +89,7 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     visitFilterElemMatch(expr: Filter<FilterFieldOperator.ELEM_MATCH, Filter | Filters>): IFiltersAdapter {
         const oldPrefix = this.adapter.getFieldPrefix();
 
-        this.adapter.setFieldPrefix(`${expr.field}.`);
+        this.adapter.setFieldPrefix(`${oldPrefix}${expr.field}.`);
 
         expr.value.accept(this);
 

--- a/packages/sql/test/unit/interpreters/elem-match.spec.ts
+++ b/packages/sql/test/unit/interpreters/elem-match.spec.ts
@@ -17,11 +17,12 @@ import {
 const options: FiltersContainerOptions = { ...pg };
 
 describe('elemMatch', () => {
+    let relationsAdapter : RelationsAdapter;
     let adapter : FiltersAdapter;
     let visitor : FiltersVisitor;
 
     beforeEach(() => {
-        const relationsAdapter = new RelationsAdapter();
+        relationsAdapter = new RelationsAdapter();
         adapter = new FiltersAdapter(
             relationsAdapter,
             options,
@@ -42,6 +43,28 @@ describe('elemMatch', () => {
 
         expect(sql).toEqual('"projects"."active" = $1');
         expect(params).toStrictEqual([true]);
+    });
+
+    it('generates query from a nested condition', () => {
+        const condition = new Filter(
+            'elemMatch',
+            'items',
+            new Filter(
+                'elemMatch',
+                'parts',
+                new Filter('eq', 'id', 7),
+            ),
+        );
+        condition.accept(visitor);
+
+        const [sql, params] = adapter.getQueryAndParameters();
+
+        expect(sql).toEqual('"parts"."id" = $1');
+        expect(params).toStrictEqual([7]);
+
+        // the inner interior binds relative to the OUTER element —
+        // the join path composes instead of resetting to the root.
+        expect(relationsAdapter.getPaths()).toStrictEqual(['items', 'items.parts']);
     });
 
     it('generates query from a compound condition based on relation', () => {


### PR DESCRIPTION
Implements issue #701: a new parser dialect accepting MongoDB-style filter documents, designed against the [ucast](https://github.com/stalniy/ucast) reference implementation (mapped in `.agents/references/ucast.md`). Dialect semantics were settled by a design review across three lenses (mongo fidelity, IR consistency, consumer DX); decisions recorded in local plan 013.

## Design decisions

1. **Two-class failure model** (load-bearing): grammar errors — unknown/misplaced `$`-operators, malformed operator values, invalid compound arrays, mixed operator/plain keys, non-object input, nesting deeper than 32 levels — **always throw** typed `FiltersParseError`, independent of `throwOnFailure`. A `$`-prefixed key is never a field name, and a silently dropped `$where` or typo'd operator would mean an unfiltered result set. Field-key/allow-list failures stay schema-governed (drop by default, throw under `throwOnFailure`), exactly like the simple dialect.
2. **`$not`/`$nor` desugar via De Morgan operator negation** (`$eq` ↔ `$ne`, `$lt` ↔ `$gte`, `$in` ↔ `$nin`, AND ↔ OR, `$exists` flips its value) — the expression dialect's `not(...)` precedent; the AST deliberately has no NOT compound. Non-negatable operators (`$regex`/`$mod`/`$elemMatch`) under negation throw `OPERATOR_UNSUPPORTED`.
3. **Full IR coverage via extensions**: `$startsWith`/`$notStartsWith`/`$endsWith`/`$notEndsWith`/`$contains`/`$notContains` are accepted as documented rapiq extensions (`$` + `FilterFieldOperator` value, aligned with the build layer's `$`-vocabulary from plan 012) — the only dialect covering the entire operator inventory, so a future mongo codec's encode is total under the subset law.
4. **Deviations from MongoDB** (documented in the docs page): operator-free nested objects expand to dotted key paths (`{ realm: { name: 'x' } }` ≡ `{ 'realm.name': 'x' }`); bare arrays mean `$in`; algebraic negation does not replicate mongo's missing-field semantics; `$elemMatch` supports the nested-document form only (the IR has no element self-reference marker); `$where`/`$size`/`$all`/`$type` and the evaluation/geo/bitwise operators throw.
5. **`$regex`** accepts bare RegExp, `$regex: RegExp`, and `$regex: string` + `$options` (key-order independent); the AST value is always a `RegExp` instance (the SQL visitor dereferences `.source`/`.ignoreCase`). Dangling `$options` and `$options` beside a RegExp-valued `$regex` throw.
6. **Values stay typed** — no wire-string coercion, no ISO-string→Date guessing; `Date` instances pass through. Strict per-operator argument validation throws unconditionally.

## Changes

### `@rapiq/parser-mongo` (new)
- `MongoFiltersParser`: document walk (implicit AND, explicit `$and`/`$or`/`$nor` always materialized, nested compounds preserved — no flattening), operator objects, `$elemMatch` with schema descend (related schema via `schemaMapping`, unbound fallback for schemaless array columns, relations gating respected), schema defaults on absent/`{}`/all-dropped input, recursion depth cap (crafted ~17KB nested-`$and` JSON previously escaped as an untyped `RangeError`).
- `MongoParser` composing the filters parser with the simple-dialect parsers for fields/relations/pagination/sort (parser-expression template).
- Typed input surface: `parseTyped(input: MongoFiltersParserInput<RECORD>)` — field keys via `NestedKeys`, per-path operator objects, `$not` typed to the negatable subset.
- 113 unit specs (operator matrix incl. negation flips, compound algebra, `$elemMatch` scoping, schema policy/strict/defaults, grammar always-throws set, hostile inputs).

### `@rapiq/core`
- `ParseError.operatorUnsupported(...)` / `ParseError.featureUnsupported(...)` factories (existing `ErrorCode` members), mirroring `AdapterError`/`BuildError`.

### `@rapiq/sql`
- Fix: `visitFilterElemMatch` reset the adapter field prefix instead of composing it, so a nested `elemMatch` interior bound relative to the root (registering relation `parts` instead of `items.parts`). Newly client-reachable through this dialect; pre-existing for hand-built ASTs.

### Docs
- New `integrations/mongo.md` (operator table with extension markers, deviations callout, failure model, usage) + sidebar, integrations index, installation, root README package table, `.agents/{structure,architecture}.md` updated (the "`$and`/`$or` reserved for a future mongo parser dialect" note now points here), `guide/build.md` reserved-keys note linked.

Closes #701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `@rapiq/parser-mongo` package to parse MongoDB-style `filters` into the shared query AST (including `$and/$or/$nor`, common comparison/string operators, and `$elemMatch`).
* **Bug Fixes**
  * Improved parse error coverage with dedicated “unsupported operator/feature” error helpers.
  * Fixed nested `$elemMatch` field-prefix handling in SQL generation to produce correct nested paths.
* **Documentation**
  * Added Mongo Parser integration/guide pages and updated installation/navigation and architecture notes.
* **Tests**
  * Added comprehensive unit test suites for Mongo parser behaviors and SQL `elemMatch` nesting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->