### PR TITLE
feat: add $size array-length filter operator

### DIFF
--- a/packages/codec-url/src/expression/encoder/filters.ts
+++ b/packages/codec-url/src/expression/encoder/filters.ts
@@ -132,6 +132,19 @@ function serializeCondition(node: ICondition, insideElemMatch: boolean) : string
 
             return `elemMatch(${field},${serializeCondition(interior, true)})`;
         }
+        case FilterFieldOperator.SIZE: {
+            // the decoder rejects anything but a non-negative integer —
+            // fail loudly here instead of emitting an undecodable token.
+            if (
+                typeof node.value !== 'number' ||
+                !Number.isInteger(node.value) ||
+                node.value < 0
+            ) {
+                throw AdapterError.featureUnsupported('filters:size:value');
+            }
+
+            return `size(${field},${serializeValue(node.value)})`;
+        }
         default: {
             // REGEX, MOD, EXISTS, ... have no expression grammar
             // production.

--- a/packages/codec-url/test/unit/expression-roundtrip.spec.ts
+++ b/packages/codec-url/test/unit/expression-roundtrip.spec.ts
@@ -40,6 +40,7 @@ import {
     notStartsWith,
     or,
     regex,
+    size,
     startsWith,
 } from '@rapiq/core';
 import type { IFilter, IFilters, IQuery } from '@rapiq/core';
@@ -104,6 +105,9 @@ describe('round-trip', () => {
             ['elemMatch document form', elemMatch('items', eq('name', 'chess'))],
             ['elemMatch ITSELF leaf', elemMatch('scores', gt(ITSELF, 5))],
             ['nested elemMatch on the element itself', elemMatch('matrix', elemMatch(ITSELF, gt(ITSELF, 5)))],
+            ['size', size('tags', 2)],
+            ['size zero', size('tags', 0)],
+            ['element-level size on the element itself', elemMatch('matrix', size(ITSELF, 2))],
         ])('should round-trip %s', (_, filter) => {
             expect(roundTripFilter(filter)).toEqual(
                 new Filters(FilterCompoundOperator.AND, [filter]),
@@ -192,8 +196,11 @@ describe('round-trip', () => {
             ['whitespace-padded eq value (would decode trimmed)', eq('name', ' John ')],
             ['value-mutating numeric text (0xFF would decode to 255)', eq('code', '0xFF')],
             ['NaN value (would decode to the string NaN)', eq('age', Number.NaN)],
+            ['non-integer size value', size('tags', 2.5)],
+            ['negative size value', size('tags', -1)],
             ['keyword field segment', eq('null', 'x')],
             ['elemMatch keyword field segment', eq('elemMatch', 'x')],
+            ['size keyword field segment', eq('size', 'x')],
             ['non-tokenizable field segment', eq('a b', 'x')],
             ['empty nested compound', and(eq('name', 'x'), or())],
         ])('should throw for %s', (_, filter) => {
@@ -269,6 +276,16 @@ describe('round-trip', () => {
 
             expect(decodeURIComponent(encoded!)).toEqual(
                 'filter=elemMatch(scores,gt($this,\'5\'))',
+            );
+        });
+
+        it('should emit the documented size wire format', () => {
+            const query = defineQuery({ filters: size('tags', 2) });
+
+            const encoded = encoder.encode(query);
+
+            expect(decodeURIComponent(encoded!)).toEqual(
+                'filter=size(tags,\'2\')',
             );
         });
     });

--- a/packages/codec-url/test/unit/simple-roundtrip.spec.ts
+++ b/packages/codec-url/test/unit/simple-roundtrip.spec.ts
@@ -39,6 +39,7 @@ import {
     notStartsWith,
     or,
     regex,
+    size,
     startsWith,
 } from '@rapiq/core';
 import type { IFilter, IQuery } from '@rapiq/core';
@@ -153,6 +154,7 @@ describe('round-trip', () => {
         it.each([
             ['regex', regex('name', /^Jo/)],
             ['mod', mod('age', [2, 0])],
+            ['size', size('tags', 2)],
             ['exists', exists('email', true)],
             ['elemMatch', elemMatch('items', eq('name', 'a'))],
             ['elemMatch with ITSELF interior', elemMatch('scores', gt(ITSELF, 5))],

--- a/packages/core/src/build/parameter/filters/types.ts
+++ b/packages/core/src/build/parameter/filters/types.ts
@@ -43,6 +43,7 @@ export type FiltersBuildOperatorInput<V> = {
     $regex?: RegExp | string,
 
     $mod?: [number, number],
+    $size?: number,
     $exists?: boolean,
 };
 
@@ -56,11 +57,17 @@ export type FiltersBuildValueInput<V> = V | null |
     (V extends string ? RegExp : never) |
     FiltersBuildOperatorInput<V>;
 
+/**
+ * Array-level operators of an object-array field — element matching
+ * and the array-length check (scalar arrays reach both through the
+ * plain operator object).
+ */
 export type FiltersBuildElemMatchInput<
     T extends ObjectLiteral = ObjectLiteral,
     DEPTH extends number = 5,
 > = {
-    $elemMatch: FiltersBuildInput<T, DEPTH> | ICondition,
+    $elemMatch?: FiltersBuildInput<T, DEPTH> | ICondition,
+    $size?: number,
 };
 
 type FiltersBuildKeyValueInput<

--- a/packages/core/src/parameter/filters/helpers/module.ts
+++ b/packages/core/src/parameter/filters/helpers/module.ts
@@ -144,6 +144,17 @@ export function mod<RECORD extends ObjectLiteral = ObjectLiteral>(
     return new Filter(FilterFieldOperator.MOD, field, [divisor, remainder]);
 }
 
+/**
+ * Match arrays with exactly the given number of elements
+ * (a non-negative integer); missing or non-array values never match.
+ */
+export function size<RECORD extends ObjectLiteral = ObjectLiteral>(
+    field: FieldKey<RECORD>,
+    value: number,
+) : Filter {
+    return new Filter(FilterFieldOperator.SIZE, field, value);
+}
+
 export function exists<RECORD extends ObjectLiteral = ObjectLiteral>(
     field: FieldKey<RECORD>,
     value: boolean = true,

--- a/packages/core/src/parameter/filters/record/module.ts
+++ b/packages/core/src/parameter/filters/record/module.ts
@@ -65,6 +65,10 @@ export class Filter<
             return this.acceptWithFallback(visitor, 'visitFilterMod');
         }
 
+        if (this.operator === FilterFieldOperator.SIZE) {
+            return this.acceptWithFallback(visitor, 'visitFilterSize');
+        }
+
         if (this.operator === FilterFieldOperator.ELEM_MATCH) {
             return this.acceptWithFallback(visitor, 'visitFilterElemMatch');
         }
@@ -104,8 +108,9 @@ export class Filter<
         visitor: IFilterVisitor<R>,
         property: P,
     ) : R {
-        if (visitor[property]) {
-            return visitor[property](this as Filter<any, any>);
+        const method = visitor[property] as ((expr: IFilter) => R) | undefined;
+        if (method) {
+            return method.call(visitor, this);
         }
 
         return visitor.visitFilter(this);

--- a/packages/core/src/parameter/filters/record/types.ts
+++ b/packages/core/src/parameter/filters/record/types.ts
@@ -29,6 +29,8 @@ export interface IFilterVisitor<R> {
 
     visitFilterMod?(expr: IFilter<FilterFieldOperator.MOD, [number, number]>) : R;
 
+    visitFilterSize?(expr: IFilter<FilterFieldOperator.SIZE, number>) : R;
+
     visitFilterElemMatch?(expr: IFilter<FilterFieldOperator.ELEM_MATCH, IFilter | IFilters>) : R;
 
     visitFilterContains?(expr: IFilter<FilterFieldOperator.CONTAINS, unknown>) : R;

--- a/packages/core/src/schema/parameter/filters/constants.ts
+++ b/packages/core/src/schema/parameter/filters/constants.ts
@@ -30,6 +30,7 @@ export enum FilterFieldOperator {
     REGEX = 'regex',
 
     MOD = 'mod',
+    SIZE = 'size',
     EXISTS = 'exists',
     ELEM_MATCH = 'elemMatch',
 }

--- a/packages/core/test/unit/build/module.spec.ts
+++ b/packages/core/test/unit/build/module.spec.ts
@@ -89,6 +89,17 @@ describe('src/build/parameter/filters/*.ts', () => {
         });
     });
 
+    it('should desugar a $size operator object to a size condition', () => {
+        const output = defineFilters<User>({ items: { $size: 2 } });
+
+        expect(leafs(output)).toHaveLength(1);
+        expect(leafs(output)[0]).toMatchObject({
+            operator: FilterFieldOperator.SIZE,
+            field: 'items',
+            value: 2,
+        });
+    });
+
     it('should desugar a bare RegExp to a regex condition', () => {
         const pattern = /^Jo/;
         const output = defineFilters<User>({ name: pattern });

--- a/packages/core/test/unit/parameter/filters-helpers.spec.ts
+++ b/packages/core/test/unit/parameter/filters-helpers.spec.ts
@@ -29,6 +29,7 @@ import {
     notStartsWith,
     or,
     regex,
+    size,
     startsWith,
 } from '../../../src';
 import type { User } from '../../data';
@@ -79,6 +80,14 @@ describe('src/parameter/filters/helpers/*.ts', () => {
 
         expect(output.operator).toBe(FilterFieldOperator.MOD);
         expect(output.value).toEqual([4, 0]);
+    });
+
+    it('should build a size condition', () => {
+        const output = size('items', 2);
+
+        expect(output.operator).toBe(FilterFieldOperator.SIZE);
+        expect(output.field).toBe('items');
+        expect(output.value).toBe(2);
     });
 
     it('should build an exists condition (default true)', () => {

--- a/packages/core/test/unit/parameter/filters.spec.ts
+++ b/packages/core/test/unit/parameter/filters.spec.ts
@@ -62,6 +62,10 @@ class NamingFilterVisitor implements IFilterVisitor<string> {
         return 'visitFilterMod';
     }
 
+    visitFilterSize(_: IFilter) {
+        return 'visitFilterSize';
+    }
+
     visitFilterElemMatch(_: IFilter) {
         return 'visitFilterElemMatch';
     }
@@ -106,6 +110,7 @@ const OPERATOR_METHOD: [string, string][] = [
     [FilterFieldOperator.IN, 'visitFilterIn'],
     [FilterFieldOperator.NOT_IN, 'visitFilterNotIn'],
     [FilterFieldOperator.MOD, 'visitFilterMod'],
+    [FilterFieldOperator.SIZE, 'visitFilterSize'],
     [FilterFieldOperator.ELEM_MATCH, 'visitFilterElemMatch'],
     [FilterFieldOperator.CONTAINS, 'visitFilterContains'],
     [FilterFieldOperator.NOT_CONTAINS, 'visitFilterNotContains'],

--- a/packages/docs/guide/building-queries.md
+++ b/packages/docs/guide/building-queries.md
@@ -37,7 +37,7 @@ Multiple keys combine with **and** (a flat root-AND). Nested records (`{ realm: 
 
 One key per [filter operator](/guide/filters#operators), prefixed with `$`:
 
-`$eq` `$ne` `$lt` `$lte` `$gt` `$gte` `$in` `$nin` `$startsWith` `$notStartsWith` `$endsWith` `$notEndsWith` `$contains` `$notContains` `$regex` `$mod` `$exists` `$elemMatch`
+`$eq` `$ne` `$lt` `$lte` `$gt` `$gte` `$in` `$nin` `$startsWith` `$notStartsWith` `$endsWith` `$notEndsWith` `$contains` `$notContains` `$regex` `$mod` `$size` `$exists` `$elemMatch`
 
 Most take the field's value type (`$eq`/`$ne` also accept `null`, `$in`/`$nin` take arrays, the string operators take strings). The remaining value shapes:
 
@@ -46,6 +46,7 @@ defineQuery<User>({
     filters: {
         name: { $regex: /^jo/i },              // RegExp or pattern string
         age: { $mod: [4, 0] },                 // [divisor, remainder]
+        tags: { $size: 2 },                    // array length
         email: { $exists: true },              // boolean
         items: {                               // match array elements;
             $elemMatch: { name: 'chess' },     // field paths are relative
@@ -78,12 +79,13 @@ const query = defineQuery<User>({
 });
 ```
 
-`eq` `ne` `lt` `lte` `gt` `gte` `inArray` `nin` `startsWith` `notStartsWith` `endsWith` `notEndsWith` `contains` `notContains` `regex` `mod` `exists` `elemMatch` — plus `and` / `or` compounds.
+`eq` `ne` `lt` `lte` `gt` `gte` `inArray` `nin` `startsWith` `notStartsWith` `endsWith` `notEndsWith` `contains` `notContains` `regex` `mod` `size` `exists` `elemMatch` — plus `and` / `or` compounds.
 
-Three helpers deviate from the uniform `(field, value)` signature:
+A few helpers deviate from the uniform `(field, value)` signature:
 
 ```typescript
 mod('age', 4, 0);                    // (field, divisor, remainder)
+size('tags', 2);                     // (field, length) — array length
 exists('email');                     // (field, value = true)
 elemMatch('items', eq('name', 'x')); // (field, condition) — condition
                                      // field paths are element-relative

--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -30,10 +30,13 @@ Every dialect maps onto the same operator set (`FilterFieldOperator`):
 | `NOT_CONTAINS` | not substring | `$notContains` | `notContains` | `!~jo~` |
 | `REGEX` | pattern | `$regex` | `regex` | — |
 | `MOD` | divisible remainder | `$mod` | `mod` | — |
+| `SIZE` | array length | `$size` | `size` | — |
 | `EXISTS` | is not null | `$exists` | `exists` | — |
 | `ELEM_MATCH` | array element match | `$elemMatch` | `elemMatch` | — |
 
-`REGEX`, `MOD` and `EXISTS` have no representation in the URL dialects — they work in code, via the [MongoDB-style parser](/packages/parser-mongo), and in every [adapter](/guide/executing-queries). `ELEM_MATCH` travels in the [expression dialect](/packages/parser-expression) only.
+`REGEX`, `MOD` and `EXISTS` have no representation in the URL dialects — they work in code, via the [MongoDB-style parser](/packages/parser-mongo), and in every [adapter](/guide/executing-queries). `ELEM_MATCH` and `SIZE` travel in the [expression dialect](/packages/parser-expression) only.
+
+`SIZE` matches arrays with exactly the given number of elements (a non-negative integer); missing or non-array values never match, and there is no negated form. It evaluates in [`@rapiq/memory`](/packages/memory) — the SQL adapters throw a typed `featureUnsupported` until dialect-level JSON-array support lands.
 
 Inside an `elemMatch` interior, the reserved `ITSELF` marker (wire spelling `$this`) may take the field position of a condition to address the array element itself: `elemMatch('scores', gt(ITSELF, 5))` matches when some score is greater than five. `@rapiq/memory` evaluates it element-wise; the SQL adapters throw a typed `featureUnsupported` (a joined relation row is not a scalar column). Anywhere outside an `elemMatch` interior the marker is a typed error.
 

--- a/packages/docs/packages/core.md
+++ b/packages/docs/packages/core.md
@@ -12,7 +12,7 @@ npm install @rapiq/core
 |---|---|---|
 | **Query AST** | `Query`, `Fields`/`Field`, `Filters`/`Filter`, `Relations`/`Relation`, `Sorts`/`Sort`, `Pagination`, operator constants (`FilterFieldOperator`, `FilterCompoundOperator`, `FieldOperator`, `SortDirection`, `Parameter`), visitor interfaces (`IQueryVisitor`, `IFiltersVisitor`, …) | [The Query AST](/guide/query-ast) |
 | **Build layer** | `defineQuery`, `defineFields`, `defineFilters`, `definePagination`, `defineRelations`, `defineSorts` | [Building Queries](/guide/building-queries) |
-| **Condition helpers** | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `inArray`, `nin`, `startsWith`, `notStartsWith`, `endsWith`, `notEndsWith`, `contains`, `notContains`, `regex`, `mod`, `exists`, `elemMatch`, `and`, `or` | [Condition helpers](/guide/building-queries#condition-helpers) |
+| **Condition helpers** | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `inArray`, `nin`, `startsWith`, `notStartsWith`, `endsWith`, `notEndsWith`, `contains`, `notContains`, `regex`, `mod`, `size`, `exists`, `elemMatch`, `and`, `or` | [Condition helpers](/guide/building-queries#condition-helpers) |
 | **Composition** | `mergeQueries`, `Filters.merge` / `.and` / `.or` | [Merging & Composition](/guide/merging-queries) |
 | **Schema system** | `defineSchema`, `Schema`, `SchemaRegistry`, per-parameter `define*Schema` factories, `ResolutionScope` | [Schemas & Validation](/guide/schemas) |
 | **Parser base** | `BaseParser`, per-parameter parse-option types | [Custom parsers](/guide/query-ast#writing-a-custom-parser-resolutionscope) |

--- a/packages/docs/packages/memory.md
+++ b/packages/docs/packages/memory.md
@@ -64,7 +64,7 @@ The package aims for **SQL parity**: the same query should select the same recor
 
 `undefined`, missing properties and `null` are one absent value (SQL has a single `NULL`).
 
-- Positive operators (`eq`, `lt`, `lte`, `gt`, `gte`, `in`, `mod`, `contains`, `startsWith`, `endsWith`, `regex`) never match absent values — except `eq(field, null)`, `in` with a `null` element, and `exists(field, false)`.
+- Positive operators (`eq`, `lt`, `lte`, `gt`, `gte`, `in`, `mod`, `size`, `contains`, `startsWith`, `endsWith`, `regex`) never match absent values — except `eq(field, null)`, `in` with a `null` element, and `exists(field, false)`.
 - **Negated operators are exact complements**: `ne`, `nin`, `notContains`, `notStartsWith` and `notEndsWith` *do* match absent values. `ne('name', 'Peter')` matches a record without a name.
 - `exists` means *has a non-null value* (SQL `IS NOT NULL`), not Mongo's "property present".
 - Type mismatches evaluate to `false` — never to an error.

--- a/packages/docs/packages/parser-expression.md
+++ b/packages/docs/packages/parser-expression.md
@@ -29,8 +29,9 @@ elemMatch(scores, gt($this, '5'))
 | `startsWith(field, value)` | prefix | `STARTS_WITH` |
 | `endsWith(field, value)` | suffix | `ENDS_WITH` |
 | `elemMatch(field, expr)` | array element match | `ELEM_MATCH` |
+| `size(field, n)` | array length (non-negative integer) | `SIZE` |
 | `and(expr, …)` / `or(expr, …)` | compound | `Filters` node |
-| `not(expr, …)` | negation | flips operators (`eq` → `NOT_EQUAL`, `contains` → `NOT_CONTAINS`, …), `and` ↔ `or`; `elemMatch` has no complement and throws |
+| `not(expr, …)` | negation | flips operators (`eq` → `NOT_EQUAL`, `contains` → `NOT_CONTAINS`, …), `and` ↔ `or`; `elemMatch` and `size` have no complement and throw |
 
 Rules:
 

--- a/packages/docs/packages/parser-mongo.md
+++ b/packages/docs/packages/parser-mongo.md
@@ -20,6 +20,7 @@ Filters are plain objects with typed values — numbers stay numbers, there is n
 { items: { $elemMatch: { id: { $gt: 5 } } } }       // array-element match
 { scores: { $elemMatch: { $gt: 5 } } }              // element-level match (the element itself)
 { tags: { $all: ['a', 'b'] } }                      // every listed value has a matching element
+{ tags: { $size: 2 } }                              // array-length match
 ```
 
 Multiple document entries combine with an implicit AND. `$and` / `$or` / `$nor` take a non-empty array of sub-documents; `$nor` and `$not` desugar via De Morgan operator negation (`$eq` ↔ `$ne`, `$lt` ↔ `$gte`, AND ↔ OR, …).
@@ -40,6 +41,7 @@ Multiple document entries combine with an implicit AND. `$and` / `$or` / `$nor` 
 | `$regex` | `REGEX` | — (throws) | `RegExp` instance or pattern string |
 | `$options` | — (modifier) | — | flag string; only beside a string-valued `$regex` |
 | `$mod` | `MOD` | — (throws) | `[divisor, remainder]`, divisor ≠ 0 |
+| `$size` | `SIZE` | — (throws) | non-negative integer (array length) |
 | `$exists` | `EXISTS` | boolean flag flipped | boolean |
 | `$elemMatch` | `ELEM_MATCH` | — (throws) | nested filter document (fields relative to the array element) or element-level operator object (operators apply to the element itself, via the `ITSELF` marker) |
 | `$all` | AND of `ELEM_MATCH` | — (throws) | non-empty array of scalar/`null`/`Date`; desugars to one independently scoped element match per value |
@@ -52,7 +54,7 @@ Multiple document entries combine with an implicit AND. `$and` / `$or` / `$nor` 
 - A bare array value means `$in` instead of MongoDB's exact-array match.
 - Negation is algebraic (De Morgan operator flipping) — it does not replicate MongoDB's missing-field semantics, where `$not` also matches documents lacking the field.
 - `$all` never falls back to plain equality on non-array fields — MongoDB's `{ tags: { $all: ['a'] } }` matches `tags: 'a'`, the rapiq desugar does not (element matches require a real array).
-- `$where`, `$size`, `$type` and the other evaluation/geo/bitwise operators are unsupported and throw.
+- `$where`, `$type` and the other evaluation/geo/bitwise operators are unsupported and throw.
 - MongoDB's `x` regex flag has no JavaScript equivalent — `$options: 'x'` is rejected.
 - An empty sub-document `{}` inside a compound (MongoDB's match-all branch) is a grammar error.
 :::
@@ -99,4 +101,4 @@ Failures fall into two classes:
 
 Absent input, `{}` and an all-dropped document are not failures — the schema's `filters.default` applies, like with the other parsers.
 
-Error codes: malformed documents carry `ErrorCode.SYNTAX_INVALID`, invalid operator values `KEY_VALUE_INVALID`, non-object top-level input `INPUT_INVALID`, known-but-unsupported MongoDB operators (`$where`, `$size`, …) and non-negatable operators under `$not`/`$nor` (`$regex`, `$mod`, `$elemMatch`, `$all`) `OPERATOR_UNSUPPORTED`. See [Error Handling](/guide/errors).
+Error codes: malformed documents carry `ErrorCode.SYNTAX_INVALID`, invalid operator values `KEY_VALUE_INVALID`, non-object top-level input `INPUT_INVALID`, known-but-unsupported MongoDB operators (`$where`, `$type`, …) and non-negatable operators under `$not`/`$nor` (`$regex`, `$mod`, `$size`, `$elemMatch`, `$all`) `OPERATOR_UNSUPPORTED`. See [Error Handling](/guide/errors).

--- a/packages/docs/packages/sql.md
+++ b/packages/docs/packages/sql.md
@@ -135,3 +135,7 @@ Folding only happens for string filter values. Backends with column metadata can
 ### ITSELF (element-level conditions)
 
 The [`ITSELF` marker](/guide/filters#operators) — an `elemMatch` interior condition on the array element itself, produced e.g. by the mongo parser's element-level `$elemMatch` and `$all` — has no SQL rendering: `elemMatch` maps to a relation join, and a joined row is not a scalar column. Both `@rapiq/sql` and `@rapiq/typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`). Dialect-level JSON-array support (`json_each` / `unnest`) may lift this later; evaluate such filters with [`@rapiq/memory`](/packages/memory) in the meantime.
+
+### size (array length)
+
+The [`size` operator](/guide/filters#operators) has no SQL rendering either — an array-length check needs per-dialect JSON-array support (`json_array_length` on Postgres/SQLite, `JSON_LENGTH` on MySQL, `cardinality` for Postgres arrays). Both `@rapiq/sql` and `@rapiq/typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`); evaluate such filters with [`@rapiq/memory`](/packages/memory) in the meantime.

--- a/packages/memory/src/parameter/filters/compiler.ts
+++ b/packages/memory/src/parameter/filters/compiler.ts
@@ -137,6 +137,23 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
         ));
     }
 
+    visitFilterSize(expr: IFilter<FilterFieldOperator.SIZE, number>) : FilterCompileResult {
+        if (
+            typeof expr.value !== 'number' ||
+            !Number.isInteger(expr.value) ||
+            expr.value < 0
+        ) {
+            return this.leaf(expr.field, () => false);
+        }
+
+        const length = expr.value;
+
+        // the condition addresses the array itself, not its elements —
+        // missing or non-array values never match (mongo parity).
+        return this.leaf(expr.field, (value) => Array.isArray(value) &&
+            value.length === length);
+    }
+
     visitFilterElemMatch(expr: IFilter<FilterFieldOperator.ELEM_MATCH, IFilter | IFilters>) : FilterCompileResult {
         if (!isFilter(expr.value) && !isFilters(expr.value)) {
             throw AdapterError.featureUnsupported('filters:elemMatch:value');

--- a/packages/memory/test/unit/filters/binding.spec.ts
+++ b/packages/memory/test/unit/filters/binding.spec.ts
@@ -17,6 +17,7 @@ import {
     exists,
     ne,
     or,
+    size,
 } from '@rapiq/core';
 import { compileFilters } from '../../../src';
 
@@ -255,6 +256,14 @@ describe('filters: join-row binding', () => {
             // not even a null test matches the empty-array NULL row.
             expect(compileFilters(elemMatch('scores', eq(ITSELF, null)))({ scores: [] })).toBeFalsy();
             expect(compileFilters(elemMatch('scores', eq(ITSELF, null)))({ scores: [null] })).toBeTruthy();
+        });
+
+        it('should evaluate an element-level size against the element itself', () => {
+            // { matrix: { $elemMatch: { $size: 2 } } }
+            const predicate = compileFilters(elemMatch('matrix', size(ITSELF, 2)));
+
+            expect(predicate({ matrix: [[1], [1, 2]] })).toBeTruthy();
+            expect(predicate({ matrix: [[1], [1, 2, 3]] })).toBeFalsy();
         });
 
         it('should evaluate nested element-level elemMatch on arrays of arrays', () => {

--- a/packages/memory/test/unit/filters/primitives.spec.ts
+++ b/packages/memory/test/unit/filters/primitives.spec.ts
@@ -15,6 +15,7 @@ import {
     lte,
     mod,
     ne,
+    size,
 } from '@rapiq/core';
 import { compileFilters } from '../../../src';
 
@@ -169,6 +170,32 @@ describe('filters: primitive operators', () => {
         it('should match some element of an array value', () => {
             expect(compileFilters(mod('scores', 2, 0))({ scores: [1, 4] })).toBeTruthy();
             expect(compileFilters(mod('scores', 2, 0))({ scores: [1, 3] })).toBeFalsy();
+        });
+    });
+
+    describe('size', () => {
+        it('should match arrays of exactly the given length', () => {
+            expect(compileFilters(size('tags', 2))({ tags: ['a', 'b'] })).toBeTruthy();
+            expect(compileFilters(size('tags', 2))({ tags: ['a'] })).toBeFalsy();
+            expect(compileFilters(size('tags', 0))({ tags: [] })).toBeTruthy();
+        });
+
+        it('should never match non-array or absent values', () => {
+            expect(compileFilters(size('tags', 2))({ tags: 'ab' })).toBeFalsy();
+            expect(compileFilters(size('tags', 0))({ tags: null })).toBeFalsy();
+            expect(compileFilters(size('tags', 0))({})).toBeFalsy();
+        });
+
+        it('should compare the array itself, never its elements', () => {
+            // element-wise application would match the inner array.
+            expect(compileFilters(size('matrix', 2))({ matrix: [[1, 2]] })).toBeFalsy();
+            expect(compileFilters(size('matrix', 1))({ matrix: [[1, 2]] })).toBeTruthy();
+        });
+
+        it('should totalize a malformed value to false', () => {
+            expect(compileFilters(new Filter('size', 'tags', -1))({ tags: [] })).toBeFalsy();
+            expect(compileFilters(new Filter('size', 'tags', 1.5))({ tags: ['a'] })).toBeFalsy();
+            expect(compileFilters(new Filter('size', 'tags', '1'))({ tags: ['a'] })).toBeFalsy();
         });
     });
 });

--- a/packages/parser-expression/src/parameter/filters/constants.ts
+++ b/packages/parser-expression/src/parameter/filters/constants.ts
@@ -22,6 +22,7 @@ export enum FilterTokenType {
     IN = 'in',
     NIN = 'nin',
     ELEM_MATCH = 'elemMatch',
+    SIZE = 'size',
 
     FIELD = 'FIELD',
     ITSELF = 'ITSELF',
@@ -55,6 +56,7 @@ export const FILTER_EXPRESSION_KEYWORDS = {
     in: FilterTokenType.IN,
     nin: FilterTokenType.NIN,
     elemMatch: FilterTokenType.ELEM_MATCH,
+    size: FilterTokenType.SIZE,
     null: FilterTokenType.NULL,
 } as const satisfies Record<string, FilterTokenType>;
 

--- a/packages/parser-expression/src/parameter/filters/module.ts
+++ b/packages/parser-expression/src/parameter/filters/module.ts
@@ -290,6 +290,8 @@ export class ExpressionFiltersParser extends BaseParser<
                 return this.parseInExpression(scope, negation);
             case FilterTokenType.ELEM_MATCH:
                 return this.parseElemMatchExpression(scope, negation, depth);
+            case FilterTokenType.SIZE:
+                return this.parseSizeExpression(scope, negation);
             default:
                 throw FiltersParseError.syntaxInvalid(`Unexpected token in filter expression: ${token.type}`);
         }
@@ -518,6 +520,38 @@ export class ExpressionFiltersParser extends BaseParser<
             field,
             values,
         );
+    }
+
+    /**
+     * size(field, n): the field holds an array of exactly n elements
+     * (a non-negative integer — the wire is untyped, so the quoted
+     * value coerces back to a number). There is no complement — a
+     * negated size would silently widen and always throws.
+     */
+    private parseSizeExpression(
+        scope?: FiltersScope,
+        negation: boolean = false,
+    ): Filter {
+        if (negation) {
+            throw FiltersParseError.operatorUnsupported('size');
+        }
+
+        this.consume(FilterTokenType.SIZE);
+        this.consume(FilterTokenType.LPAREN);
+        const field = this.parseExpressionFieldChain(scope);
+        this.consume(FilterTokenType.COMMA);
+        const value = this.parseExpressionValue();
+        this.consume(FilterTokenType.RPAREN);
+
+        if (
+            typeof value !== 'number' ||
+            !Number.isInteger(value) ||
+            value < 0
+        ) {
+            throw FiltersParseError.keyValueInvalid(field);
+        }
+
+        return new Filter(FilterFieldOperator.SIZE, field, value);
     }
 
     /**

--- a/packages/parser-expression/test/unit/parser/filters.spec.ts
+++ b/packages/parser-expression/test/unit/parser/filters.spec.ts
@@ -469,6 +469,44 @@ describe('filters/expr-parser', () => {
         });
     });
 
+    describe('size', () => {
+        it('should parse a size expression', () => {
+            const output = parser.parseExact('size(items,\'2\')');
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.SIZE, 'items', 2));
+        });
+
+        it('should coerce the quoted wire value back to a number', () => {
+            const output = parser.parseExact('size(items,\'0\')');
+
+            expect(output).toEqual(new Filter(FilterFieldOperator.SIZE, 'items', 0));
+        });
+
+        it('should parse an element-level size inside an elemMatch interior', () => {
+            // array of arrays: some inner array has exactly two elements.
+            const output = parser.parseExact('elemMatch(matrix,size($this,\'2\'))');
+
+            expect(output).toEqual(new Filter(
+                FilterFieldOperator.ELEM_MATCH,
+                'matrix',
+                new Filter(FilterFieldOperator.SIZE, ITSELF, 2),
+            ));
+        });
+
+        it('should throw on a negated size', () => {
+            const error = FiltersParseError.operatorUnsupported('size');
+
+            expect(() => parser.parseExact('not(size(items,\'2\'))')).toThrow(error);
+        });
+
+        it('should throw on a non integer, negative or non numeric value', () => {
+            expect(() => parser.parseExact('size(items,\'2.5\')')).toThrow(FiltersParseError);
+            expect(() => parser.parseExact('size(items,\'-1\')')).toThrow(FiltersParseError);
+            expect(() => parser.parseExact('size(items,\'abc\')')).toThrow(FiltersParseError);
+            expect(() => parser.parseExact('size(items,null)')).toThrow(FiltersParseError);
+        });
+    });
+
     describe('elemMatch', () => {
         it('should parse the nested document form', () => {
             const output = parser.parseExact('elemMatch(items,eq(name,\'chess\'))');

--- a/packages/parser-mongo/src/parameter/filters/constants.ts
+++ b/packages/parser-mongo/src/parameter/filters/constants.ts
@@ -51,6 +51,7 @@ export const MONGO_FIELD_OPERATORS : readonly string[] = [
     '$regex',
     '$options',
     '$mod',
+    '$size',
     '$exists',
     '$elemMatch',
     '$all',
@@ -62,7 +63,6 @@ export const MONGO_FIELD_OPERATORS : readonly string[] = [
  * operatorUnsupported error instead of the generic unknown-operator error.
  */
 export const MONGO_UNSUPPORTED_OPERATORS : readonly string[] = [
-    '$size',
     '$type',
     '$where',
     '$text',

--- a/packages/parser-mongo/src/parameter/filters/module.ts
+++ b/packages/parser-mongo/src/parameter/filters/module.ts
@@ -577,6 +577,24 @@ export class MongoFiltersParser extends BaseParser<
 
                     break;
                 }
+                case '$size': {
+                    // no complement twin — negated $size can not be
+                    // expressed without silently widening.
+                    if (negated) {
+                        throw FiltersParseError.operatorUnsupported('$size');
+                    }
+
+                    const value = input[operator];
+                    if (
+                        typeof value !== 'number' ||
+                        !Number.isInteger(value) ||
+                        value < 0
+                    ) {
+                        throw FiltersParseError.keyValueInvalid(key);
+                    }
+
+                    break;
+                }
                 case '$exists': {
                     if (typeof input[operator] !== 'boolean') {
                         throw FiltersParseError.keyValueInvalid(key);
@@ -744,6 +762,15 @@ export class MongoFiltersParser extends BaseParser<
                 case '$mod': {
                     output.push(new Filter(
                         FilterFieldOperator.MOD,
+                        resolved.field,
+                        input[operator],
+                    ));
+
+                    break;
+                }
+                case '$size': {
+                    output.push(new Filter(
+                        FilterFieldOperator.SIZE,
                         resolved.field,
                         input[operator],
                     ));

--- a/packages/parser-mongo/src/parameter/filters/types.ts
+++ b/packages/parser-mongo/src/parameter/filters/types.ts
@@ -42,10 +42,11 @@ export type MongoFieldQueryOperators<V = unknown> = {
     $regex?: RegExp | string,
     $options?: string,
     $mod?: [number, number],
+    $size?: number,
     $exists?: boolean,
     $elemMatch?: ObjectLiteral,
     $all?: (V | null)[],
-    $not?: Omit<MongoFieldQueryOperators<V>, '$not' | '$regex' | '$options' | '$mod' | '$elemMatch' | '$all'>,
+    $not?: Omit<MongoFieldQueryOperators<V>, '$not' | '$regex' | '$options' | '$mod' | '$size' | '$elemMatch' | '$all'>,
 };
 
 /**
@@ -73,7 +74,7 @@ type MongoFiltersParserInputSubLevel<
     T extends IsArray<T> ?
         ArrayItem<T> extends Record<PropertyKey, any> ?
             MongoFiltersParserInput<ArrayItem<T>, PrevIndex[DEPTH]> |
-            { $elemMatch?: MongoFiltersParserInput<ArrayItem<T>, PrevIndex[DEPTH]> } :
+            { $elemMatch?: MongoFiltersParserInput<ArrayItem<T>, PrevIndex[DEPTH]>, $size?: number } :
             MongoFiltersParserInputValue<ArrayItem<T>, PrevIndex[DEPTH]> :
         T extends Date ?
             MongoFiltersParserInputValue<T, PrevIndex[DEPTH]> :

--- a/packages/parser-mongo/test/unit/parser/filters.spec.ts
+++ b/packages/parser-mongo/test/unit/parser/filters.spec.ts
@@ -204,6 +204,20 @@ describe('filters/mongo-parser', () => {
             expectParseError(() => parser.parse({ age: { $mod: 3 } }), ErrorCode.KEY_VALUE_INVALID);
         });
 
+        it('should parse the size operator', () => {
+            expect(parseFlat({ items: { $size: 2 } }))
+                .toEqual(new Filter(FilterFieldOperator.SIZE, 'items', 2));
+            expect(parseFlat({ items: { $size: 0 } }))
+                .toEqual(new Filter(FilterFieldOperator.SIZE, 'items', 0));
+        });
+
+        it('should throw on invalid size values', () => {
+            expectParseError(() => parser.parse({ items: { $size: -1 } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ items: { $size: 2.5 } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ items: { $size: '2' } }), ErrorCode.KEY_VALUE_INVALID);
+            expectParseError(() => parser.parse({ items: { $size: Number.NaN } }), ErrorCode.KEY_VALUE_INVALID);
+        });
+
         it('should parse the exists operator', () => {
             expect(parseFlat({ deleted: { $exists: true } }))
                 .toEqual(new Filter(FilterFieldOperator.EXISTS, 'deleted', true));
@@ -229,9 +243,9 @@ describe('filters/mongo-parser', () => {
         });
 
         it('should throw on a known but unsupported operator at field level', () => {
-            const error = FiltersParseError.operatorUnsupported('$size');
+            const error = FiltersParseError.operatorUnsupported('$where');
 
-            expect(() => parser.parse({ items: { $size: 2 } })).toThrow(error);
+            expect(() => parser.parse({ items: { $where: 'true' } })).toThrow(error);
 
             expectParseError(() => parser.parse({ age: { $type: 'number' } }), ErrorCode.OPERATOR_UNSUPPORTED);
         });
@@ -499,6 +513,10 @@ describe('filters/mongo-parser', () => {
                 ErrorCode.OPERATOR_UNSUPPORTED,
             );
             expectParseError(
+                () => parser.parse({ items: { $not: { $size: 2 } } }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+            expectParseError(
                 () => parser.parse({ items: { $not: { $elemMatch: { id: 1 } } } }),
                 ErrorCode.OPERATOR_UNSUPPORTED,
             );
@@ -515,6 +533,10 @@ describe('filters/mongo-parser', () => {
         it('should throw on non negatable operators under $nor', () => {
             expectParseError(
                 () => parser.parse({ $nor: [{ age: { $mod: [3, 1] } }] }),
+                ErrorCode.OPERATOR_UNSUPPORTED,
+            );
+            expectParseError(
+                () => parser.parse({ $nor: [{ items: { $size: 2 } }] }),
                 ErrorCode.OPERATOR_UNSUPPORTED,
             );
             expectParseError(
@@ -1055,9 +1077,18 @@ describe('filters/mongo-parser', () => {
                 ErrorCode.KEY_VALUE_INVALID,
             );
             expectParseError(
-                () => parser.parse({ scores: { $elemMatch: { $size: 2 } } }),
+                () => parser.parse({ scores: { $elemMatch: { $type: 'number' } } }),
                 ErrorCode.OPERATOR_UNSUPPORTED,
             );
+        });
+
+        it('should parse an element-level size onto the element itself', () => {
+            // array of arrays: some inner array has exactly two elements.
+            expect(parseFlat({ matrix: { $elemMatch: { $size: 2 } } })).toEqual(new Filter(
+                FilterFieldOperator.ELEM_MATCH,
+                'matrix',
+                new Filter(FilterFieldOperator.SIZE, ITSELF, 2),
+            ));
         });
 
         it('should keep the element operator interior unbound under a schema', () => {

--- a/packages/sql/src/visitor/filters.ts
+++ b/packages/sql/src/visitor/filters.ts
@@ -111,6 +111,12 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
         return this.adapter.whereRaw(sql, ...expr.value);
     }
 
+    visitFilterSize(): IFiltersAdapter {
+        // no SQL rendering yet — an array-length check needs per-dialect
+        // JSON-array support (json_array_length/JSON_LENGTH/cardinality).
+        throw AdapterError.featureUnsupported('filters:size');
+    }
+
     visitFilterElemMatch(expr: Filter<FilterFieldOperator.ELEM_MATCH, Filter | Filters>): IFiltersAdapter {
         const oldPrefix = this.adapter.getFieldPrefix();
 

--- a/packages/sql/test/unit/interpreters/primitves.spec.ts
+++ b/packages/sql/test/unit/interpreters/primitves.spec.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { Filter } from '@rapiq/core';
+import { AdapterError, ErrorCode, Filter } from '@rapiq/core';
 import {
     FiltersAdapter, 
     type FiltersContainerOptions, 
@@ -109,5 +109,17 @@ describe('primitive operators', () => {
 
         expect(sql).toEqual('mod("qty", $1) = $2');
         expect(params).toStrictEqual([4, 0]);
+    });
+
+    it('throws a typed featureUnsupported error for "size"', () => {
+        const condition = new Filter('size', 'tags', 2);
+
+        try {
+            condition.accept(visitor);
+            expect.fail('size must throw');
+        } catch (e) {
+            expect(e).toBeInstanceOf(AdapterError);
+            expect((e as AdapterError).code).toEqual(ErrorCode.FEATURE_UNSUPPORTED);
+        }
     });
 });

--- a/packages/typeorm/test/unit/filters.spec.ts
+++ b/packages/typeorm/test/unit/filters.spec.ts
@@ -329,6 +329,23 @@ describe('src/filters', () => {
         expect(data.length).toEqual(1);
     });
 
+    it('should throw typed on a size condition', () => {
+        // no SQL rendering yet (mirrors @rapiq/sql).
+        const condition = new Filter(
+            FilterFieldOperator.SIZE,
+            'first_name',
+            2,
+        );
+
+        try {
+            createQueryBuilder(condition);
+            expect.fail('should have thrown');
+        } catch (e) {
+            expect(e).toBeInstanceOf(AdapterError);
+            expect((e as AdapterError).code).toEqual(ErrorCode.FEATURE_UNSUPPORTED);
+        }
+    });
+
     it('should throw typed on an ITSELF leaf', () => {
         // a joined relation row is not a scalar column — no rendering
         // for the element itself (mirrors @rapiq/sql).


### PR DESCRIPTION
Closes #769.

Adds the `SIZE` leaf operator (array-length match) across the pipeline, following the design sketch in the issue:

- **core**: `FilterFieldOperator.SIZE`, optional `visitFilterSize` on `IFilterVisitor`, `size(field, n)` condition helper, `$size` in the build layer's operator-object grammar (object-array fields accept it next to `$elemMatch`).
- **parser-mongo**: `$size` moves out of `MONGO_UNSUPPORTED_OPERATORS`; the value must be a non-negative integer (`KEY_VALUE_INVALID` otherwise); negation via `$not`/`$nor` throws `OPERATOR_UNSUPPORTED` (no complement twin, consistent with `$regex`/`$mod`). An element-level `$elemMatch: { $size: n }` interior builds `SIZE` on the `ITSELF` marker (arrays of arrays).
- **parser-expression / codec-url**: new `size(field,'n')` grammar production; the quoted wire value coerces back to a number per the untyped-wire normalization rule. The expression encoder validates the value before emitting; the simple dialect cannot express it, so encode throws typed under the subset law.
- **memory**: matches `Array.isArray(v) && v.length === n` — the condition addresses the array itself (never element-wise); missing/non-array values never match (mongo parity); malformed values totalize to `false`.
- **sql / typeorm**: throw typed `AdapterError.featureUnsupported('filters:size')` for now — an array-length check needs per-dialect JSON-array support (`json_array_length`/`JSON_LENGTH`/`cardinality`), left as a follow-up per the issue.
- **docs**: operator tables (filters guide, building-queries, parser-mongo, parser-expression, core, memory, sql) updated.

Notes for review:

- `Filter.acceptWithFallback` now casts the dispatched method instead of the argument — adding a `number`-valued visitor method made TypeScript reduce the old parameter intersection to `never` (`boolean & number`).
- `size` becomes a reserved keyword of the expression dialect: a field literally named `size` can no longer be referenced there (same trade-off as `elemMatch`); the encoder rejects such field segments loudly.

Verified end-to-end through the built package boundary: `defineQuery({ tags: { $size: 2 } })` → `URLCodec` encode (`filter=size(tags,'2')`) → decode → `applyQuery` matches only the exact-length array record; the mongo document path agrees; all negation/value-shape probes throw the typed errors listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added array-length filtering with the `size` helper and `$size` operator.
  * Supports exact-length matching, including nested array checks and expression/Mongo-style query parsing.
  * Memory-based filtering now evaluates `size` conditions.

* **Documentation**
  * Documented `size` syntax, semantics, dialect support, and limitations.

* **Bug Fixes**
  * Invalid size values, negated usage, and unsupported SQL rendering now produce consistent typed errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->