### PR TITLE
feat(memory): accept boolean for caseSensitive filter option

### DIFF
--- a/packages/docs/packages/memory.md
+++ b/packages/docs/packages/memory.md
@@ -80,6 +80,14 @@ applyQuery(query, users, { filters: { caseSensitive: ['id'] } });
 compileFilters(eq('id', 'aBc'), { caseSensitive: ['id'] });
 ```
 
+`caseSensitive: true` keeps **every** equality comparison exact (byte-exact strings) — for evaluating arbitrary condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies:
+
+```typescript
+compileFilters(condition, { caseSensitive: true });
+```
+
+The boolean only governs the equality family — `contains`/`startsWith`/`endsWith` stay case-insensitive, exactly like the list form. `caseSensitive: false` equals the default.
+
 ### Join-row binding
 
 Dotted paths emulate the SQL adapter's joins: all conditions on one relation path bind to the **same array element**, and the record matches if *some* assignment of elements satisfies the whole filter tree. An empty or absent array contributes one all-`null` row, like a LEFT JOIN.

--- a/packages/memory/src/parameter/filters/compiler.ts
+++ b/packages/memory/src/parameter/filters/compiler.ts
@@ -61,6 +61,8 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
 
     protected scopeSequence : number;
 
+    protected caseSensitiveAll : boolean;
+
     protected caseSensitiveFields : Set<string>;
 
     constructor(options: FiltersVisitorOptions = {}) {
@@ -68,7 +70,10 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
         this.fieldPrefix = '';
         this.bindingPrefix = '';
         this.scopeSequence = 0;
-        this.caseSensitiveFields = new Set(options.caseSensitive || []);
+        this.caseSensitiveAll = options.caseSensitive === true;
+        this.caseSensitiveFields = new Set(
+            Array.isArray(options.caseSensitive) ? options.caseSensitive : [],
+        );
     }
 
     // -----------------------------------------------------------
@@ -309,14 +314,15 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
     /**
      * Single-value equality: string conditions compare case-insensitively
      * (mirroring the SQL adapter's lower()-wrapped rendering) unless the
-     * field is opted out via the `caseSensitive` option.
+     * field is opted out via the `caseSensitive` option — either listed
+     * by key or globally via `caseSensitive: true`.
      */
     protected buildValueEqualTest(input: unknown, field: string) : ValueTest {
         const condition = normalizeValue(input);
 
         if (
             typeof condition === 'string' &&
-            !this.caseSensitiveFields.has(`${this.fieldPrefix}${field}`)
+            !this.isCaseSensitive(field)
         ) {
             const lowered = condition.toLowerCase();
 
@@ -325,6 +331,11 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
         }
 
         return (value) => isValueEqual(value, condition);
+    }
+
+    protected isCaseSensitive(field: string) : boolean {
+        return this.caseSensitiveAll ||
+            this.caseSensitiveFields.has(`${this.fieldPrefix}${field}`);
     }
 
     protected buildCompareTest(input: unknown, min: number, max: number) : ValueTest {

--- a/packages/memory/src/parameter/filters/types.ts
+++ b/packages/memory/src/parameter/filters/types.ts
@@ -27,6 +27,10 @@ export type FiltersVisitorOptions = {
      * case-sensitive instead of the case-insensitive default —
      * e.g. identifier or token columns. Typically forwarded from
      * a schema's `filters.caseSensitive` list.
+     *
+     * `true` keeps every equality comparison case-sensitive
+     * (byte-exact), for evaluating arbitrary condition trees whose
+     * field keys aren't known upfront. `false` equals the default.
      */
-    caseSensitive?: string[],
+    caseSensitive?: string[] | boolean,
 };

--- a/packages/memory/test/unit/filters/case-sensitivity.spec.ts
+++ b/packages/memory/test/unit/filters/case-sensitivity.spec.ts
@@ -6,6 +6,8 @@
  */
 
 import {
+    contains,
+    elemMatch,
     eq,
     inArray,
     ne,
@@ -64,5 +66,72 @@ describe('filters: equality case sensitivity', () => {
 
         expect(predicate({ id: 'aBc' })).toBeTruthy();
         expect(predicate({ id: 'abc' })).toBeFalsy();
+    });
+
+    it('should keep every field exact with caseSensitive true', () => {
+        const predicate = compileFilters(eq('name', 'super hero'), { caseSensitive: true });
+
+        expect(predicate({ name: 'super hero' })).toBeTruthy();
+        expect(predicate({ name: 'Super Hero' })).toBeFalsy();
+    });
+
+    it('should complement ne exactly with caseSensitive true', () => {
+        const predicate = compileFilters(ne('name', 'super hero'), { caseSensitive: true });
+
+        expect(predicate({ name: 'super hero' })).toBeFalsy();
+        expect(predicate({ name: 'Super Hero' })).toBeTruthy();
+    });
+
+    it('should keep in members exact with caseSensitive true', () => {
+        const predicate = compileFilters(
+            inArray('status', ['Active', 'Pending']),
+            { caseSensitive: true },
+        );
+
+        expect(predicate({ status: 'Active' })).toBeTruthy();
+        expect(predicate({ status: 'active' })).toBeFalsy();
+        expect(predicate({ status: 'PENDING' })).toBeFalsy();
+    });
+
+    it('should complement nin exactly with caseSensitive true', () => {
+        const predicate = compileFilters(nin('status', ['Active']), { caseSensitive: true });
+
+        expect(predicate({ status: 'Active' })).toBeFalsy();
+        expect(predicate({ status: 'active' })).toBeTruthy();
+    });
+
+    it('should keep dotted paths exact with caseSensitive true', () => {
+        const predicate = compileFilters(eq('items.name', 'sword'), { caseSensitive: true });
+
+        expect(predicate({ items: [{ name: 'sword' }] })).toBeTruthy();
+        expect(predicate({ items: [{ name: 'Sword' }] })).toBeFalsy();
+    });
+
+    it('should keep elemMatch interiors exact with caseSensitive true', () => {
+        const predicate = compileFilters(
+            elemMatch('items', eq('name', 'sword')),
+            { caseSensitive: true },
+        );
+
+        expect(predicate({ items: [{ name: 'sword' }] })).toBeTruthy();
+        expect(predicate({ items: [{ name: 'Sword' }] })).toBeFalsy();
+    });
+
+    it('should not affect the contains family with caseSensitive true', () => {
+        // contains/startsWith/endsWith stay case-insensitive — the
+        // caseSensitive option only governs the equality family,
+        // matching the per-field list semantics.
+        const predicate = compileFilters(contains('name', 'eter'), { caseSensitive: true });
+
+        expect(predicate({ name: 'Peter' })).toBeTruthy();
+        expect(predicate({ name: 'PETER' })).toBeTruthy();
+    });
+
+    it('should stay case-insensitive with caseSensitive false', () => {
+        const predicate = compileFilters(eq('name', 'super hero'), { caseSensitive: false });
+
+        expect(predicate({ name: 'Super Hero' })).toBeTruthy();
+        expect(predicate({ name: 'sUpEr HeRo' })).toBeTruthy();
+        expect(predicate({ name: 'super' })).toBeFalsy();
     });
 });


### PR DESCRIPTION
## Motivation

`FiltersVisitorOptions.caseSensitive` in `@rapiq/memory` only accepted a field-key list. Evaluators that compile arbitrary, caller-supplied condition trees (e.g. authup's ABAC attributes policy, which replaced `@ucast/mongo2js` with `MongoFiltersParser` + `compileFilters`) want ucast-style byte-exact equality for every field — they cannot know the keys upfront and had to walk the parsed tree to collect all leaf fields first:

```ts
const condition = parser.parse(policy.query);
const testIt = compileFilters(condition, {
    caseSensitive: collectConditionFields(condition), // boilerplate
});
```

## What changed

- `FiltersVisitorOptions.caseSensitive` is widened to `string[] | boolean` (`packages/memory/src/parameter/filters/types.ts`). The option threads unchanged through `compileFilters`, `compileQuery`, `applyQuery` and `QueryVisitorOptions.filters`.
- `FiltersCompiler` (`packages/memory/src/parameter/filters/compiler.ts`) tracks a `caseSensitiveAll` flag next to the existing field set; the equality builder consults a new `isCaseSensitive(field)` helper (`caseSensitiveAll || set.has(prefix + field)`).
- Semantics:
  - `true` — every equality comparison (`eq`/`ne`/`in`/`nin`) stays byte-exact, including dotted paths and `elemMatch` interiors.
  - `false` / absent — identical to today (case-insensitive default).
  - list form — unchanged.
  - the `contains` family is untouched by the boolean, exactly matching the per-field list semantics (the list never affected it).
- Schema forwarding (`filters.caseSensitive`) stays list-based; the core schema type is untouched.
- Docs: `packages/docs/packages/memory.md` documents the boolean form.

## Testing

- New specs in `packages/memory/test/unit/filters/case-sensitivity.spec.ts`: boolean-true exactness for eq/ne/in/nin, dotted paths and elemMatch interiors; contains stays case-insensitive under `true`; `false` and the list form keep current behavior.
- `npx nx run @rapiq/memory:build` — clean.
- `npm run test --workspace=packages/memory` — 139 tests, 11 files, all passing.
- `npx eslint` on changed files — clean.

Closes #775