### PR TITLE
fix(sql): render negated filter operators null-inclusively

### DIFF
--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -97,6 +97,8 @@ The simple object/wire dialect only expresses flat **and** sets. For `or` and ne
 | `inArray(field, [a, null])` | `field IN (…) OR field IS NULL` |
 | `exists(field)` | `field IS NOT NULL` |
 
+Negated operators (`ne`, `nin`, `notContains`, `notStartsWith`, `notEndsWith`) are **exact complements** of their positive twins — they also match records where the field is `NULL`/absent. Adapters render them null-inclusively, e.g. `ne(field, a)` → `(field <> ? OR field IS NULL)`.
+
 ## Schema options
 
 ```typescript

--- a/packages/docs/packages/memory.md
+++ b/packages/docs/packages/memory.md
@@ -98,7 +98,6 @@ compileFilters(elemMatch('items', and(eq('id', 1), eq('active', true))))(user); 
 
 | Case | @rapiq/memory | Baseline |
 |---|---|---|
-| `ne`/`nin`/`not*` on absent values | match (complement law) | SQL renders `field <> ?`, which does **not** match `NULL` rows (alignment planned) |
 | Per-leaf array quantification | same-element binding | Mongo/ucast quantify each dotted condition independently |
 | `exists` | is-not-null | Mongo: property presence |
 | `contains` family | case-insensitive | Mongo/ucast: case-sensitive |

--- a/packages/docs/packages/sql.md
+++ b/packages/docs/packages/sql.md
@@ -94,6 +94,16 @@ A `null` filter value is rewritten to the SQL null predicates instead of being b
 
 An empty list never matches: `in(field, [])` renders `1 = 0` and `nin(field, [])` renders `1 = 1` (instead of the invalid `IN ()`).
 
+Negated operators are **exact complements** of their positive twins: a record that does not match `eq(field, a)` matches `ne(field, a)` — including records where the column is `NULL`. Since a bare SQL negation drops `NULL` rows under three-valued logic, negations render null-inclusively:
+
+| Filter | SQL |
+|---|---|
+| `ne(field, a)` | `(field <> ? OR field IS NULL)` |
+| `nin(field, [a, b])` | `(field NOT IN (...) OR field IS NULL)` |
+| `notContains(field, a)` (also `notStartsWith` / `notEndsWith`) | `(field ~* ? OR field IS NULL)` |
+
 ### String matching
 
 The `contains` / `startsWith` / `endsWith` operators (and their negations) match their value **literally** on every dialect: regex metacharacters are escaped on regex-capable dialects, LIKE wildcards are escaped on the LIKE fallback. Only the `regex` operator interprets its value as a pattern.
+
+The negations match rows whose column is `NULL` (complement law, see above) — on the LIKE fallback they render `(field NOT LIKE ? ESCAPE '\' OR field IS NULL)`.

--- a/packages/sql/src/visitor/filters.ts
+++ b/packages/sql/src/visitor/filters.ts
@@ -45,11 +45,16 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     }
 
     visitFilterNotEqual(expr: Filter<FilterFieldOperator.NOT_EQUAL>): IFiltersAdapter {
+        const field = this.adapter.buildField(expr.field);
         if (expr.value === null) {
-            return this.adapter.whereRaw(`${this.adapter.buildField(expr.field)} is not null`);
+            return this.adapter.whereRaw(`${field} is not null`);
         }
 
-        return this.adapter.where(expr.field, '<>', expr.value);
+        return this.whereComplement(
+            field,
+            `${field} <> ${this.adapter.buildParamPlaceholder()}`,
+            expr.value,
+        );
     }
 
     visitFilterLessThan(expr: Filter<FilterFieldOperator.LESS_THAN>): IFiltersAdapter {
@@ -210,6 +215,10 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
 
         const inCondition = `${field} ${negated ? 'not ' : ''}in(${this.adapter.buildParamsPlaceholders(values).join(', ')})`;
         if (values.length === input.length) {
+            if (negated) {
+                return this.whereComplement(field, inCondition, ...values);
+            }
+
             return this.adapter.whereRaw(inCondition, ...values);
         }
 
@@ -240,14 +249,36 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
         }
 
         const regex = createFilterRegex(`${value}`, flag);
+        if (!(flag & FilterRegexFlag.NEGATION)) {
+            return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, field, regex));
+        }
 
-        return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, field, regex));
+        const fieldBuilt = this.adapter.buildField(field);
+        const sql = this.adapter.regexp(
+            fieldBuilt,
+            this.adapter.buildParamPlaceholder(),
+            regex.ignoreCase,
+        );
+
+        return this.whereComplement(fieldBuilt, sql, regex.source);
     }
 
     protected whereLike(field: string, pattern: string, negated = false) : IFiltersAdapter {
-        return this.adapter.whereRaw(
-            `${this.adapter.buildField(field)} ${negated ? 'not ' : ''}like ${this.adapter.buildParamPlaceholder()} escape '\\'`,
-            pattern,
-        );
+        const fieldBuilt = this.adapter.buildField(field);
+        const condition = `${fieldBuilt} ${negated ? 'not ' : ''}like ${this.adapter.buildParamPlaceholder()} escape '\\'`;
+        if (negated) {
+            return this.whereComplement(fieldBuilt, condition, pattern);
+        }
+
+        return this.adapter.whereRaw(condition, pattern);
+    }
+
+    /**
+     * Render a negated condition null-inclusively. Negated operators are
+     * exact complements of their positive twins (complement law), but the
+     * bare SQL negation follows three-valued logic and drops NULL rows.
+     */
+    protected whereComplement(field: string, sql: string, ...values: unknown[]) : IFiltersAdapter {
+        return this.adapter.whereRaw(`(${sql} or ${field} is null)`, ...values);
     }
 }

--- a/packages/sql/test/unit/interpreters/in.spec.ts
+++ b/packages/sql/test/unit/interpreters/in.spec.ts
@@ -53,13 +53,14 @@ describe('in (within, nin)', () => {
         expect(params).toStrictEqual(['John', 1, 2]);
     });
 
-    it('generates `not in` operator for "nin', () => {
+    it('generates a null-inclusive `not in` condition for "nin"', () => {
         const condition = new Filter('nin', 'age', [1, 2]);
         condition.accept(visitor);
 
         const [sql, params] = adapter.getQueryAndParameters();
 
-        expect(sql).toEqual(`${options.escapeField(condition.field)} not in($1, $2)`);
+        const field = options.escapeField(condition.field);
+        expect(sql).toEqual(`(${field} not in($1, $2) or ${field} is null)`);
         expect(params).toStrictEqual(condition.value);
     });
 

--- a/packages/sql/test/unit/interpreters/primitves.spec.ts
+++ b/packages/sql/test/unit/interpreters/primitves.spec.ts
@@ -40,13 +40,14 @@ describe('primitive operators', () => {
         expect(params).toStrictEqual([condition.value]);
     });
 
-    it('generates query with `<>` operator for "ne"', () => {
+    it('generates a null-inclusive `<>` condition for "ne"', () => {
         const condition = new Filter('ne', 'name', 'test');
         condition.accept(visitor);
 
         const [sql, params] = adapter.getQueryAndParameters();
 
-        expect(sql).toEqual(`${options.escapeField(condition.field)} <> $1`);
+        const field = options.escapeField(condition.field);
+        expect(sql).toEqual(`(${field} <> $1 or ${field} is null)`);
         expect(params).toStrictEqual([condition.value]);
     });
 

--- a/packages/sql/test/unit/interpreters/regex.spec.ts
+++ b/packages/sql/test/unit/interpreters/regex.spec.ts
@@ -117,7 +117,7 @@ describe('regex', () => {
         ({ adapter, visitor } = buildAdapter());
         new Filter('notContains', 'name', 'foo').accept(visitor);
         expect(adapter.getQueryAndParameters()).toEqual([
-            '[name] not like ? escape \'\\\'', 
+            '([name] not like ? escape \'\\\' or [name] is null)',
             ['%foo%'],
         ]);
     });
@@ -154,23 +154,25 @@ describe('regex', () => {
     });
 
     it('generates anchored patterns for anchored operators on regexp dialects', () => {
-        const cases : [string, string][] = [
-            ['startsWith', '^foo'],
-            ['endsWith', 'foo$'],
-            ['contains', 'foo'],
-            ['notStartsWith', '^(?!foo).*'],
-            ['notEndsWith', '^(?!.*foo$).*'],
-            ['notContains', '^(?!.*foo).*'],
+        const cases : [string, string, boolean][] = [
+            ['startsWith', '^foo', false],
+            ['endsWith', 'foo$', false],
+            ['contains', 'foo', false],
+            ['notStartsWith', '^(?!foo).*', true],
+            ['notEndsWith', '^(?!.*foo$).*', true],
+            ['notContains', '^(?!.*foo).*', true],
         ];
 
-        for (const [operator, pattern] of cases) {
+        for (const [operator, pattern, negated] of cases) {
             const adapter = new FiltersAdapter(new RelationsAdapter(), pg);
             const visitor = new FiltersVisitor(adapter);
 
             new Filter(operator, 'name', 'foo').accept(visitor);
 
             const [sql, params] = adapter.getQueryAndParameters();
-            expect(sql, operator).toEqual('"name" ~* $1');
+            expect(sql, operator).toEqual(negated ?
+                '("name" ~* $1 or "name" is null)' :
+                '"name" ~* $1');
             expect(params, operator).toStrictEqual([pattern]);
         }
     });

--- a/packages/typeorm/test/unit/complement.spec.ts
+++ b/packages/typeorm/test/unit/complement.spec.ts
@@ -65,6 +65,10 @@ describe('cross-adapter complement law (memory vs typeorm)', () => {
         records = await repository.find();
     });
 
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
     const fetchIds = async (condition: Filter) : Promise<number[]> => {
         const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
 

--- a/packages/typeorm/test/unit/complement.spec.ts
+++ b/packages/typeorm/test/unit/complement.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Filter } from '@rapiq/core';
+import {
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    contains,
+    endsWith,
+    eq,
+    exists,
+    inArray,
+    ne,
+    nin,
+    notContains,
+    notEndsWith,
+    notStartsWith,
+    startsWith,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/memory';
+import type { DataSource } from 'typeorm';
+import { TypeormAdapter } from '../../src';
+import { User } from '../data/entity/user';
+import { createDataSource } from '../data/factory';
+
+describe('cross-adapter complement law (memory vs typeorm)', () => {
+    let dataSource : DataSource;
+
+    let records : User[];
+
+    beforeAll(async () => {
+        dataSource = createDataSource();
+        await dataSource.initialize();
+        await dataSource.synchronize();
+
+        const repository = dataSource.getRepository(User);
+        await repository.save([
+            {
+                first_name: 'Caleb',
+                last_name: 'Barrows',
+                age: 18,
+                address: 'Hogwarts',
+                email: 'caleb.barrows@gmail.com',
+            },
+            {
+                first_name: 'Aston',
+                last_name: 'Nel',
+                age: 60,
+                email: 'ashton.nel@gmail.com',
+            },
+            {
+                first_name: 'Frodo',
+                last_name: 'Baggins',
+                age: 33,
+                address: 'Mordor',
+                email: 'frodo.baggins@gmail.com',
+            },
+        ]);
+
+        records = await repository.find();
+    });
+
+    const fetchIds = async (condition: Filter) : Promise<number[]> => {
+        const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
+
+        const adapter = new TypeormAdapter({ queryBuilder });
+        adapter.execute(new Query({ filters: new Filters(FilterCompoundOperator.AND, [condition]) }));
+
+        const data = await queryBuilder.getMany();
+        return data.map((user) => user.id).sort((a, b) => a - b);
+    };
+
+    const evaluateIds = (condition: Filter) : number[] => {
+        const predicate = compileFilters(condition);
+
+        return records
+            .filter((record) => predicate(record))
+            .map((user) => user.id)
+            .sort((a, b) => a - b);
+    };
+
+    // the complement-law matrix pinned by @rapiq/memory, replayed against
+    // the live database: address is 'Hogwarts', NULL and 'Mordor'.
+    const pairs : [string, Filter, Filter][] = [
+        ['eq/ne', eq('address', 'Hogwarts'), ne('address', 'Hogwarts')],
+        ['eq/ne (null)', eq('address', null), ne('address', null)],
+        ['in/nin', inArray('address', ['Hogwarts', 'Mordor']), nin('address', ['Hogwarts', 'Mordor'])],
+        ['in/nin (null element)', inArray('address', ['Hogwarts', null]), nin('address', ['Hogwarts', null])],
+        ['in/nin (empty)', inArray('address', []), nin('address', [])],
+        ['contains/notContains', contains('address', 'wart'), notContains('address', 'wart')],
+        ['startsWith/notStartsWith', startsWith('address', 'Hog'), notStartsWith('address', 'Hog')],
+        ['endsWith/notEndsWith', endsWith('address', 'arts'), notEndsWith('address', 'arts')],
+        ['exists true/false', exists('address'), exists('address', false)],
+    ];
+
+    pairs.forEach(([name, positive, negative]) => {
+        it(`should agree for ${name}`, async () => {
+            const positiveIds = await fetchIds(positive);
+            const negativeIds = await fetchIds(negative);
+
+            expect(positiveIds).toEqual(evaluateIds(positive));
+            expect(negativeIds).toEqual(evaluateIds(negative));
+
+            // the negation selects exactly the remaining records.
+            const allIds = records.map((user) => user.id).sort((a, b) => a - b);
+            expect([...positiveIds, ...negativeIds].sort((a, b) => a - b)).toEqual(allIds);
+        });
+    });
+});

--- a/packages/typeorm/test/unit/filters.spec.ts
+++ b/packages/typeorm/test/unit/filters.spec.ts
@@ -222,6 +222,64 @@ describe('src/filters', () => {
         expect(user.first_name).toEqual('Caleb');
     });
 
+    // complement law: negated operators match rows where the filtered
+    // column is NULL (Aston has no address, Caleb lives at 'Hogwarts').
+    it('should match a NULL row with not eq', async () => {
+        const condition = new Filter(
+            FilterFieldOperator.NOT_EQUAL,
+            'address',
+            'Hogwarts',
+        );
+
+        const queryBuilder = createQueryBuilder(condition);
+        const data = await queryBuilder.getMany();
+
+        expect(data.length).toEqual(1);
+
+        const [user] = data;
+        expect(user.first_name).toEqual('Aston');
+    });
+
+    it('should match a NULL row with nin', async () => {
+        const condition = new Filter(
+            FilterFieldOperator.NOT_IN,
+            'address',
+            ['Hogwarts', 'Mordor'],
+        );
+
+        const queryBuilder = createQueryBuilder(condition);
+        const data = await queryBuilder.getMany();
+
+        expect(data.length).toEqual(1);
+
+        const [user] = data;
+        expect(user.first_name).toEqual('Aston');
+    });
+
+    it('should match a NULL row with notContains, but not with contains', async () => {
+        const negated = new Filter(
+            FilterFieldOperator.NOT_CONTAINS,
+            'address',
+            'wart',
+        );
+
+        const negatedData = await createQueryBuilder(negated).getMany();
+
+        expect(negatedData.length).toEqual(1);
+        expect(negatedData[0].first_name).toEqual('Aston');
+
+        const positive = new Filter(
+            FilterFieldOperator.CONTAINS,
+            'address',
+            'wart',
+        );
+
+        const positiveData = await createQueryBuilder(positive).getMany();
+
+        expect(positiveData.length).toEqual(1);
+        expect(positiveData[0].first_name).toEqual('Caleb');
+    });
+
     it('work with compound and (eq + in)', async () => {
         const condition = new Filters(
             FilterCompoundOperator.AND,


### PR DESCRIPTION
## Summary

Negated filter operators evaluated through `@rapiq/sql` / `@rapiq/typeorm` silently excluded records whose column is `NULL`: `ne('name', 'Peter')` rendered a bare `name <> ?`, which drops `NULL` rows under SQL three-valued logic. Every negated operator is now the exact logical complement of its positive twin — matching the semantics `@rapiq/memory` already pins with its complement-law spec.

A shared `whereComplement()` helper in the filters visitor wraps every negated rendering:

| Filter | SQL (before) | SQL (after) |
|---|---|---|
| `ne(field, a)` | `"field" <> $1` | `("field" <> $1 or "field" is null)` |
| `nin(field, [a, b])` | `"field" not in($1, $2)` | `("field" not in($1, $2) or "field" is null)` |
| `notContains` family (regexp dialects) | `"field" ~* $1` | `("field" ~* $1 or "field" is null)` |
| `notContains` family (LIKE fallback) | `[field] not like ? escape '\'` | `([field] not like ? escape '\' or [field] is null)` |

The already-complement-correct renderings are unchanged: `ne(null)` → `is not null`, `nin` with a null element → `(not in(...) and is not null)`, only-null / empty-list `nin`, and `exists(false)`.

The TypeORM adapter contains no rendering logic of its own, so it inherits the fix 1:1 through the shared visitor.

## Tests

- Updated the SQL interpreter specs that pinned the old renderings (`ne`, `nin`, negated anchored operators on both the regexp path and the LIKE fallback); the existing null-semantics spec stayed green throughout.
- New TypeORM live-DB specs seed a record with a `NULL` value in the filtered column and assert `ne`, `nin` and `notContains` return it while the positive twins do not.
- New cross-adapter agreement spec (`packages/typeorm/test/unit/complement.spec.ts`): the complement-law matrix (9 positive/negative pairs, including null-element / empty-list `in`/`nin` shapes) evaluated via `@rapiq/memory` and via the TypeORM adapter on a live better-sqlite3 database yields identical record sets, and each pair partitions the table. `@rapiq/memory` resolves through the workspace symlink — no dependency declaration needed for the test-only import.

## Docs

- `@rapiq/sql` page: null-semantics section documents the null-inclusive negations; string-matching section notes the LIKE-fallback form.
- `@rapiq/memory` page: removed the "alignment planned" divergence row.
- Filters guide: states the complement law under null semantics.

Closes #752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL generation for negated filters (`ne`, `nin`, and negated string matching) so they are null-inclusive and correctly match records with missing or `NULL` field values.
  * Ensured consistent “complement” behavior across SQL adapters, aligning SQL results with in-memory filtering.

* **Documentation**
  * Updated null semantics documentation and added examples showing how negated operators behave with `NULL`/absent fields.

* **Tests**
  * Added and expanded unit coverage to verify complement behavior for null scenarios across adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->