### PR TITLE
feat(core): forward DEPTH generic through QueryBuildInput

### DIFF
--- a/packages/core/src/build/module.ts
+++ b/packages/core/src/build/module.ts
@@ -25,7 +25,8 @@ import type { QueryBuildInput } from './types';
 export function defineQuery(input?: QueryBuildInput<ObjectLiteral>) : Query;
 export function defineQuery<
     RECORD extends ObjectLiteral,
->(input?: QueryBuildInput<RECORD>) : Query;
+    DEPTH extends number = 5,
+>(input?: QueryBuildInput<RECORD, DEPTH>) : Query;
 export function defineQuery(input: QueryBuildInput<ObjectLiteral> = {}) : Query {
     const context : QueryContext = {};
 

--- a/packages/core/src/build/types.ts
+++ b/packages/core/src/build/types.ts
@@ -25,13 +25,18 @@ import type {
  * Keys are the canonical {@link Parameter} names. Every parameter accepts
  * either raw build input or an already-built AST fragment (the define*
  * factories return the latter), so fragments assign without casts.
+ *
+ * DEPTH bounds the recursive per-parameter input types (default 5, like
+ * the per-parameter Build*Input types). Lower it for self-recursive
+ * record types whose inferred input type would otherwise grow too large.
  */
 export type QueryBuildInput<
     RECORD extends ObjectLiteral = ObjectLiteral,
+    DEPTH extends number = 5,
 > = {
-    fields?: FieldsBuildInput<RECORD> | IFields,
-    filters?: FiltersBuildInput<RECORD> | ICondition,
+    fields?: FieldsBuildInput<RECORD, DEPTH> | IFields,
+    filters?: FiltersBuildInput<RECORD, DEPTH> | ICondition,
     pagination?: PaginationBuildInput | IPagination,
-    relations?: RelationsBuildInput<RECORD> | IRelations,
-    sort?: SortsBuildInput<RECORD> | ISorts,
+    relations?: RelationsBuildInput<RECORD, DEPTH> | IRelations,
+    sort?: SortsBuildInput<RECORD, DEPTH> | ISorts,
 };

--- a/packages/core/test/unit/build/module.spec.ts
+++ b/packages/core/test/unit/build/module.spec.ts
@@ -5,7 +5,7 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
-import type { IFilter } from '../../../src';
+import type { IFilter, QueryBuildInput } from '../../../src';
 import {
     BuildError,
     ErrorCode,
@@ -408,5 +408,50 @@ describe('src/build/module.ts', () => {
 
         const output = defineQuery<User>({ filters });
         expect(output.filters).toBe(filters);
+    });
+
+    it('should accept a shallow DEPTH for self-recursive record types', () => {
+        type TreeNode = {
+            id: string,
+            name: string,
+            children: TreeNode[],
+        };
+
+        // compile-level: an explicit shallow DEPTH bounds the recursive
+        // input types while flat keys stay expressible.
+        const input : QueryBuildInput<TreeNode, 1> = {
+            fields: ['id', 'name'],
+            filters: { name: 'root' },
+            relations: { children: true },
+            sort: '-name',
+            pagination: { limit: 5 },
+        };
+
+        const output = defineQuery<TreeNode, 1>(input);
+
+        expect(output.fields.value.map((el) => el.name)).toEqual(['id', 'name']);
+        expect(leafs(output.filters)).toHaveLength(1);
+        expect(output.relations.value.map((el) => el.name)).toEqual(['children']);
+        expect(output.sorts.value.map((el) => [el.name, el.operator])).toEqual([
+            ['name', SortDirection.DESC],
+        ]);
+        expect(output.pagination.limit).toBe(5);
+    });
+
+    it('should keep the default DEPTH when the generic is omitted', () => {
+        // compile-level: QueryBuildInput<RECORD> still equals
+        // QueryBuildInput<RECORD, 5> — nested notations keep working.
+        const input : QueryBuildInput<User> = {
+            filters: { 'realm.id': 1 },
+            sort: { realm: { name: 'DESC' } },
+        };
+        const explicit : QueryBuildInput<User, 5> = input;
+
+        const output = defineQuery<User>(explicit);
+
+        expect(leafs(output.filters)).toHaveLength(1);
+        expect(output.sorts.value.map((el) => [el.name, el.operator])).toEqual([
+            ['realm.name', SortDirection.DESC],
+        ]);
     });
 });

--- a/packages/docs/guide/building-queries.md
+++ b/packages/docs/guide/building-queries.md
@@ -16,6 +16,8 @@ const query = defineQuery<User>({
 
 Supplying a record generic (`defineQuery<User>`) types every field path (`'realm.name'`, …) with autocomplete; without one, plain strings are accepted.
 
+The input types recurse through nested records up to a default depth of 5. For self-recursive record types (`type Category = { children: Category[] }`) the inferred input type can outgrow what the compiler will serialize — pass an explicit depth as the second generic to bound it: `defineQuery<Category, 2>(...)`, `QueryBuildInput<Category, 2>`.
+
 ::: info No validation here
 The build layer constructs the query verbatim. What a client *may* request is decided on the receiving side, where parsers validate against a [Schema](/guide/schemas). Keeping the two concerns apart is deliberate: the caller doesn't need the schema, and the receiver never trusts the caller.
 :::


### PR DESCRIPTION
## Motivation

Every per-parameter build input (`FieldsBuildInput`, `FiltersBuildInput`, `RelationsBuildInput`, `SortsBuildInput`) accepts a `DEPTH` generic (default `5`), but the aggregate `QueryBuildInput<RECORD>` did not forward it. For self-recursive record types (e.g. `type Policy = { children: Policy[] }`) the depth-5 default explodes the inferred type as soon as `QueryBuildInput<Policy>` appears in a serialized position (Vue prop types), hitting TS7056 ("inferred type exceeds the maximum length the compiler will serialize"). Consumers had to hand-roll a depth-bounded aggregate.

## What changed

- `QueryBuildInput` (`packages/core/src/build/types.ts`) gains an optional `DEPTH extends number = 5` generic, forwarded to the fields/filters/relations/sort members (pagination has no depth). The default mirrors the per-parameter defaults, so omitting `DEPTH` is behavior-identical.
- The generic `defineQuery` overload (`packages/core/src/build/module.ts`) forwards the same generic, so callers can write `defineQuery<Policy, 3>({ ... })`. The untyped overload and the implementation are untouched.
- Docs: `packages/docs/guide/building-queries.md` notes the depth generic next to the record-generic explanation.

Purely additive generic plumbing — the recursive key-path types (`NestedKeys` etc.) are not touched.

## Testing

- New compile-level + runtime specs in `packages/core/test/unit/build/module.spec.ts`: a self-recursive `TreeNode` type with `QueryBuildInput<TreeNode, 1>` / `defineQuery<TreeNode, 1>` (flat keys stay expressible at shallow depth), and a default-depth assignment check (`QueryBuildInput<User>` ≡ `QueryBuildInput<User, 5>`, nested notations keep working).
- `npx nx run-many -t build` — all 9 projects build (downstream packages type-check against core's dist).
- `npx nx run-many -t test --skip-nx-cache` — all 8 test projects pass (core: 196 tests).
- `npx eslint` clean on changed files.

Closes #776
