### PR TITLE
feat(typeorm): derive schemas from entity metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4137,7 +4137,6 @@
             "version": "5.4.4",
             "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
             "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/character-entities-html4": {
@@ -9926,6 +9925,9 @@
             "name": "@rapiq/typeorm",
             "version": "2.0.0-beta.0",
             "license": "MIT",
+            "dependencies": {
+                "change-case": "^5.4.4"
+            },
             "devDependencies": {
                 "@rapiq/core": "^2.0.0-beta.0",
                 "@rapiq/parser-simple": "^2.0.0-beta.0",

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -88,8 +88,8 @@ import { defineSchemaRegistryWithDataSource } from '@rapiq/typeorm';
 const registry = defineSchemaRegistryWithDataSource(dataSource, {
     schemas: {
         user: {
-            filters: { allowed: 'columns' },
-            sort: { allowed: 'columns' },
+            filters: { allowed: 'inherit' },
+            sort: { allowed: 'inherit' },
         },
     },
 });
@@ -97,14 +97,14 @@ const registry = defineSchemaRegistryWithDataSource(dataSource, {
 
 Every schema gets its **structure** derived unconditionally: the schema name (lower-camel entity name, `RoleDetail` → `roleDetail`), the allowed relations, and the `schemaMapping` linking each relation to its target entity's schema — so nested paths like `role.detail` resolve across the registry without any manual wiring.
 
-Column-based **allow-lists** are opt-in per parameter: `allowed: 'columns'` expands to the entity's column property paths. Hidden columns (`select: false`) and virtual join columns are always excluded; explicitly declared FK columns (e.g. `realmId`) are included. Any explicit option wins over its derived counterpart:
+Column-based **allow-lists** are opt-in per parameter: `allowed: 'inherit'` expands to the entity's column property paths. Hidden columns (`select: false`) and virtual join columns are always excluded; explicitly declared FK columns (e.g. `realmId`) are included. Any explicit option wins over its derived counterpart:
 
 ```typescript
 import { defineSchemaWithEntity } from '@rapiq/typeorm';
 
 const schema = defineSchemaWithEntity(User, dataSource, {
     strict: true,
-    fields: { allowed: 'columns' },
+    fields: { allowed: 'inherit' },
     filters: { allowed: ['id', 'name'] },   // explicit list, nothing derived
     sort: { default: { id: 'DESC' } },
 });
@@ -123,7 +123,7 @@ defineSchemaRegistryWithDataSource(dataSource, { registry });
 
 Passing `schemas` options for a skipped (already registered) name throws — options that would be silently ignored are treated as a mistake.
 
-Derivation never sets [`strict`](/guide/schemas#strict-mode) — combined with `strict: true`, a derived `allowed: 'columns'` opens **every** (non-hidden) column to clients, so opt sensitive resources into explicit lists instead.
+Derivation never sets [`strict`](/guide/schemas#strict-mode) — combined with `strict: true`, a derived `allowed: 'inherit'` opens **every** (non-hidden) column to clients, so opt sensitive resources into explicit lists instead.
 
 ::: tip
 The data source only needs built metadata, not an open connection — deriving schemas at startup before `dataSource.initialize()` completes is fine as long as the metadata was built.

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -100,9 +100,9 @@ Every schema gets its **structure** derived unconditionally: the schema name (lo
 Column-based **allow-lists** are opt-in per parameter: `allowed: 'columns'` expands to the entity's column property paths. Hidden columns (`select: false`) and virtual join columns are always excluded; explicitly declared FK columns (e.g. `realmId`) are included. Any explicit option wins over its derived counterpart:
 
 ```typescript
-import { defineSchemaFromEntity } from '@rapiq/typeorm';
+import { defineSchemaWithEntity } from '@rapiq/typeorm';
 
-const schema = defineSchemaFromEntity(User, dataSource, {
+const schema = defineSchemaWithEntity(User, dataSource, {
     strict: true,
     fields: { allowed: 'columns' },
     filters: { allowed: ['id', 'name'] },   // explicit list, nothing derived
@@ -110,7 +110,7 @@ const schema = defineSchemaFromEntity(User, dataSource, {
 });
 ```
 
-`defineSchemaFromEntity` also accepts an `EntityMetadata` directly (`defineSchemaFromEntity(dataSource.getMetadata(User))`), and the registry's `schemas` options can be keyed by entity class via a `Map` instead of the derived name. An options key that matches no entity throws, so entity renames fail loudly.
+`defineSchemaWithEntity` also accepts an `EntityMetadata` directly (`defineSchemaWithEntity(dataSource.getMetadata(User))`), and the registry's `schemas` options can be keyed by entity class via a `Map` instead of the derived name. An options key that matches no entity throws, so entity renames fail loudly.
 
 To mix hand-written and derived schemas, pass an existing registry — entities whose derived name is already registered are skipped, so the hand-written schema stays authoritative and derivation fills in the rest:
 

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -112,6 +112,17 @@ const schema = defineSchemaFromEntity(User, dataSource, {
 
 `defineSchemaFromEntity` also accepts an `EntityMetadata` directly (`defineSchemaFromEntity(dataSource.getMetadata(User))`), and the registry's `schemas` options can be keyed by entity class via a `Map` instead of the derived name. An options key that matches no entity throws, so entity renames fail loudly.
 
+To mix hand-written and derived schemas, pass an existing registry — entities whose derived name is already registered are skipped, so the hand-written schema stays authoritative and derivation fills in the rest:
+
+```typescript
+const registry = new SchemaRegistry();
+registry.add(userSchema);   // curated by hand
+
+createSchemaRegistryFromDataSource(dataSource, { registry });
+```
+
+Passing `schemas` options for a skipped (already registered) name throws — options that would be silently ignored are treated as a mistake.
+
 Derivation never sets [`strict`](/guide/schemas#strict-mode) — combined with `strict: true`, a derived `allowed: 'columns'` opens **every** (non-hidden) column to clients, so opt sensitive resources into explicit lists instead.
 
 ::: tip

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -80,12 +80,12 @@ The adapter resolves the SQL dialect from the attached query builder's connectio
 
 ## Deriving schemas from entities
 
-Instead of hand-maintaining a [`Schema`](/guide/schemas) per resource, derive it from the TypeORM entity metadata. `createSchemaRegistryFromDataSource` walks all entities of a data source and returns a populated `SchemaRegistry` — one schema per entity, cross-linked automatically:
+Instead of hand-maintaining a [`Schema`](/guide/schemas) per resource, derive it from the TypeORM entity metadata. `defineSchemaRegistryWithDataSource` walks all entities of a data source and returns a populated `SchemaRegistry` — one schema per entity, cross-linked automatically:
 
 ```typescript
-import { createSchemaRegistryFromDataSource } from '@rapiq/typeorm';
+import { defineSchemaRegistryWithDataSource } from '@rapiq/typeorm';
 
-const registry = createSchemaRegistryFromDataSource(dataSource, {
+const registry = defineSchemaRegistryWithDataSource(dataSource, {
     schemas: {
         user: {
             filters: { allowed: 'columns' },
@@ -118,7 +118,7 @@ To mix hand-written and derived schemas, pass an existing registry — entities 
 const registry = new SchemaRegistry();
 registry.add(userSchema);   // curated by hand
 
-createSchemaRegistryFromDataSource(dataSource, { registry });
+defineSchemaRegistryWithDataSource(dataSource, { registry });
 ```
 
 Passing `schemas` options for a skipped (already registered) name throws — options that would be silently ignored are treated as a mistake.

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -78,6 +78,46 @@ The adapter resolves the SQL dialect from the attached query builder's connectio
 
 [Case-insensitive string equality](/guide/filters#case-sensitivity) folds through `lower()` on case-sensitive dialects. The adapter resolves each filtered field against the entity metadata (relation paths included) and folds **only string-typed columns** — filtering an `int` column with an untyped wire string (`filter[age]=18`) renders a plain `=` instead of a `lower(...)` type error, and non-string columns never pay the folding cost. Unresolvable fields keep the folding default; opt fields out explicitly via `execute(query, { visitor: { caseSensitive: [...] } })`.
 
+## Deriving schemas from entities
+
+Instead of hand-maintaining a [`Schema`](/guide/schemas) per resource, derive it from the TypeORM entity metadata. `createSchemaRegistryFromDataSource` walks all entities of a data source and returns a populated `SchemaRegistry` — one schema per entity, cross-linked automatically:
+
+```typescript
+import { createSchemaRegistryFromDataSource } from '@rapiq/typeorm';
+
+const registry = createSchemaRegistryFromDataSource(dataSource, {
+    schemas: {
+        user: {
+            filters: { allowed: 'columns' },
+            sort: { allowed: 'columns' },
+        },
+    },
+});
+```
+
+Every schema gets its **structure** derived unconditionally: the schema name (lower-camel entity name, `RoleDetail` → `roleDetail`), the allowed relations, and the `schemaMapping` linking each relation to its target entity's schema — so nested paths like `role.detail` resolve across the registry without any manual wiring.
+
+Column-based **allow-lists** are opt-in per parameter: `allowed: 'columns'` expands to the entity's column property paths. Hidden columns (`select: false`) and virtual join columns are always excluded; explicitly declared FK columns (e.g. `realmId`) are included. Any explicit option wins over its derived counterpart:
+
+```typescript
+import { defineSchemaFromEntity } from '@rapiq/typeorm';
+
+const schema = defineSchemaFromEntity(User, dataSource, {
+    strict: true,
+    fields: { allowed: 'columns' },
+    filters: { allowed: ['id', 'name'] },   // explicit list, nothing derived
+    sort: { default: { id: 'DESC' } },
+});
+```
+
+`defineSchemaFromEntity` also accepts an `EntityMetadata` directly (`defineSchemaFromEntity(dataSource.getMetadata(User))`), and the registry's `schemas` options can be keyed by entity class via a `Map` instead of the derived name. An options key that matches no entity throws, so entity renames fail loudly.
+
+Derivation never sets [`strict`](/guide/schemas#strict-mode) — combined with `strict: true`, a derived `allowed: 'columns'` opens **every** (non-hidden) column to clients, so opt sensitive resources into explicit lists instead.
+
+::: tip
+The data source only needs built metadata, not an open connection — deriving schemas at startup before `dataSource.initialize()` completes is fine as long as the metadata was built.
+:::
+
 ## Applying a single parameter
 
 A `Query` with only some parameters set applies just those — the rest are empty and become no-ops. To apply, say, only the filters of a parsed query:

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -15,6 +15,9 @@
     "files": [
         "dist/"
     ],
+    "dependencies": {
+        "change-case": "^5.4.4"
+    },
     "devDependencies": {
         "@rapiq/core": "^2.0.0-beta.0",
         "@rapiq/parser-simple": "^2.0.0-beta.0",

--- a/packages/typeorm/src/schema/index.ts
+++ b/packages/typeorm/src/schema/index.ts
@@ -5,6 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './adapter';
-export * from './dialect';
-export * from './schema';
+export * from './module';
+export * from './types';

--- a/packages/typeorm/src/schema/module.ts
+++ b/packages/typeorm/src/schema/module.ts
@@ -11,6 +11,7 @@ import type {
     SchemaOptions,
 } from '@rapiq/core';
 import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import { camelCase } from 'change-case';
 import { DataSource, EntityMetadata } from 'typeorm';
 import type { EntityTarget } from 'typeorm';
 import type {
@@ -19,9 +20,7 @@ import type {
 } from './types';
 
 export function buildEntitySchemaName(input: EntityMetadata | string) : string {
-    const name = typeof input === 'string' ? input : input.name;
-
-    return name.charAt(0).toLowerCase() + name.slice(1);
+    return camelCase(typeof input === 'string' ? input : input.name);
 }
 
 function deriveColumnKeys(metadata: EntityMetadata) : string[] {

--- a/packages/typeorm/src/schema/module.ts
+++ b/packages/typeorm/src/schema/module.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    ObjectLiteral,
+    Schema,
+    SchemaOptions,
+} from '@rapiq/core';
+import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import { DataSource, EntityMetadata } from 'typeorm';
+import type { EntityTarget } from 'typeorm';
+import type {
+    EntitySchemaOptions,
+    SchemaRegistryFromDataSourceOptions,
+} from './types';
+
+export function buildEntitySchemaName(input: EntityMetadata | string) : string {
+    const name = typeof input === 'string' ? input : input.name;
+
+    return name.charAt(0).toLowerCase() + name.slice(1);
+}
+
+function deriveColumnKeys(metadata: EntityMetadata) : string[] {
+    const output : string[] = [];
+
+    for (const column of metadata.columns) {
+        // hidden (`select: false`) columns never enter derived lists;
+        // virtual columns are implicit join columns of relations
+        // without a declared FK property.
+        if (!column.isSelect || column.isVirtual) {
+            continue;
+        }
+
+        output.push(column.propertyPath);
+    }
+
+    return output;
+}
+
+function buildSchemaOptions(
+    metadata: EntityMetadata,
+    input: EntitySchemaOptions<any> = {},
+) : SchemaOptions {
+    const {
+        fields, 
+        filters, 
+        sort, 
+        relations, 
+        pagination, 
+        ...base
+    } = input;
+
+    const relationKeys : string[] = [];
+    const schemaMapping : Record<string, string> = {};
+    for (const relation of metadata.relations) {
+        relationKeys.push(relation.propertyName);
+        schemaMapping[relation.propertyName] = buildEntitySchemaName(relation.inverseEntityMetadata);
+    }
+
+    let columnKeys : string[] | undefined;
+    const resolveAllowed = (allowed: unknown) => {
+        if (allowed === 'columns') {
+            columnKeys = columnKeys || deriveColumnKeys(metadata);
+            return columnKeys;
+        }
+
+        return allowed;
+    };
+
+    const output : SchemaOptions = {
+        ...base,
+        name: base.name ?? buildEntitySchemaName(metadata),
+        schemaMapping: { ...schemaMapping, ...base.schemaMapping },
+        relations: {
+            allowed: relationKeys,
+            ...relations,
+        },
+    };
+
+    if (fields) {
+        output.fields = { ...fields, allowed: resolveAllowed(fields.allowed) } as SchemaOptions['fields'];
+    }
+
+    if (filters) {
+        output.filters = { ...filters, allowed: resolveAllowed(filters.allowed) } as SchemaOptions['filters'];
+    }
+
+    if (sort) {
+        output.sort = { ...sort, allowed: resolveAllowed(sort.allowed) } as SchemaOptions['sort'];
+    }
+
+    if (pagination) {
+        output.pagination = pagination;
+    }
+
+    return output;
+}
+
+export function defineSchemaFromEntity<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    metadata: EntityMetadata,
+    options?: EntitySchemaOptions<RECORD>,
+) : Schema<RECORD>;
+export function defineSchemaFromEntity<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    target: EntityTarget<RECORD>,
+    dataSource: DataSource,
+    options?: EntitySchemaOptions<RECORD>,
+) : Schema<RECORD>;
+export function defineSchemaFromEntity<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    target: EntityMetadata | EntityTarget<RECORD>,
+    dataSourceOrOptions?: DataSource | EntitySchemaOptions<RECORD>,
+    options?: EntitySchemaOptions<RECORD>,
+) : Schema<RECORD> {
+    let metadata : EntityMetadata;
+    let schemaOptions : EntitySchemaOptions<RECORD> | undefined;
+
+    if (target instanceof EntityMetadata) {
+        metadata = target;
+        schemaOptions = dataSourceOrOptions as EntitySchemaOptions<RECORD> | undefined;
+    } else {
+        if (!(dataSourceOrOptions instanceof DataSource)) {
+            throw new Error('A data source is required to resolve the metadata of an entity target.');
+        }
+
+        metadata = dataSourceOrOptions.getMetadata(target);
+        schemaOptions = options;
+    }
+
+    return defineSchema(buildSchemaOptions(metadata, schemaOptions) as SchemaOptions<RECORD>);
+}
+
+export function createSchemaRegistryFromDataSource(
+    dataSource: DataSource,
+    options: SchemaRegistryFromDataSourceOptions = {},
+) : SchemaRegistry {
+    const registry = new SchemaRegistry();
+
+    const schemasOptions = new Map<string, EntitySchemaOptions<any>>();
+    if (options.schemas instanceof Map) {
+        for (const [target, schemaOptions] of options.schemas) {
+            schemasOptions.set(
+                buildEntitySchemaName(dataSource.getMetadata(target)),
+                schemaOptions,
+            );
+        }
+    } else if (options.schemas) {
+        for (const [name, schemaOptions] of Object.entries(options.schemas)) {
+            schemasOptions.set(name, schemaOptions);
+        }
+    }
+
+    const names = new Set<string>();
+    for (const metadata of dataSource.entityMetadatas) {
+        if (
+            metadata.tableType === 'junction' ||
+            metadata.tableType === 'closure-junction'
+        ) {
+            continue;
+        }
+
+        const name = buildEntitySchemaName(metadata);
+        if (names.has(name)) {
+            throw new Error(`The derived schema name "${name}" is not unique across the data source entities.`);
+        }
+
+        names.add(name);
+
+        registry.add(defineSchemaFromEntity(metadata, schemasOptions.get(name)));
+    }
+
+    for (const name of schemasOptions.keys()) {
+        if (!names.has(name)) {
+            throw new Error(`The schemas option key "${name}" does not match any entity of the data source.`);
+        }
+    }
+
+    return registry;
+}

--- a/packages/typeorm/src/schema/module.ts
+++ b/packages/typeorm/src/schema/module.ts
@@ -62,7 +62,7 @@ function buildSchemaOptions(
 
     let columnKeys : string[] | undefined;
     const resolveAllowed = (allowed: unknown) => {
-        if (allowed === 'columns') {
+        if (allowed === 'inherit') {
             columnKeys = columnKeys || deriveColumnKeys(metadata);
             return columnKeys;
         }

--- a/packages/typeorm/src/schema/module.ts
+++ b/packages/typeorm/src/schema/module.ts
@@ -15,7 +15,7 @@ import { DataSource, EntityMetadata } from 'typeorm';
 import type { EntityTarget } from 'typeorm';
 import type {
     EntitySchemaOptions,
-    SchemaRegistryFromDataSourceOptions,
+    SchemaRegistryWithDataSourceOptions,
 } from './types';
 
 export function buildEntitySchemaName(input: EntityMetadata | string) : string {
@@ -138,9 +138,9 @@ export function defineSchemaFromEntity<
     return defineSchema(buildSchemaOptions(metadata, schemaOptions) as SchemaOptions<RECORD>);
 }
 
-export function createSchemaRegistryFromDataSource(
+export function defineSchemaRegistryWithDataSource(
     dataSource: DataSource,
-    options: SchemaRegistryFromDataSourceOptions = {},
+    options: SchemaRegistryWithDataSourceOptions = {},
 ) : SchemaRegistry {
     const registry = options.registry || new SchemaRegistry();
 

--- a/packages/typeorm/src/schema/module.ts
+++ b/packages/typeorm/src/schema/module.ts
@@ -142,7 +142,7 @@ export function createSchemaRegistryFromDataSource(
     dataSource: DataSource,
     options: SchemaRegistryFromDataSourceOptions = {},
 ) : SchemaRegistry {
-    const registry = new SchemaRegistry();
+    const registry = options.registry || new SchemaRegistry();
 
     const schemasOptions = new Map<string, EntitySchemaOptions<any>>();
     if (options.schemas instanceof Map) {
@@ -173,6 +173,15 @@ export function createSchemaRegistryFromDataSource(
         }
 
         names.add(name);
+
+        // an already registered schema (e.g. hand-written) takes precedence.
+        if (registry.get(name)) {
+            if (schemasOptions.has(name)) {
+                throw new Error(`The schemas option key "${name}" cannot be applied, since the schema is already registered.`);
+            }
+
+            continue;
+        }
 
         registry.add(defineSchemaFromEntity(metadata, schemasOptions.get(name)));
     }

--- a/packages/typeorm/src/schema/module.ts
+++ b/packages/typeorm/src/schema/module.ts
@@ -100,20 +100,20 @@ function buildSchemaOptions(
     return output;
 }
 
-export function defineSchemaFromEntity<
+export function defineSchemaWithEntity<
     RECORD extends ObjectLiteral = ObjectLiteral,
 >(
     metadata: EntityMetadata,
     options?: EntitySchemaOptions<RECORD>,
 ) : Schema<RECORD>;
-export function defineSchemaFromEntity<
+export function defineSchemaWithEntity<
     RECORD extends ObjectLiteral = ObjectLiteral,
 >(
     target: EntityTarget<RECORD>,
     dataSource: DataSource,
     options?: EntitySchemaOptions<RECORD>,
 ) : Schema<RECORD>;
-export function defineSchemaFromEntity<
+export function defineSchemaWithEntity<
     RECORD extends ObjectLiteral = ObjectLiteral,
 >(
     target: EntityMetadata | EntityTarget<RECORD>,
@@ -183,7 +183,7 @@ export function defineSchemaRegistryWithDataSource(
             continue;
         }
 
-        registry.add(defineSchemaFromEntity(metadata, schemasOptions.get(name)));
+        registry.add(defineSchemaWithEntity(metadata, schemasOptions.get(name)));
     }
 
     for (const name of schemasOptions.keys()) {

--- a/packages/typeorm/src/schema/types.ts
+++ b/packages/typeorm/src/schema/types.ts
@@ -41,7 +41,7 @@ export type EntitySchemaOptions<
 export type EntitySchemasOptions =    Record<string, EntitySchemaOptions<any>> |
     Map<EntityTarget<any>, EntitySchemaOptions<any>>;
 
-export type SchemaRegistryFromDataSourceOptions = {
+export type SchemaRegistryWithDataSourceOptions = {
     /**
      * Per-entity options, keyed by the derived schema name
      * (lower-camel entity name) or by the entity class itself.

--- a/packages/typeorm/src/schema/types.ts
+++ b/packages/typeorm/src/schema/types.ts
@@ -18,14 +18,14 @@ import type {
 import type { EntityTarget } from 'typeorm';
 
 /**
- * Marks an `allowed` list to be derived from the entity's column
+ * Marks an `allowed` list to be inherited from the entity's column
  * property paths (hidden `select: false` columns and virtual join
  * columns excluded).
  */
-export type ColumnsSentinel = 'columns';
+export type InheritSentinel = 'inherit';
 
 type WithDerivableAllowed<OPTIONS extends { allowed?: unknown }> = Omit<OPTIONS, 'allowed'> & {
-    allowed?: NonNullable<OPTIONS['allowed']> | ColumnsSentinel,
+    allowed?: NonNullable<OPTIONS['allowed']> | InheritSentinel,
 };
 
 export type EntitySchemaOptions<

--- a/packages/typeorm/src/schema/types.ts
+++ b/packages/typeorm/src/schema/types.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    BaseSchemaOptions,
+    FieldsOptions,
+    FiltersOptions,
+    ObjectLiteral,
+    PaginationOptions,
+    RelationsOptions,
+    SortOptions,
+} from '@rapiq/core';
+import type { EntityTarget } from 'typeorm';
+
+/**
+ * Marks an `allowed` list to be derived from the entity's column
+ * property paths (hidden `select: false` columns and virtual join
+ * columns excluded).
+ */
+export type ColumnsSentinel = 'columns';
+
+type WithDerivableAllowed<OPTIONS extends { allowed?: unknown }> = Omit<OPTIONS, 'allowed'> & {
+    allowed?: NonNullable<OPTIONS['allowed']> | ColumnsSentinel,
+};
+
+export type EntitySchemaOptions<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+> = BaseSchemaOptions & {
+    fields?: WithDerivableAllowed<FieldsOptions<RECORD>>,
+    filters?: WithDerivableAllowed<FiltersOptions<RECORD>>,
+    sort?: WithDerivableAllowed<SortOptions<RECORD>>,
+    relations?: RelationsOptions<RECORD>,
+    pagination?: PaginationOptions,
+};
+
+export type EntitySchemasOptions =    Record<string, EntitySchemaOptions<any>> |
+    Map<EntityTarget<any>, EntitySchemaOptions<any>>;
+
+export type SchemaRegistryFromDataSourceOptions = {
+    /**
+     * Per-entity options, keyed by the derived schema name
+     * (lower-camel entity name) or by the entity class itself.
+     */
+    schemas?: EntitySchemasOptions,
+};

--- a/packages/typeorm/src/schema/types.ts
+++ b/packages/typeorm/src/schema/types.ts
@@ -12,6 +12,7 @@ import type {
     ObjectLiteral,
     PaginationOptions,
     RelationsOptions,
+    SchemaRegistry,
     SortOptions,
 } from '@rapiq/core';
 import type { EntityTarget } from 'typeorm';
@@ -46,4 +47,11 @@ export type SchemaRegistryFromDataSourceOptions = {
      * (lower-camel entity name) or by the entity class itself.
      */
     schemas?: EntitySchemasOptions,
+
+    /**
+     * Registry to extend instead of creating a new one.
+     * Schemas already registered under a derived name take
+     * precedence — the entity is skipped.
+     */
+    registry?: SchemaRegistry,
 };

--- a/packages/typeorm/test/unit/schema/module.spec.ts
+++ b/packages/typeorm/test/unit/schema/module.spec.ts
@@ -55,6 +55,8 @@ describe('src/schema/*.ts', () => {
 
     it('should derive lower-camel schema names', () => {
         expect(buildEntitySchemaName('RoleDetail')).toEqual('roleDetail');
+        expect(buildEntitySchemaName('HTTPRequestLog')).toEqual('httpRequestLog');
+        expect(buildEntitySchemaName('Role_Detail')).toEqual('roleDetail');
         expect(buildEntitySchemaName(dataSource.getMetadata(RoleDetail))).toEqual('roleDetail');
 
         const schema = defineSchemaWithEntity(RoleDetail, dataSource);

--- a/packages/typeorm/test/unit/schema/module.spec.ts
+++ b/packages/typeorm/test/unit/schema/module.spec.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SimpleParser } from '@rapiq/parser-simple';
+import type { DataSource } from 'typeorm';
+import {
+    Column, 
+    Entity, 
+    ManyToOne, 
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+import {
+    buildEntitySchemaName,
+    createSchemaRegistryFromDataSource,
+    defineSchemaFromEntity,
+} from '../../../src';
+import { createDataSourceOptions, createUnconnectedDataSource } from '../../data/factory';
+import { Realm } from '../../data/entity/realm';
+import { RoleDetail } from '../../data/entity/role-detail';
+import { User } from '../../data/entity/user';
+
+@Entity()
+class Article {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column({ select: false })
+    secret: string;
+
+    @ManyToOne(() => Realm)
+    owner: Realm;
+}
+
+describe('src/schema/*.ts', () => {
+    let dataSource : DataSource;
+    let articleDataSource : DataSource;
+
+    beforeAll(async () => {
+        dataSource = await createUnconnectedDataSource();
+
+        const options = createDataSourceOptions();
+        articleDataSource = await createUnconnectedDataSource({
+            ...options,
+            entities: [Article, Realm],
+        });
+    });
+
+    it('should derive lower-camel schema names', () => {
+        expect(buildEntitySchemaName('RoleDetail')).toEqual('roleDetail');
+        expect(buildEntitySchemaName(dataSource.getMetadata(RoleDetail))).toEqual('roleDetail');
+
+        const schema = defineSchemaFromEntity(RoleDetail, dataSource);
+        expect(schema.name).toEqual('roleDetail');
+    });
+
+    it('should derive structure (relations + schemaMapping) by default', () => {
+        const schema = defineSchemaFromEntity(User, dataSource);
+
+        expect(schema.name).toEqual('user');
+        expect(schema.relations.allowed).toEqual(['role', 'realm']);
+        expect(schema.mapSchema('role')).toEqual('role');
+        expect(schema.mapSchema('realm')).toEqual('realm');
+
+        expect(schema.filters.allowedIsUndefined).toBeTruthy();
+        expect(schema.strict).toBeUndefined();
+    });
+
+    it('should accept entity metadata as input', () => {
+        const schema = defineSchemaFromEntity(dataSource.getMetadata(User));
+
+        expect(schema.name).toEqual('user');
+    });
+
+    it('should derive column allow-lists on opt-in', () => {
+        const schema = defineSchemaFromEntity(User, dataSource, {
+            filters: { allowed: 'columns' },
+            sort: { allowed: 'columns' },
+        });
+
+        expect(schema.filters.allowed).toContain('id');
+        expect(schema.filters.allowed).toContain('email');
+        // explicitly declared fk columns are part of the derived list
+        expect(schema.filters.allowed).toContain('realm_id');
+
+        expect(schema.sort.allowed).toEqual(schema.filters.allowed);
+
+        // fields were not opted in
+        expect(schema.fields.allowedIsUndefined).toBeTruthy();
+    });
+
+    it('should exclude hidden and virtual join columns from derived lists', () => {
+        const schema = defineSchemaFromEntity(Article, articleDataSource, { filters: { allowed: 'columns' } });
+
+        expect(schema.filters.allowed).toEqual(['id', 'title']);
+    });
+
+    it('should prioritize explicit options over derived values', () => {
+        const schema = defineSchemaFromEntity(User, dataSource, {
+            name: 'account',
+            strict: true,
+            schemaMapping: { realm: 'customRealm' },
+            filters: { allowed: ['id'] },
+            relations: { allowed: ['realm'] },
+        });
+
+        expect(schema.name).toEqual('account');
+        expect(schema.strict).toBeTruthy();
+        expect(schema.filters.allowed).toEqual(['id']);
+        expect(schema.relations.allowed).toEqual(['realm']);
+        expect(schema.mapSchema('realm')).toEqual('customRealm');
+        expect(schema.mapSchema('role')).toEqual('role');
+    });
+
+    it('should build a registry for all data source entities', () => {
+        const registry = createSchemaRegistryFromDataSource(dataSource);
+
+        expect(registry.get('user')).toBeDefined();
+        expect(registry.get('role')).toBeDefined();
+        expect(registry.get('roleDetail')).toBeDefined();
+        expect(registry.get('realm')).toBeDefined();
+    });
+
+    it('should resolve relation traversal across derived schemas', () => {
+        const registry = createSchemaRegistryFromDataSource(dataSource);
+        const parser = new SimpleParser(registry);
+
+        // "detail" resolves to the "roleDetail" schema via the derived schemaMapping
+        const output = parser.parse({ relations: ['role.detail'] }, { schema: 'user' });
+
+        expect(output.relations.value.map((relation) => relation.name)).toEqual(['role', 'role.detail']);
+    });
+
+    it('should apply per-entity options keyed by schema name', () => {
+        const registry = createSchemaRegistryFromDataSource(dataSource, { schemas: { user: { filters: { allowed: 'columns' } } } });
+
+        const schema = registry.getOrFail('user');
+        expect(schema.filters.allowed).toContain('email');
+
+        const roleSchema = registry.getOrFail('role');
+        expect(roleSchema.filters.allowedIsUndefined).toBeTruthy();
+    });
+
+    it('should apply per-entity options keyed by entity class', () => {
+        const registry = createSchemaRegistryFromDataSource(dataSource, {
+            schemas: new Map([
+                [User, { filters: { allowed: 'columns' as const } }],
+            ]),
+        });
+
+        const schema = registry.getOrFail('user');
+        expect(schema.filters.allowed).toContain('email');
+    });
+
+    it('should fail on schema options for an unknown entity', () => {
+        expect(() => createSchemaRegistryFromDataSource(dataSource, { schemas: { unknownEntity: {} } })).toThrow('unknownEntity');
+    });
+});

--- a/packages/typeorm/test/unit/schema/module.spec.ts
+++ b/packages/typeorm/test/unit/schema/module.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { SchemaRegistry, defineSchema } from '@rapiq/core';
 import { SimpleParser } from '@rapiq/parser-simple';
 import type { DataSource } from 'typeorm';
 import {
@@ -156,6 +157,34 @@ describe('src/schema/*.ts', () => {
 
         const schema = registry.getOrFail('user');
         expect(schema.filters.allowed).toContain('email');
+    });
+
+    it('should extend an existing registry', () => {
+        const registry = new SchemaRegistry();
+        const realmSchema = defineSchema<Realm>({
+            name: 'realm',
+            filters: { allowed: ['id'] },
+        });
+        registry.add(realmSchema);
+
+        const output = createSchemaRegistryFromDataSource(dataSource, { registry });
+
+        expect(output).toBe(registry);
+        expect(registry.get('user')).toBeDefined();
+        expect(registry.get('roleDetail')).toBeDefined();
+
+        // the hand-written schema takes precedence over derivation
+        expect(registry.get('realm')).toBe(realmSchema);
+    });
+
+    it('should fail on schema options for an already registered schema', () => {
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema({ name: 'realm' }));
+
+        expect(() => createSchemaRegistryFromDataSource(dataSource, {
+            registry,
+            schemas: { realm: {} },
+        })).toThrow('already registered');
     });
 
     it('should fail on schema options for an unknown entity', () => {

--- a/packages/typeorm/test/unit/schema/module.spec.ts
+++ b/packages/typeorm/test/unit/schema/module.spec.ts
@@ -16,8 +16,8 @@ import {
 } from 'typeorm';
 import {
     buildEntitySchemaName,
-    defineSchemaFromEntity,
     defineSchemaRegistryWithDataSource,
+    defineSchemaWithEntity,
 } from '../../../src';
 import { createDataSourceOptions, createUnconnectedDataSource } from '../../data/factory';
 import { Realm } from '../../data/entity/realm';
@@ -57,12 +57,12 @@ describe('src/schema/*.ts', () => {
         expect(buildEntitySchemaName('RoleDetail')).toEqual('roleDetail');
         expect(buildEntitySchemaName(dataSource.getMetadata(RoleDetail))).toEqual('roleDetail');
 
-        const schema = defineSchemaFromEntity(RoleDetail, dataSource);
+        const schema = defineSchemaWithEntity(RoleDetail, dataSource);
         expect(schema.name).toEqual('roleDetail');
     });
 
     it('should derive structure (relations + schemaMapping) by default', () => {
-        const schema = defineSchemaFromEntity(User, dataSource);
+        const schema = defineSchemaWithEntity(User, dataSource);
 
         expect(schema.name).toEqual('user');
         expect(schema.relations.allowed).toEqual(['role', 'realm']);
@@ -74,13 +74,13 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should accept entity metadata as input', () => {
-        const schema = defineSchemaFromEntity(dataSource.getMetadata(User));
+        const schema = defineSchemaWithEntity(dataSource.getMetadata(User));
 
         expect(schema.name).toEqual('user');
     });
 
     it('should derive column allow-lists on opt-in', () => {
-        const schema = defineSchemaFromEntity(User, dataSource, {
+        const schema = defineSchemaWithEntity(User, dataSource, {
             filters: { allowed: 'columns' },
             sort: { allowed: 'columns' },
         });
@@ -97,13 +97,13 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should exclude hidden and virtual join columns from derived lists', () => {
-        const schema = defineSchemaFromEntity(Article, articleDataSource, { filters: { allowed: 'columns' } });
+        const schema = defineSchemaWithEntity(Article, articleDataSource, { filters: { allowed: 'columns' } });
 
         expect(schema.filters.allowed).toEqual(['id', 'title']);
     });
 
     it('should prioritize explicit options over derived values', () => {
-        const schema = defineSchemaFromEntity(User, dataSource, {
+        const schema = defineSchemaWithEntity(User, dataSource, {
             name: 'account',
             strict: true,
             schemaMapping: { realm: 'customRealm' },

--- a/packages/typeorm/test/unit/schema/module.spec.ts
+++ b/packages/typeorm/test/unit/schema/module.spec.ts
@@ -16,8 +16,8 @@ import {
 } from 'typeorm';
 import {
     buildEntitySchemaName,
-    createSchemaRegistryFromDataSource,
     defineSchemaFromEntity,
+    defineSchemaRegistryWithDataSource,
 } from '../../../src';
 import { createDataSourceOptions, createUnconnectedDataSource } from '../../data/factory';
 import { Realm } from '../../data/entity/realm';
@@ -120,7 +120,7 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should build a registry for all data source entities', () => {
-        const registry = createSchemaRegistryFromDataSource(dataSource);
+        const registry = defineSchemaRegistryWithDataSource(dataSource);
 
         expect(registry.get('user')).toBeDefined();
         expect(registry.get('role')).toBeDefined();
@@ -129,7 +129,7 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should resolve relation traversal across derived schemas', () => {
-        const registry = createSchemaRegistryFromDataSource(dataSource);
+        const registry = defineSchemaRegistryWithDataSource(dataSource);
         const parser = new SimpleParser(registry);
 
         // "detail" resolves to the "roleDetail" schema via the derived schemaMapping
@@ -139,7 +139,7 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should apply per-entity options keyed by schema name', () => {
-        const registry = createSchemaRegistryFromDataSource(dataSource, { schemas: { user: { filters: { allowed: 'columns' } } } });
+        const registry = defineSchemaRegistryWithDataSource(dataSource, { schemas: { user: { filters: { allowed: 'columns' } } } });
 
         const schema = registry.getOrFail('user');
         expect(schema.filters.allowed).toContain('email');
@@ -149,7 +149,7 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should apply per-entity options keyed by entity class', () => {
-        const registry = createSchemaRegistryFromDataSource(dataSource, {
+        const registry = defineSchemaRegistryWithDataSource(dataSource, {
             schemas: new Map([
                 [User, { filters: { allowed: 'columns' as const } }],
             ]),
@@ -167,7 +167,7 @@ describe('src/schema/*.ts', () => {
         });
         registry.add(realmSchema);
 
-        const output = createSchemaRegistryFromDataSource(dataSource, { registry });
+        const output = defineSchemaRegistryWithDataSource(dataSource, { registry });
 
         expect(output).toBe(registry);
         expect(registry.get('user')).toBeDefined();
@@ -181,13 +181,13 @@ describe('src/schema/*.ts', () => {
         const registry = new SchemaRegistry();
         registry.add(defineSchema({ name: 'realm' }));
 
-        expect(() => createSchemaRegistryFromDataSource(dataSource, {
+        expect(() => defineSchemaRegistryWithDataSource(dataSource, {
             registry,
             schemas: { realm: {} },
         })).toThrow('already registered');
     });
 
     it('should fail on schema options for an unknown entity', () => {
-        expect(() => createSchemaRegistryFromDataSource(dataSource, { schemas: { unknownEntity: {} } })).toThrow('unknownEntity');
+        expect(() => defineSchemaRegistryWithDataSource(dataSource, { schemas: { unknownEntity: {} } })).toThrow('unknownEntity');
     });
 });

--- a/packages/typeorm/test/unit/schema/module.spec.ts
+++ b/packages/typeorm/test/unit/schema/module.spec.ts
@@ -83,8 +83,8 @@ describe('src/schema/*.ts', () => {
 
     it('should derive column allow-lists on opt-in', () => {
         const schema = defineSchemaWithEntity(User, dataSource, {
-            filters: { allowed: 'columns' },
-            sort: { allowed: 'columns' },
+            filters: { allowed: 'inherit' },
+            sort: { allowed: 'inherit' },
         });
 
         expect(schema.filters.allowed).toContain('id');
@@ -99,7 +99,7 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should exclude hidden and virtual join columns from derived lists', () => {
-        const schema = defineSchemaWithEntity(Article, articleDataSource, { filters: { allowed: 'columns' } });
+        const schema = defineSchemaWithEntity(Article, articleDataSource, { filters: { allowed: 'inherit' } });
 
         expect(schema.filters.allowed).toEqual(['id', 'title']);
     });
@@ -141,7 +141,7 @@ describe('src/schema/*.ts', () => {
     });
 
     it('should apply per-entity options keyed by schema name', () => {
-        const registry = defineSchemaRegistryWithDataSource(dataSource, { schemas: { user: { filters: { allowed: 'columns' } } } });
+        const registry = defineSchemaRegistryWithDataSource(dataSource, { schemas: { user: { filters: { allowed: 'inherit' } } } });
 
         const schema = registry.getOrFail('user');
         expect(schema.filters.allowed).toContain('email');
@@ -153,7 +153,7 @@ describe('src/schema/*.ts', () => {
     it('should apply per-entity options keyed by entity class', () => {
         const registry = defineSchemaRegistryWithDataSource(dataSource, {
             schemas: new Map([
-                [User, { filters: { allowed: 'columns' as const } }],
+                [User, { filters: { allowed: 'inherit' as const } }],
             ]),
         });
 


### PR DESCRIPTION
## Summary

New `schema/` module in `@rapiq/typeorm`: derive rapiq schemas and their registry linkage from TypeORM `EntityMetadata` instead of hand-maintaining them.

- **`defineSchemaWithEntity(target, dataSource, options?)`** — also accepts a built `EntityMetadata` directly. Structure is always derived: lower-camel schema name (`RoleDetail` → `roleDetail`), `relations.allowed` from relation property names, `schemaMapping` from each relation's `inverseEntityMetadata`.
- **Column allow-lists are opt-in** per parameter via the `allowed: 'columns'` sentinel — expands to the entity's column property paths. Hidden columns (`select: false`) and virtual join columns are always excluded; explicitly declared FK columns (e.g. `realm_id`) are included. Explicit options always win over derived values.
- **`defineSchemaRegistryWithDataSource(dataSource, { schemas?, registry? })`** — one schema per entity (junction/closure-junction metadata skipped), cross-linked by construction so nested paths like `role.detail` resolve without manual wiring. Per-entity `schemas` options are keyed by derived name or by entity class (`Map`); an options key matching no entity throws, so renames fail loudly.
- **Extending an existing registry**: pass `registry` to fill in derived schemas around hand-written ones — already-registered names take precedence (the entity is skipped), and `schemas` options targeting a skipped name throw instead of being silently ignored.
- Derivation never sets `strict`; the docs call out the `strict: true` + `allowed: 'columns'` interplay explicitly.

```typescript
const registry = defineSchemaRegistryWithDataSource(dataSource, {
    schemas: {
        user: {
            filters: { allowed: 'columns' },
            sort: { allowed: 'columns' },
        },
    },
});
```

Docs: new "Deriving schemas from entities" section in `packages/docs/packages/typeorm.md`.

Context: this is the successor feature to typeorm-extension's rapiq integration, which is being removed in its v4 (tada5hi/typeorm-extension#1411).

## Notes

- Registry failure modes (duplicate derived name, unknown/inapplicable options key) currently throw plain `Error`; a typed error class is a follow-up.
- Entity decorators were considered and deliberately deferred — metadata + the options object cover the same ground without the `experimentalDecorators` toolchain friction.

## Tests

13 new specs in `packages/typeorm/test/unit/schema/module.spec.ts` — derivation rules, precedence, both registry keying styles, registry extension, and end-to-end cross-schema relation traversal through `SimpleParser`. Edge cases (`select: false`, virtual join columns) use a spec-local entity; the shared fixtures are untouched. Package suite: 88/88.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced TypeORM integration to automatically derive schemas and build schema registries from entity metadata.
  * Supports derivation of schema names, relation mapping, and column-based allow-lists (with an opt-in “inherit” mechanism).
  * Added entity-targeted schema options, override precedence, and the ability to extend existing registries safely.
* **Documentation**
  * Added a new guide section covering deriving schemas from entities, allow-list rules, override behavior, and required metadata setup.
* **Tests**
  * Added unit tests covering derivation, registry behavior, overrides, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->