### PR TITLE
feat(core): widen schema key types for nullable relations and JSON columns

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -22,16 +22,41 @@ export type KeyWithOptionalPrefix<T, O extends string> = T extends string ? (`${
 
 export type PrevIndex = [never, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
 
+/**
+ * A property counts as a leaf when it is scalar-like (Scalar, Date) or an
+ * index-signature record with no known literal keys (e.g. a JSON column
+ * typed Record<string, any>). `null`/`undefined` are stripped before the
+ * structural checks so nullable/optional columns resolve like their
+ * non-nullable counterparts.
+ */
+type IsLeafKeyValue<T> = T extends Scalar | Date ?
+    T :
+    T extends Record<PropertyKey, any> ?
+        string extends keyof T ?
+            T :
+            never :
+        never;
+
 export type SimpleKeys<
     T extends Record<PropertyKey, any>,
 > = {
-    [Key in keyof T & string]: T[Key] extends Scalar | Date ? `${Key}` : never;
+    [Key in keyof T & string]: NonNullable<T[Key]> extends IsLeafKeyValue<NonNullable<T[Key]>> ?
+        `${Key}` :
+        never;
 }[keyof T & string];
 
+/**
+ * A property is traversed as a nested branch only when it is a record with
+ * known literal keys. Index-signature records (e.g. JSON columns typed
+ * Record<string, any>) stay leaves — recursing into them would produce
+ * unbounded `${string}` key unions.
+ */
 type IsRecursiveKeyValue<T> = T extends Date ?
     never :
     T extends Record<PropertyKey, any> ?
-        T :
+        string extends keyof T ?
+            never :
+            T :
         never;
 
 export type NestedKeys<
@@ -39,27 +64,27 @@ export type NestedKeys<
     DEPTH extends number = 4,
 > = [DEPTH] extends [0] ? never :
     {
-        [Key in keyof T & string]: T[Key] extends Array<infer ELEMENT> ?
+        [Key in keyof T & string]: NonNullable<T[Key]> extends Array<infer ELEMENT> ?
             (
-                ELEMENT extends IsRecursiveKeyValue<ELEMENT> ?
-                    `${Key}.${NestedKeys<ELEMENT, PrevIndex[DEPTH]>}` :
+                NonNullable<ELEMENT> extends IsRecursiveKeyValue<NonNullable<ELEMENT>> ?
+                    `${Key}.${NestedKeys<NonNullable<ELEMENT>, PrevIndex[DEPTH]>}` :
                     `${Key}`
             ) :
-            T[Key] extends IsRecursiveKeyValue<T[Key]> ?
-                `${Key}.${NestedKeys<T[Key], PrevIndex[DEPTH]>}` :
+            NonNullable<T[Key]> extends IsRecursiveKeyValue<NonNullable<T[Key]>> ?
+                `${Key}.${NestedKeys<NonNullable<T[Key]>, PrevIndex[DEPTH]>}` :
                 `${Key}`
     }[keyof T & string];
 
 export type SimpleResourceKeys<
     T extends Record<PropertyKey, any>,
 > = {
-    [Key in keyof T & string]: T[Key] extends Array<infer ELEMENT> ?
+    [Key in keyof T & string]: NonNullable<T[Key]> extends Array<infer ELEMENT> ?
         (
-            ELEMENT extends IsRecursiveKeyValue<ELEMENT> ?
+            NonNullable<ELEMENT> extends IsRecursiveKeyValue<NonNullable<ELEMENT>> ?
                 Key :
                 never
         ) :
-        T[Key] extends IsRecursiveKeyValue<T[Key]> ?
+        NonNullable<T[Key]> extends IsRecursiveKeyValue<NonNullable<T[Key]>> ?
             Key :
             never
 }[keyof T & string];
@@ -69,13 +94,13 @@ export type NestedResourceKeys<
     DEPTH extends number = 4,
 > = [DEPTH] extends [0] ? never :
     {
-        [Key in keyof T & string]: T[Key] extends Array<infer ELEMENT> ?
+        [Key in keyof T & string]: NonNullable<T[Key]> extends Array<infer ELEMENT> ?
             (
-                ELEMENT extends IsRecursiveKeyValue<ELEMENT> ?
-                    Key | `${Key}.${NestedResourceKeys<ELEMENT, PrevIndex[DEPTH]>}` :
+                NonNullable<ELEMENT> extends IsRecursiveKeyValue<NonNullable<ELEMENT>> ?
+                    Key | `${Key}.${NestedResourceKeys<NonNullable<ELEMENT>, PrevIndex[DEPTH]>}` :
                     never
-            ) : T[Key] extends IsRecursiveKeyValue<T[Key]> ?
-                Key | `${Key}.${NestedResourceKeys<ArrayItem<T[Key]>, PrevIndex[DEPTH]>}` :
+            ) : NonNullable<T[Key]> extends IsRecursiveKeyValue<NonNullable<T[Key]>> ?
+                Key | `${Key}.${NestedResourceKeys<ArrayItem<NonNullable<T[Key]>>, PrevIndex[DEPTH]>}` :
                 never
     }[keyof T & string];
 
@@ -87,21 +112,21 @@ export type TypeFromNestedKeyPath<
     {
         [Key in Path & string]: Key extends keyof T ?
             (
-                T[Key] extends Array<infer ELEMENT> ?
+                NonNullable<T[Key]> extends Array<infer ELEMENT> ?
                     ELEMENT :
                     T[Key]
             ) :
             Key extends `${infer P}.${infer S}` ?
                 (P extends keyof T ?
                     (
-                        T[P] extends Array<infer ELEMENT> ?
+                        NonNullable<T[P]> extends Array<infer ELEMENT> ?
                             (
-                                ELEMENT extends Record<PropertyKey, any> ?
-                                    TypeFromNestedKeyPath<ELEMENT, S, PrevIndex[DEPTH]> :
+                                NonNullable<ELEMENT> extends Record<PropertyKey, any> ?
+                                    TypeFromNestedKeyPath<NonNullable<ELEMENT>, S, PrevIndex[DEPTH]> :
                                     never
                             ) :
-                            T[P] extends Record<PropertyKey, any> ?
-                                TypeFromNestedKeyPath<T[P], S, PrevIndex[DEPTH]> :
+                            NonNullable<T[P]> extends Record<PropertyKey, any> ?
+                                TypeFromNestedKeyPath<NonNullable<T[P]>, S, PrevIndex[DEPTH]> :
                                 never
                     ) :
                     never

--- a/packages/core/test/data/type.ts
+++ b/packages/core/test/data/type.ts
@@ -27,6 +27,16 @@ export type User = {
     items: Item[]
 };
 
+export type Event = {
+    id: string,
+    data: Record<string, any> | null,
+    meta: Record<string, string>,
+    realm: Realm | null,
+    user?: User,
+    items: Item[] | null,
+    created_at: Date,
+};
+
 // -----------------------------------------------------
 
 export type GrandChildEntity = {

--- a/packages/core/test/unit/types.spec.ts
+++ b/packages/core/test/unit/types.spec.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { expectTypeOf } from 'vitest';
+import { defineSchema } from '../../src';
+import type {
+    NestedKeys,
+    NestedResourceKeys,
+    SimpleKeys,
+    SimpleResourceKeys,
+    TypeFromNestedKeyPath,
+} from '../../src';
+import type { Event, User } from '../data/type';
+
+describe('src/types.ts', () => {
+    describe('SimpleKeys', () => {
+        it('should keep existing non-nullable behavior', () => {
+            const keys: SimpleKeys<User>[] = ['id', 'name', 'email', 'age'];
+
+            // @ts-expect-error a relation is not a simple key
+            const invalid: SimpleKeys<User>[] = ['realm'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+
+        it('should treat JSON columns as leaf keys', () => {
+            const keys: SimpleKeys<Event>[] = ['id', 'data', 'meta', 'created_at'];
+
+            // @ts-expect-error a (nullable) relation is not a simple key
+            const invalid: SimpleKeys<Event>[] = ['realm'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+    });
+
+    describe('SimpleResourceKeys', () => {
+        it('should cover nullable & optional relations', () => {
+            const keys: SimpleResourceKeys<Event>[] = ['realm', 'user', 'items'];
+
+            // @ts-expect-error a JSON column is not a resource key
+            const invalid: SimpleResourceKeys<Event>[] = ['data'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+
+        it('should keep existing non-nullable behavior', () => {
+            const keys: SimpleResourceKeys<User>[] = ['realm', 'items'];
+
+            // @ts-expect-error a scalar column is not a resource key
+            const invalid: SimpleResourceKeys<User>[] = ['name'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+    });
+
+    describe('NestedKeys', () => {
+        it('should traverse nullable & optional relations', () => {
+            const keys: NestedKeys<Event>[] = [
+                'id',
+                'data',
+                'meta',
+                'created_at',
+                'realm.id',
+                'realm.name',
+                'user.name',
+                'user.realm.name',
+                'items.name',
+                'items.realm.name',
+            ];
+
+            expect(keys).toBeDefined();
+        });
+
+        it('should not recurse into JSON columns', () => {
+            // @ts-expect-error a JSON column has no nested sub paths
+            const invalid: NestedKeys<Event>[] = ['data.foo'];
+
+            // @ts-expect-error an index-signature record has no nested sub paths
+            const invalidTyped: NestedKeys<Event>[] = ['meta.foo'];
+
+            expect(invalid).toBeDefined();
+            expect(invalidTyped).toBeDefined();
+        });
+    });
+
+    describe('NestedResourceKeys', () => {
+        it('should cover nullable & optional relations (incl. nested)', () => {
+            const keys: NestedResourceKeys<Event>[] = [
+                'realm',
+                'user',
+                'user.realm',
+                'user.items',
+                'user.items.realm',
+                'items',
+                'items.realm',
+            ];
+
+            // @ts-expect-error a JSON column is not a resource key
+            const invalid: NestedResourceKeys<Event>[] = ['data'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+    });
+
+    describe('TypeFromNestedKeyPath', () => {
+        it('should resolve value types through nullable segments', () => {
+            expectTypeOf<TypeFromNestedKeyPath<Event, 'realm.name'>>().toEqualTypeOf<string>();
+            expectTypeOf<TypeFromNestedKeyPath<Event, 'user.age'>>().toEqualTypeOf<number>();
+            expectTypeOf<TypeFromNestedKeyPath<Event, 'items.name'>>().toEqualTypeOf<string>();
+            expectTypeOf<TypeFromNestedKeyPath<Event, 'data'>>().toEqualTypeOf<Record<string, any> | null>();
+        });
+    });
+
+    describe('defineSchema', () => {
+        it('should accept nullable relations & JSON columns without casts', () => {
+            const schema = defineSchema<Event>({
+                name: 'event',
+                fields: { allowed: ['id', 'data', 'meta'] },
+                filters: { allowed: ['id', 'data'] },
+                relations: { allowed: ['realm', 'user', 'items'] },
+                sort: {
+                    allowed: ['id', 'created_at'],
+                    default: { created_at: 'DESC' },
+                },
+            });
+
+            expect(schema.fields.allowed).toEqual(['id', 'data', 'meta']);
+            expect(schema.filters.allowed).toEqual(['id', 'data']);
+            expect(schema.relations.allowed).toEqual(['realm', 'user', 'items']);
+        });
+
+        it('should reject JSON columns as relations', () => {
+            const schema = defineSchema<Event>({
+                relations: {
+                    // @ts-expect-error a JSON column is not a relation
+                    allowed: ['data'],
+                },
+            });
+
+            expect(schema).toBeDefined();
+        });
+    });
+});

--- a/packages/docs/guide/schemas.md
+++ b/packages/docs/guide/schemas.md
@@ -42,7 +42,7 @@ const userSchema = defineSchema<User>({
 });
 ```
 
-Field keys are typed against `RECORD` via recursive key paths — `allowed` and `default` autocomplete and type-check.
+Field keys are typed against `RECORD` via recursive key paths — `allowed` and `default` autocomplete and type-check. `null`/`undefined` are unwrapped before traversal, so nullable or optional relations (`realm: Realm | null`) type-check like their non-nullable counterparts. Index-signature records (JSON columns such as `data: Record<string, any>`) count as selectable/filterable leaf keys and are not traversed as nested branches.
 
 ## Top-level options
 


### PR DESCRIPTION
## Motivation

Two type-level gaps surfaced while writing per-entity schemas for authup (authup/authup#3276):

1. `SimpleResourceKeys<T>` did not unwrap nullable relations — properties typed `Related | null` (or optional `?:`) fell out of `relations.allowed`'s key union, forcing `@ts-expect-error` markers.
2. `SimpleKeys<T>` excluded `Record`-typed scalar columns — a JSON column such as `data: Record<string, any> | null` is a legitimate selectable/filterable leaf, but every record-typed property was treated as a nested branch, forcing `'data' as never` casts.

## What changed

`packages/core/src/types.ts` — the whole key-path family is adjusted consistently:

- **Null-unwrap**: `NonNullable<...>` is applied to property values (and array elements) before the record/array branch checks in `SimpleKeys`, `NestedKeys`, `SimpleResourceKeys`, `NestedResourceKeys` and `TypeFromNestedKeyPath`. Nullable and optional relations now resolve exactly like their non-nullable counterparts — in relation allow-lists, nested key paths, and value-type resolution (`realm.name` resolves through `realm: Realm | null`).
- **JSON columns as leaves**: index-signature records (`string extends keyof T`, i.e. no known literal keys — e.g. `Record<string, any>`) are now leaf keys in `SimpleKeys`/`NestedKeys` and are *not* traversed as branches. Previously a non-nullable `Record<string, any>` property recursed into unbounded `${string}` template unions; now it is simply addressable as `'data'`. JSON columns deliberately do **not** appear in the resource-key unions (a JSON column is not a relation).

Both fixes compose: `data: Record<string, any> | null` works.

Also:

- `packages/docs/guide/schemas.md` — documents the unwrapping and JSON-column leaf semantics.
- `packages/core/test/data/type.ts` — new `Event` fixture type (nullable/optional relations, nullable collection, nullable + non-nullable JSON columns).
- `packages/core/test/unit/types.spec.ts` — compile-time assertions (positive assignments + `@ts-expect-error` negatives, `expectTypeOf` value-type checks) plus runtime `defineSchema` assertions covering the exact authup scenarios: nullable relation in `relations.allowed`, JSON column in `fields.allowed`/`filters.allowed` without casts, no forced `data.x` sub-paths, and unchanged non-nullable behavior.

## Testing

- `npx tsc --noEmit -p packages/core/tsconfig.json` (src + test) — clean; every `@ts-expect-error` suppresses a real error (unused directives would fail).
- `npx nx run-many -t build` — all 9 projects pass; ~10s wall, no type-check-time regression.
- `npx nx run-many -t test --skip-nx-cache` — all 8 test targets pass (core: 204 tests).
- `npx eslint` on changed files — clean.

Closes #777