### PR TITLE
feat(core): export AST node guard family

### DIFF
--- a/packages/core/src/build/index.ts
+++ b/packages/core/src/build/index.ts
@@ -8,3 +8,4 @@
 export * from './parameter';
 export * from './module';
 export * from './types';
+export * from './utils';

--- a/packages/core/src/build/utils.ts
+++ b/packages/core/src/build/utils.ts
@@ -7,7 +7,7 @@
 
 import { isObject } from '../utils';
 
-type ParameterNode = { accept: (visitor: any) => any };
+export type ParameterNode = { accept: (visitor: any) => any };
 
 /**
  * Every AST parameter node (Fields, Filters, Filter, Pagination, ...)

--- a/packages/core/src/parameter/check.ts
+++ b/packages/core/src/parameter/check.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../utils';
+import type { IQuery, IQueryVisitor } from './types';
+
+/**
+ * A `Query` node is identified by its visitor dispatch: accept() of a
+ * query node calls visitQuery and nothing else. Works across package
+ * instances, where instanceof fails.
+ */
+export function isQuery(input: unknown) : input is IQuery {
+    return dispatchesTo<IQueryVisitor<unknown>>(input, 'visitQuery');
+}

--- a/packages/core/src/parameter/fields/collection/check.ts
+++ b/packages/core/src/parameter/fields/collection/check.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../../utils';
+import type { IFields, IFieldsVisitor } from './types';
+
+/**
+ * A `Fields` collection is identified by its visitor dispatch: accept()
+ * of a fields node calls visitFields and nothing else. Works across
+ * package instances, where instanceof fails, and distinguishes the
+ * structurally identical collection nodes (Fields, Sorts, ...).
+ */
+export function isFields(input: unknown) : input is IFields {
+    return dispatchesTo<IFieldsVisitor<unknown>>(input, 'visitFields');
+}

--- a/packages/core/src/parameter/fields/collection/index.ts
+++ b/packages/core/src/parameter/fields/collection/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './module';
 export * from './types';

--- a/packages/core/src/parameter/fields/record/check.ts
+++ b/packages/core/src/parameter/fields/record/check.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../../utils';
+import type { IField, IFieldVisitor } from './types';
+
+/**
+ * A `Field` record is identified by its visitor dispatch: accept() of a
+ * field node calls visitField and nothing else. Works across package
+ * instances, where instanceof fails, and distinguishes the structurally
+ * overlapping record nodes (Field, Sort, Relation).
+ */
+export function isField(input: unknown) : input is IField {
+    return dispatchesTo<IFieldVisitor<unknown>>(input, 'visitField');
+}

--- a/packages/core/src/parameter/fields/record/index.ts
+++ b/packages/core/src/parameter/fields/record/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './module';
 export * from './types';

--- a/packages/core/src/parameter/index.ts
+++ b/packages/core/src/parameter/index.ts
@@ -11,6 +11,7 @@ export * from './pagination';
 export * from './relations';
 export * from './sorts';
 
+export * from './check';
 export * from './merge';
 export * from './module';
 export * from './types';

--- a/packages/core/src/parameter/pagination/check.ts
+++ b/packages/core/src/parameter/pagination/check.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../utils';
+import type { IPagination, IPaginationVisitor } from './types';
+
+/**
+ * A `Pagination` node is identified by its visitor dispatch: accept()
+ * of a pagination node calls visitPagination and nothing else. Works
+ * across package instances, where instanceof fails.
+ */
+export function isPagination(input: unknown) : input is IPagination {
+    return dispatchesTo<IPaginationVisitor<unknown>>(input, 'visitPagination');
+}

--- a/packages/core/src/parameter/pagination/index.ts
+++ b/packages/core/src/parameter/pagination/index.ts
@@ -5,5 +5,6 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './pagination';
 export * from './types';

--- a/packages/core/src/parameter/relations/collection/check.ts
+++ b/packages/core/src/parameter/relations/collection/check.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../../utils';
+import type { IRelations, IRelationsVisitor } from './types';
+
+/**
+ * A `Relations` collection is identified by its visitor dispatch:
+ * accept() of a relations node calls visitRelations and nothing else.
+ * Works across package instances, where instanceof fails, and
+ * distinguishes the structurally identical collection nodes
+ * (Relations, Sorts, ...).
+ */
+export function isRelations(input: unknown) : input is IRelations {
+    return dispatchesTo<IRelationsVisitor<unknown>>(input, 'visitRelations');
+}

--- a/packages/core/src/parameter/relations/collection/index.ts
+++ b/packages/core/src/parameter/relations/collection/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './module';
 export * from './types';

--- a/packages/core/src/parameter/relations/record/check.ts
+++ b/packages/core/src/parameter/relations/record/check.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../../utils';
+import type { IRelation, IRelationVisitor } from './types';
+
+/**
+ * A `Relation` record is identified by its visitor dispatch: accept()
+ * of a relation node calls visitRelation and nothing else. Works across
+ * package instances, where instanceof fails, and distinguishes the
+ * structurally overlapping record nodes (Relation, Field, Sort).
+ */
+export function isRelation(input: unknown) : input is IRelation {
+    return dispatchesTo<IRelationVisitor<unknown>>(input, 'visitRelation');
+}

--- a/packages/core/src/parameter/relations/record/index.ts
+++ b/packages/core/src/parameter/relations/record/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './module';
 export * from './types';

--- a/packages/core/src/parameter/sorts/collection/check.ts
+++ b/packages/core/src/parameter/sorts/collection/check.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../../utils';
+import type { ISorts, ISortsVisitor } from './types';
+
+/**
+ * A `Sorts` collection is identified by its visitor dispatch: accept()
+ * of a sorts node calls visitSorts and nothing else. Works across
+ * package instances, where instanceof fails, and distinguishes the
+ * structurally identical collection nodes (Sorts, Fields, ...).
+ */
+export function isSorts(input: unknown) : input is ISorts {
+    return dispatchesTo<ISortsVisitor<unknown>>(input, 'visitSorts');
+}

--- a/packages/core/src/parameter/sorts/collection/index.ts
+++ b/packages/core/src/parameter/sorts/collection/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './module';
 export * from './types';

--- a/packages/core/src/parameter/sorts/record/check.ts
+++ b/packages/core/src/parameter/sorts/record/check.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { dispatchesTo } from '../../../utils';
+import type { ISort, ISortVisitor } from './types';
+
+/**
+ * A `Sort` record is identified by its visitor dispatch: accept() of a
+ * sort node calls visitSort and nothing else. Works across package
+ * instances, where instanceof fails, and distinguishes the structurally
+ * overlapping record nodes (Sort, Field, Relation).
+ */
+export function isSort(input: unknown) : input is ISort {
+    return dispatchesTo<ISortVisitor<unknown>>(input, 'visitSort');
+}

--- a/packages/core/src/parameter/sorts/record/index.ts
+++ b/packages/core/src/parameter/sorts/record/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './check';
 export * from './module';
 export * from './types';

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -9,4 +9,5 @@ export * from './mapping';
 export * from './key';
 export * from './relation';
 export * from './object';
+export * from './visitor';
 export * from './property-name';

--- a/packages/core/src/utils/visitor.ts
+++ b/packages/core/src/utils/visitor.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import { isObject } from './object';
+
+/**
+ * Check whether the input is an AST node dispatching to the given
+ * visitor method. Every node's accept() performs double dispatch to
+ * exactly one visit* method, so the dispatch target identifies the
+ * node kind — reliably across package instances (where instanceof
+ * fails) and for structurally identical nodes (e.g. Fields & Sorts),
+ * which member checks cannot tell apart.
+ */
+export function dispatchesTo<VISITOR>(
+    input: unknown,
+    method: keyof VISITOR & string,
+) : boolean {
+    if (
+        !isObject(input) ||
+        typeof input.accept !== 'function'
+    ) {
+        return false;
+    }
+
+    let output = false;
+
+    const visitor = {
+        [method]: () => {
+            output = true;
+        },
+    };
+
+    try {
+        input.accept(visitor);
+    } catch {
+        // a foreign node dispatches to a visit* method
+        // the probe visitor does not implement.
+    }
+
+    return output;
+}

--- a/packages/core/test/unit/parameter/check.spec.ts
+++ b/packages/core/test/unit/parameter/check.spec.ts
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    Fields,
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+    Pagination,
+    Query,
+    Relation,
+    Relations,
+    Sort,
+    Sorts,
+    defineQuery,
+    isField,
+    isFields,
+    isFilter,
+    isFilters,
+    isPagination,
+    isParameterNode,
+    isQuery,
+    isRelation,
+    isRelations,
+    isSort,
+    isSorts,
+} from '../../../src';
+
+const guards = {
+    query: isQuery,
+    fields: isFields,
+    field: isField,
+    filters: isFilters,
+    filter: isFilter,
+    pagination: isPagination,
+    relations: isRelations,
+    relation: isRelation,
+    sorts: isSorts,
+    sort: isSort,
+} as const;
+
+const nodes = {
+    query: new Query(),
+    fields: new Fields([new Field('id')]),
+    field: new Field('id'),
+    filters: new Filters(FilterCompoundOperator.AND, [
+        new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+    ]),
+    filter: new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+    pagination: new Pagination(10, 0),
+    relations: new Relations([new Relation('realm')]),
+    relation: new Relation('realm'),
+    sorts: new Sorts([new Sort('name', 'DESC')]),
+    sort: new Sort('name', 'DESC'),
+} as const;
+
+type NodeKey = keyof typeof nodes;
+
+describe('src/parameter/**/check.ts', () => {
+    describe('cross-family discrimination', () => {
+        const guardKeys = Object.keys(guards) as NodeKey[];
+        const nodeKeys = Object.keys(nodes) as NodeKey[];
+
+        for (const guardKey of guardKeys) {
+            for (const nodeKey of nodeKeys) {
+                const expected = guardKey === nodeKey;
+
+                it(`is${expected ? '' : ' not'}: ${guardKey} guard x ${nodeKey} node`, () => {
+                    expect(guards[guardKey](nodes[nodeKey] as any)).toBe(expected);
+                });
+            }
+        }
+    });
+
+    describe('empty collections', () => {
+        it('should distinguish structurally identical empty collections', () => {
+            expect(isFields(new Fields())).toBe(true);
+            expect(isSorts(new Fields())).toBe(false);
+            expect(isRelations(new Fields())).toBe(false);
+
+            expect(isSorts(new Sorts())).toBe(true);
+            expect(isFields(new Sorts())).toBe(false);
+            expect(isRelations(new Sorts())).toBe(false);
+
+            expect(isRelations(new Relations())).toBe(true);
+            expect(isFields(new Relations())).toBe(false);
+            expect(isSorts(new Relations())).toBe(false);
+        });
+
+        it('should recognize a pagination node without limit & offset', () => {
+            expect(isPagination(new Pagination())).toBe(true);
+        });
+    });
+
+    describe('defineQuery output', () => {
+        const query = defineQuery({
+            fields: ['id', 'name'],
+            filters: { name: 'John' },
+            pagination: { limit: 10, offset: 0 },
+            relations: ['realm'],
+            sort: ['-name'],
+        });
+
+        it('should recognize the query node', () => {
+            expect(isQuery(query)).toBe(true);
+        });
+
+        it('should recognize the parameter nodes', () => {
+            expect(isFields(query.fields)).toBe(true);
+            expect(isFilters(query.filters)).toBe(true);
+            expect(isPagination(query.pagination)).toBe(true);
+            expect(isRelations(query.relations)).toBe(true);
+            expect(isSorts(query.sorts)).toBe(true);
+        });
+
+        it('should not confuse parameter nodes across families', () => {
+            expect(isSorts(query.fields)).toBe(false);
+            expect(isFields(query.sorts)).toBe(false);
+            expect(isQuery(query.filters)).toBe(false);
+            expect(isPagination(query)).toBe(false);
+        });
+    });
+
+    describe('build input & non-node values', () => {
+        it('should not recognize build input shapes', () => {
+            expect(isQuery({ fields: ['id'], filters: { name: 'John' } })).toBe(false);
+            expect(isFields(['id', 'name'])).toBe(false);
+            expect(isSorts(['-name'])).toBe(false);
+            expect(isSorts({ name: 'DESC' })).toBe(false);
+            expect(isRelations(['realm'])).toBe(false);
+            expect(isPagination({ limit: 10, offset: 0 })).toBe(false);
+            expect(isField({ name: 'id' })).toBe(false);
+            expect(isSort({ name: 'name', operator: 'desc' })).toBe(false);
+            expect(isRelation({ name: 'realm' })).toBe(false);
+        });
+
+        it('should not recognize primitives & empty values', () => {
+            expect(isQuery(null)).toBe(false);
+            expect(isQuery(undefined)).toBe(false);
+            expect(isQuery('query')).toBe(false);
+            expect(isSorts(1)).toBe(false);
+            expect(isFields({})).toBe(false);
+        });
+
+        it('should not recognize objects with a non-dispatching accept', () => {
+            const fake = { accept: () => true };
+
+            expect(isQuery(fake)).toBe(false);
+            expect(isFields(fake)).toBe(false);
+            expect(isSorts(fake)).toBe(false);
+            expect(isRelations(fake)).toBe(false);
+            expect(isPagination(fake)).toBe(false);
+        });
+    });
+
+    describe('cross package instances', () => {
+        it('should recognize a foreign node by its dispatch', () => {
+            // simulates a node built by another copy of @rapiq/core:
+            // same duck-typed shape, different class identity.
+            const foreign = {
+                value: [],
+                accept: (visitor: { visitSorts: (input: unknown) => unknown }) => (
+                    visitor.visitSorts(foreign)
+                ),
+                merge: () => foreign,
+            };
+
+            expect(isSorts(foreign)).toBe(true);
+            expect(isFields(foreign)).toBe(false);
+        });
+    });
+
+    describe('isParameterNode', () => {
+        it('should recognize every AST node', () => {
+            const keys = Object.keys(nodes) as NodeKey[];
+            for (const key of keys) {
+                expect(isParameterNode(nodes[key])).toBe(true);
+            }
+        });
+
+        it('should not recognize plain input', () => {
+            expect(isParameterNode(null)).toBe(false);
+            expect(isParameterNode({})).toBe(false);
+            expect(isParameterNode({ accept: 'yes' })).toBe(false);
+            expect(isParameterNode(['id'])).toBe(false);
+        });
+    });
+});

--- a/packages/docs/guide/query-ast.md
+++ b/packages/docs/guide/query-ast.md
@@ -64,6 +64,29 @@ query.filters.accept(myFiltersVisitor); // single parameter
 
 This is how all three adapters work — [`@rapiq/sql`](/packages/sql) accumulates SQL fragments, [`@rapiq/typeorm`](/packages/typeorm) writes into a query builder, [`@rapiq/memory`](/packages/memory) returns compiled functions (`R = Predicate`). New backends are added by implementing visitors; core never changes.
 
+## Type guards
+
+Every node has a matching guard: `isQuery`, `isFields` / `isField`, `isFilters` / `isFilter`, `isRelations` / `isRelation`, `isSorts` / `isSort` and `isPagination`. They identify nodes by their visitor dispatch instead of `instanceof`, so they work across package instances (e.g. a query built by one copy of `@rapiq/core` and inspected by another) and reliably tell structurally identical nodes apart (an empty `Fields` and an empty `Sorts` carry the same members).
+
+Their typical use is narrowing an SDK surface that accepts either raw build input or an already-built node:
+
+```typescript
+import type { IQuery, QueryBuildInput } from '@rapiq/core';
+import { defineQuery, isQuery } from '@rapiq/core';
+
+function toQuery<T extends Record<string, any>>(
+    input: QueryBuildInput<T> | IQuery,
+) : IQuery {
+    if (isQuery(input)) {
+        return input;
+    }
+
+    return defineQuery(input);
+}
+```
+
+`isParameterNode` is the generic escape hatch — it accepts *any* AST node (everything carrying an `accept` method) without identifying its kind, separating built fragments from plain build input.
+
 ## Writing a custom parser: ResolutionScope
 
 Parsers resolve raw client keys through a `ResolutionScope` — an immutable handle on *one parameter of one schema under one failure policy*. It owns alias mapping, allow-list verdicts, relation traversal through the registry (`schemaMapping`-aware) and the throw-vs-drop policy, so a custom parser doesn't reimplement any of it:


### PR DESCRIPTION
## Motivation

`@rapiq/core` exports `isFilter`/`isFilters`, but no guards for the remaining AST nodes. Consumers accepting `QueryBuildInput<T> | IQuery` (SDK surfaces) or `SortsBuildInput<T> | ISorts` currently have to hand-roll duck-type guards — the authup rapiq-v2 migration needed two of these — and `instanceof` is not an option across package instances.

## What changed

- **New guard family** (`check.ts` next to each node, mirroring the `isFilter`/`isFilters` placement):
  - `isQuery` (`parameter/check.ts`)
  - `isFields` / `isField` (`parameter/fields/{collection,record}/check.ts`)
  - `isSorts` / `isSort` (`parameter/sorts/{collection,record}/check.ts`)
  - `isRelations` / `isRelation` (`parameter/relations/{collection,record}/check.ts`)
  - `isPagination` (`parameter/pagination/check.ts`)
- **Discrimination via visitor dispatch**: `IFields` and `ISorts` are structurally identical (`value` + `accept` + `merge`), so member duck-typing cannot tell them apart. Instead, the guards probe the node's own double dispatch — every node's `accept()` calls exactly one `visit*` method, so the dispatch target identifies the node kind precisely, across package instances and for empty collections. The shared internal helper lives in `utils/visitor.ts` (`dispatchesTo`, not exported); the visitor-method names are type-checked against the `I*Visitor` interfaces. An object with a non-dispatching `accept` (e.g. `{ accept: () => true }`) matches no guard.
- **`isParameterNode` made public** (re-exported from `build/index.ts`, incl. the `ParameterNode` type) as the generic escape hatch: any AST node vs. plain build input, without identifying the kind.
- **Docs**: new "Type guards" section in `packages/docs/guide/query-ast.md` with the `QueryBuildInput<T> | IQuery` narrowing example.

`isFilter`/`isFilters` keep their existing structural checks (hot parse path, shipped semantics incl. the optional `operator` argument of `isFilters`).

## Testing

- `packages/core/test/unit/parameter/check.spec.ts`: full guard x node cross-family matrix (10x10), empty-collection discrimination (`Fields` vs `Sorts` vs `Relations`), `defineQuery` output recognition, build-input shapes / primitives / fake-`accept` negatives, a simulated foreign-package node (duck-typed `accept` dispatching `visitSorts`), and `isParameterNode` positives/negatives.
- `npx nx run-many -t build` — all 9 projects build (downstream packages type-check against core's dist).
- `npx nx run-many -t test --skip-nx-cache` — all 8 test projects pass (core: 305 tests).
- `npx eslint` on all changed files — clean.

Closes #774
