### PR TITLE
feat(core): typed SchemaError for schema registry failures

### DIFF
--- a/packages/core/src/errors/code.ts
+++ b/packages/core/src/errors/code.ts
@@ -29,4 +29,8 @@ export enum ErrorCode {
     FILTERS_NOT_FLAT = 'filtersNotFlat',
 
     CODEC_UNRESOLVABLE = 'codecUnresolvable',
+
+    SCHEMA_NAME_INVALID = 'schemaNameInvalid',
+
+    SCHEMA_UNRESOLVABLE = 'schemaUnresolvable',
 }

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -12,3 +12,4 @@ export * from './code';
 export * from './codec';
 export * from './merge';
 export * from './parse';
+export * from './schema';

--- a/packages/core/src/errors/schema.ts
+++ b/packages/core/src/errors/schema.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isObject } from '../utils';
+import { BaseError } from './base';
+import { ErrorCode } from './code';
+import type { BaseErrorOptions } from './types';
+
+export class SchemaError extends BaseError {
+    constructor(message?: string | BaseErrorOptions) {
+        if (isObject(message)) {
+            message.message = message.message || 'A schema error has occurred.';
+        }
+
+        super(message || 'A schema error has occurred.');
+    }
+
+    static nameUndefined() {
+        return new this({
+            message: 'The schema name is not defined.',
+            code: ErrorCode.SCHEMA_NAME_INVALID,
+        });
+    }
+
+    static notResolvable(name: string) {
+        return new this({
+            message: `The schema "${name}" could not be resolved.`,
+            code: ErrorCode.SCHEMA_UNRESOLVABLE,
+        });
+    }
+}

--- a/packages/core/src/schema/registry/module.ts
+++ b/packages/core/src/schema/registry/module.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { SchemaError } from '../../errors';
 import { Schema } from '../module';
 import type { ObjectLiteral } from '../../types';
 
@@ -21,7 +22,7 @@ export class SchemaRegistry {
 
     add<T extends ObjectLiteral>(schema: Schema<T>) {
         if (typeof schema.name === 'undefined') {
-            throw new Error('The schema name is not defined.');
+            throw SchemaError.nameUndefined();
         }
 
         this.entities.set(schema.name, schema);
@@ -48,7 +49,7 @@ export class SchemaRegistry {
     >(name: string | Schema<T>): Schema<T> {
         const schema = this.get(name);
         if (typeof schema === 'undefined') {
-            throw new Error(`Cannot find schema with name "${name}".`);
+            throw SchemaError.notResolvable(name as string);
         }
 
         return schema;

--- a/packages/core/test/unit/schema/registry.spec.ts
+++ b/packages/core/test/unit/schema/registry.spec.ts
@@ -5,7 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { SchemaRegistry, defineSchema } from '../../../src';
+import { 
+    ErrorCode, 
+    SchemaError, 
+    SchemaRegistry, 
+    defineSchema, 
+} from '../../../src';
 import { registry } from '../../data/schema';
 
 describe('src/schema/registry/*.ts', () => {
@@ -21,7 +26,14 @@ describe('src/schema/registry/*.ts', () => {
 
         it('should throw when adding a schema without a name', () => {
             const local = new SchemaRegistry();
-            expect(() => local.add(defineSchema({}))).toThrow();
+            expect(() => local.add(defineSchema({}))).toThrow(SchemaError);
+
+            try {
+                local.add(defineSchema({}));
+            } catch (e) {
+                expect(e).toBeInstanceOf(SchemaError);
+                expect((e as SchemaError).code).toBe(ErrorCode.SCHEMA_NAME_INVALID);
+            }
         });
 
         it('should return undefined for an unknown name', () => {
@@ -31,7 +43,14 @@ describe('src/schema/registry/*.ts', () => {
 
         it('should throw in getOrFail for an unknown name', () => {
             const local = new SchemaRegistry();
-            expect(() => local.getOrFail('missing')).toThrow();
+            expect(() => local.getOrFail('missing')).toThrow(SchemaError);
+
+            try {
+                local.getOrFail('missing');
+            } catch (e) {
+                expect(e).toBeInstanceOf(SchemaError);
+                expect((e as SchemaError).code).toBe(ErrorCode.SCHEMA_UNRESOLVABLE);
+            }
         });
 
         it('should return a passed Schema instance unchanged', () => {

--- a/packages/docs/guide/errors.md
+++ b/packages/docs/guide/errors.md
@@ -15,7 +15,8 @@ BaseError { code: ErrorCode }
 │   ├── RelationsParseError
 │   └── SortParseError
 ├── AdapterError          backends & encoders — query exceeds the target's subset
-└── CodecError            codec registry — unresolvable dialect
+├── CodecError            codec registry — unresolvable dialect
+└── SchemaError           schema registry — misconfigured or unresolvable schema
 ```
 
 ## Where errors come from
@@ -66,6 +67,15 @@ The URL encoders throw these too — a codec never silently changes what a query
 
 `CodecError` with `CODEC_UNRESOLVABLE` — a payload named a codec that isn't registered. See [@rapiq/codec-url](/packages/codec-url).
 
+### Schema registry (server bug)
+
+`SchemaError` — the `SchemaRegistry` was misused or misconfigured. Like `BuildError`, these indicate a programming error on the receiving side:
+
+| Code | Trigger |
+|---|---|
+| `SCHEMA_NAME_INVALID` | `registry.add()` with a schema that has no `name` |
+| `SCHEMA_UNRESOLVABLE` | `registry.getOrFail()` for a name that isn't registered |
+
 ## Mapping to HTTP responses
 
 A pragmatic mapping for a typical endpoint:
@@ -93,7 +103,7 @@ app.get('/users', async (req, res) => {
 ```
 
 - `ParseError` (with `throwOnFailure`) → **400** — the client broke the contract; `e.message` names the offending key.
-- `BuildError` / `MergeError` / `AdapterError` on the server → **500** — these mean *your* code produced or forwarded something invalid.
+- `BuildError` / `MergeError` / `AdapterError` / `SchemaError` on the server → **500** — these mean *your* code produced or forwarded something invalid.
 - `AdapterError` on the caller (encode) → fix the query or switch wire dialect; it never leaves the caller.
 
 ## Adding failure modes of your own


### PR DESCRIPTION
## What

Migrates the last two raw `Error` throws in the monorepo — `SchemaRegistry.add()` and `SchemaRegistry.getOrFail()` — to a typed `SchemaError`, following the established `CodecError`/`MergeError` pattern.

- New `SchemaError` (`packages/core/src/errors/schema.ts`) with static factories `nameUndefined()` and `notResolvable(name)`
- New `ErrorCode` members: `SCHEMA_NAME_INVALID`, `SCHEMA_UNRESOLVABLE`
- Registry spec strengthened: bare `toThrow()` assertions now pin the error class and code
- Docs (`guide/errors.md`): `SchemaError` added to the hierarchy, new schema-registry section with the code table, HTTP mapping updated — the page's "no raw `Error`s" claim now holds (`grep 'throw new Error' packages/*/src` returns nothing)

## Why

The error-handling convention requires every failure mode to carry an `ErrorCode` via a `BaseError` subtype instead of minting raw `Error`s. These two registry throws were the last leftover (plan 008 item 5 follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added specific error types and codes for invalid or unresolved schemas.
  * Schema-related errors are now publicly available through the error exports.

* **Bug Fixes**
  * Schema registry failures now provide clearer, actionable error details.

* **Documentation**
  * Documented schema errors and their mapping to HTTP 500 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->