### PR TITLE
feat: first-class parameter masking for parse and decode

### DIFF
--- a/packages/codec-url/src/expression/encoder/module.ts
+++ b/packages/codec-url/src/expression/encoder/module.ts
@@ -16,12 +16,12 @@ import type {
     ParseQueryOptions,
     SchemaRegistry,
 } from '@rapiq/core';
+import { Parameter } from '@rapiq/core';
 import {
     SimpleURLEncoder,
 } from '../../simple/encoder';
 import { URLParameter } from '../../constants';
-import type { QueryParameterMask } from '../../utils';
-import { buildQueryParameterMask, isSchemaAware } from '../../utils';
+import { buildQueryParameters, intersectQueryParameters, isSchemaAware } from '../../utils';
 import { ExpressionURLDecoder } from '../decoder';
 import { serializeFiltersExpression } from './filters';
 
@@ -58,36 +58,46 @@ export class ExpressionURLEncoder {
      * @param options
      */
     encode(input: IQuery, options: ParseQueryOptions = {}): string | null {
-        const encoded = this.encodeParts(input);
+        const encoded = this.encodeParts(input, options.parameters);
         if (encoded === null || !isSchemaAware(options)) {
             return encoded;
         }
 
-        const decoded = this.decoder.decode(encoded, options);
+        // decode only parameters present in the input — validation
+        // must not materialize schema defaults for absent ones.
+        const parameters = intersectQueryParameters(
+            buildQueryParameters(input),
+            options.parameters,
+        );
+
+        const decoded = this.decoder.decode(encoded, { ...options, parameters });
         if (!decoded) {
             return null;
         }
 
-        // re-emit only parameters present in the input — validation
-        // must not materialize schema defaults for absent ones.
-        return this.encodeParts(decoded, buildQueryParameterMask(input));
+        return this.encodeParts(decoded, parameters);
     }
 
     async encodeAsync(
         input: IQuery,
         options: ParseQueryOptions = {},
     ) : Promise<string | null> {
-        const encoded = this.encodeParts(input);
+        const encoded = this.encodeParts(input, options.parameters);
         if (encoded === null || !isSchemaAware(options)) {
             return encoded;
         }
 
-        const decoded = await this.decoder.decodeAsync(encoded, options);
+        const parameters = intersectQueryParameters(
+            buildQueryParameters(input),
+            options.parameters,
+        );
+
+        const decoded = await this.decoder.decodeAsync(encoded, { ...options, parameters });
         if (!decoded) {
             return null;
         }
 
-        return this.encodeParts(decoded, buildQueryParameterMask(input));
+        return this.encodeParts(decoded, parameters);
     }
 
     encodeFields(input: IFields, options: ParseParameterOptions = {}) {
@@ -139,21 +149,21 @@ export class ExpressionURLEncoder {
 
     // --------------------------------------------------
 
-    protected encodeParts(query: IQuery, parameters?: QueryParameterMask) : string | null {
+    protected encodeParts(query: IQuery, parameters?: `${Parameter}`[]) : string | null {
         const parts = [
-            (!parameters || parameters.fields) ?
+            (!parameters || parameters.includes(Parameter.FIELDS)) ?
                 this.simple.encodeFields(query.fields) :
                 null,
-            (!parameters || parameters.filters) ?
+            (!parameters || parameters.includes(Parameter.FILTERS)) ?
                 this.serializeFilters(query.filters) :
                 null,
-            (!parameters || parameters.pagination) ?
+            (!parameters || parameters.includes(Parameter.PAGINATION)) ?
                 this.simple.encodePagination(query.pagination) :
                 null,
-            (!parameters || parameters.relations) ?
+            (!parameters || parameters.includes(Parameter.RELATIONS)) ?
                 this.simple.encodeRelations(query.relations) :
                 null,
-            (!parameters || parameters.sorts) ?
+            (!parameters || parameters.includes(Parameter.SORT)) ?
                 this.simple.encodeSort(query.sorts) :
                 null,
         ].filter(Boolean);

--- a/packages/codec-url/src/simple/encoder/module.ts
+++ b/packages/codec-url/src/simple/encoder/module.ts
@@ -18,7 +18,7 @@ import type {
     ParseQueryOptions,
     SchemaRegistry,
 } from '@rapiq/core';
-import { buildQueryParameterMask, isSchemaAware } from '../../utils';
+import { buildQueryParameters, intersectQueryParameters, isSchemaAware } from '../../utils';
 import { SimpleURLDecoder } from '../decoder';
 import type { ISerializer } from './serializer';
 import { QueryVisitor } from './visitors';
@@ -50,22 +50,27 @@ export class SimpleURLEncoder {
     encode(input: IQuery, options: ParseQueryOptions = {}): string | null {
         this.visitor.reset();
 
-        const encoded = this.runSerializer(this.visitor.visitQuery(input));
+        const encoded = this.runSerializer(this.visitor.visitQuery(input, options.parameters));
         if (encoded === null || !isSchemaAware(options)) {
             return encoded;
         }
 
-        const decoded = this.decoder.decode(encoded, options);
+        // decode only parameters present in the input — validation
+        // must not materialize schema defaults for absent ones.
+        const parameters = intersectQueryParameters(
+            buildQueryParameters(input),
+            options.parameters,
+        );
+
+        const decoded = this.decoder.decode(encoded, { ...options, parameters });
         if (!decoded) {
             return null;
         }
 
         this.visitor.reset();
 
-        // re-emit only parameters present in the input — validation
-        // must not materialize schema defaults for absent ones.
         return this.runSerializer(
-            this.visitor.visitQuery(decoded, buildQueryParameterMask(input)),
+            this.visitor.visitQuery(decoded, parameters),
         );
     }
 
@@ -75,12 +80,17 @@ export class SimpleURLEncoder {
     ) : Promise<string | null> {
         this.visitor.reset();
 
-        const encoded = this.runSerializer(this.visitor.visitQuery(input));
+        const encoded = this.runSerializer(this.visitor.visitQuery(input, options.parameters));
         if (encoded === null || !isSchemaAware(options)) {
             return encoded;
         }
 
-        const decoded = await this.decoder.decodeAsync(encoded, options);
+        const parameters = intersectQueryParameters(
+            buildQueryParameters(input),
+            options.parameters,
+        );
+
+        const decoded = await this.decoder.decodeAsync(encoded, { ...options, parameters });
         if (!decoded) {
             return null;
         }
@@ -88,7 +98,7 @@ export class SimpleURLEncoder {
         this.visitor.reset();
 
         return this.runSerializer(
-            this.visitor.visitQuery(decoded, buildQueryParameterMask(input)),
+            this.visitor.visitQuery(decoded, parameters),
         );
     }
 

--- a/packages/codec-url/src/simple/encoder/visitors/module.ts
+++ b/packages/codec-url/src/simple/encoder/visitors/module.ts
@@ -27,7 +27,7 @@ import type {
     ISorts,
     ISortsVisitor,
 } from '@rapiq/core';
-import type { QueryParameterMask } from '../../../utils';
+import { Parameter } from '@rapiq/core';
 import type { ArraySerializer, RecordArraySerializer, RecordSerializer } from '../serializer';
 import { QuerySerializer } from '../serializer';
 import { FieldsVisitor } from './fields';
@@ -75,28 +75,27 @@ export class QueryVisitor implements IQueryVisitor<QuerySerializer>,
     }
 
     /**
-     * The optional mask limits which parameters are emitted —
-     * the schema-aware encode pass uses it to avoid materializing
-     * schema defaults for parameters absent from the input query.
+     * The optional parameter list limits which parameters are
+     * emitted — same semantics as `ParseQueryOptions.parameters`.
      */
-    visitQuery(expr: IQuery, parameters?: QueryParameterMask): QuerySerializer {
-        if (!parameters || parameters.fields) {
+    visitQuery(expr: IQuery, parameters?: `${Parameter}`[]): QuerySerializer {
+        if (!parameters || parameters.includes(Parameter.FIELDS)) {
             expr.fields.accept(this.fields);
         }
 
-        if (!parameters || parameters.filters) {
+        if (!parameters || parameters.includes(Parameter.FILTERS)) {
             expr.filters.accept(this.filters);
         }
 
-        if (!parameters || parameters.pagination) {
+        if (!parameters || parameters.includes(Parameter.PAGINATION)) {
             expr.pagination.accept(this.pagination);
         }
 
-        if (!parameters || parameters.relations) {
+        if (!parameters || parameters.includes(Parameter.RELATIONS)) {
             expr.relations.accept(this.relations);
         }
 
-        if (!parameters || parameters.sorts) {
+        if (!parameters || parameters.includes(Parameter.SORT)) {
             expr.sorts.accept(this.sort);
         }
 

--- a/packages/codec-url/src/utils/encode.ts
+++ b/packages/codec-url/src/utils/encode.ts
@@ -5,36 +5,68 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { Parameter } from '@rapiq/core';
 import type {
     IQuery,
     ParseParameterOptions,
     ParseQueryOptions,
 } from '@rapiq/core';
 
-export type QueryParameterMask = {
-    fields?: boolean,
-    filters?: boolean,
-    pagination?: boolean,
-    relations?: boolean,
-    sorts?: boolean,
-};
-
 /**
  * Which parameters are present on the input query. The schema-aware
- * encode pass re-emits only these, so validation cannot materialize
- * schema defaults for absent parameters onto the wire.
+ * encode pass decodes only these (`ParseQueryOptions.parameters`),
+ * so validation cannot materialize schema defaults for absent
+ * parameters onto the wire.
  *
  * @param input
  */
-export function buildQueryParameterMask(input: IQuery) : QueryParameterMask {
-    return {
-        fields: input.fields.value.length > 0,
-        filters: input.filters.value.length > 0,
-        pagination: typeof input.pagination.limit !== 'undefined' ||
-            typeof input.pagination.offset !== 'undefined',
-        relations: input.relations.value.length > 0,
-        sorts: input.sorts.value.length > 0,
-    };
+export function buildQueryParameters(input: IQuery) : `${Parameter}`[] {
+    const output : `${Parameter}`[] = [];
+
+    if (input.fields.value.length > 0) {
+        output.push(Parameter.FIELDS);
+    }
+
+    if (input.filters.value.length > 0) {
+        output.push(Parameter.FILTERS);
+    }
+
+    if (
+        typeof input.pagination.limit !== 'undefined' ||
+        typeof input.pagination.offset !== 'undefined'
+    ) {
+        output.push(Parameter.PAGINATION);
+    }
+
+    if (input.relations.value.length > 0) {
+        output.push(Parameter.RELATIONS);
+    }
+
+    if (input.sorts.value.length > 0) {
+        output.push(Parameter.SORT);
+    }
+
+    return output;
+}
+
+/**
+ * Restrict a parameter list by an optional caller-provided mask
+ * ({@link ParseQueryOptions.parameters}).
+ *
+ * @param input
+ * @param mask
+ */
+export function intersectQueryParameters(
+    input: `${Parameter}`[],
+    mask?: `${Parameter}`[],
+) : `${Parameter}`[] {
+    if (typeof mask === 'undefined') {
+        return input;
+    }
+
+    return input.filter(
+        (parameter) => mask.includes(parameter),
+    );
 }
 
 /**

--- a/packages/codec-url/test/unit/codec.spec.ts
+++ b/packages/codec-url/test/unit/codec.spec.ts
@@ -10,6 +10,7 @@ import {
     ErrorCode,
     Filters,
     FiltersParseError,
+    SchemaRegistry,
     defineQuery,
     defineSchema,
     eq,
@@ -135,6 +136,72 @@ describe('URLCodec', () => {
         });
 
         expect(decoded!.filters).toEqual(or(eq('name', 'John'), gte('age', 18)));
+    });
+
+    describe('parameter masking', () => {
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema({
+            name: 'user',
+            filters: { allowed: ['id', 'name'] },
+            sort: { default: { id: 'DESC' } },
+            pagination: { maxLimit: 10 },
+        }));
+
+        const aware = createURLCodec(registry);
+
+        it('should decode only the listed parameters', () => {
+            const decoded = aware.decode('filter[name]=John&page[limit]=50&sort=-id', {
+                schema: 'user',
+                parameters: ['filters'],
+            });
+
+            expect(decoded!.filters).toEqual(new Filters('and', [eq('name', 'John')]));
+            // masked parameters are neither parsed nor defaulted —
+            // no maxLimit-capped pagination, no default sort.
+            expect(decoded!.pagination.limit).toBeUndefined();
+            expect(decoded!.pagination.offset).toBeUndefined();
+            expect(decoded!.sorts.value).toHaveLength(0);
+        });
+
+        it('should skip masked schema defaults through decodeAsync', async () => {
+            const decoded = await aware.decodeAsync('filter[name]=John', {
+                schema: 'user',
+                parameters: ['filters'],
+            });
+
+            expect(decoded!.filters).toEqual(new Filters('and', [eq('name', 'John')]));
+            expect(decoded!.pagination.limit).toBeUndefined();
+            expect(decoded!.sorts.value).toHaveLength(0);
+        });
+
+        it('should encode only the listed parameters', () => {
+            const query = defineQuery({
+                filters: { name: 'John' },
+                pagination: { limit: 50 },
+            });
+
+            const encoded = codec.encode(query, {
+                parameters: ['filters'],
+                stamp: false,
+            });
+
+            expect(decodeURIComponent(encoded!)).toEqual('filter=eq(name,\'John\')');
+        });
+
+        it('should intersect the mask with schema-aware encoding', () => {
+            const query = defineQuery({
+                filters: { name: 'John' },
+                pagination: { limit: 50 },
+            });
+
+            const encoded = aware.encode(query, {
+                schema: 'user',
+                parameters: ['filters'],
+                stamp: false,
+            });
+
+            expect(decodeURIComponent(encoded!)).toEqual('filter=eq(name,\'John\')');
+        });
     });
 
     it('should fail loudly for an unregistered stamped codec', () => {

--- a/packages/core/src/parser/query.ts
+++ b/packages/core/src/parser/query.ts
@@ -48,7 +48,7 @@ export abstract class BaseQueryParser extends BaseParser<ParseQueryOptions, Quer
         const output : QueryContext = {};
         const { data, parameterOptions } = this.prepareQueryContext(input, options);
 
-        if (!this.skipParameter(options.relations)) {
+        if (!this.skipParameter(options, Parameter.RELATIONS)) {
             const relationsInput = this.readParameter(data, Parameter.RELATIONS);
 
             const relations = this.parseRelations(relationsInput, parameterOptions);
@@ -56,28 +56,28 @@ export abstract class BaseQueryParser extends BaseParser<ParseQueryOptions, Quer
             this.gateRelations(parameterOptions, relationsInput, relations);
         }
 
-        if (!this.skipParameter(options.fields)) {
+        if (!this.skipParameter(options, Parameter.FIELDS)) {
             output.fields = this.parseFields(
                 this.readParameter(data, Parameter.FIELDS),
                 parameterOptions,
             );
         }
 
-        if (!this.skipParameter(options.filters)) {
+        if (!this.skipParameter(options, Parameter.FILTERS)) {
             output.filters = this.parseFilters(
                 this.readParameter(data, Parameter.FILTERS),
                 parameterOptions,
             );
         }
 
-        if (!this.skipParameter(options.pagination)) {
+        if (!this.skipParameter(options, Parameter.PAGINATION)) {
             output.pagination = this.parsePagination(
                 this.readParameter(data, Parameter.PAGINATION),
                 parameterOptions,
             );
         }
 
-        if (!this.skipParameter(options.sort)) {
+        if (!this.skipParameter(options, Parameter.SORT)) {
             output.sorts = this.parseSort(
                 this.readParameter(data, Parameter.SORT),
                 parameterOptions,
@@ -96,7 +96,7 @@ export abstract class BaseQueryParser extends BaseParser<ParseQueryOptions, Quer
         const output : QueryContext = {};
         const { data, parameterOptions } = this.prepareQueryContext(input, options);
 
-        if (!this.skipParameter(options.relations)) {
+        if (!this.skipParameter(options, Parameter.RELATIONS)) {
             const relationsInput = this.readParameter(data, Parameter.RELATIONS);
 
             const relations = await this.parseRelationsAsync(relationsInput, parameterOptions);
@@ -104,28 +104,28 @@ export abstract class BaseQueryParser extends BaseParser<ParseQueryOptions, Quer
             this.gateRelations(parameterOptions, relationsInput, relations);
         }
 
-        if (!this.skipParameter(options.fields)) {
+        if (!this.skipParameter(options, Parameter.FIELDS)) {
             output.fields = await this.parseFieldsAsync(
                 this.readParameter(data, Parameter.FIELDS),
                 parameterOptions,
             );
         }
 
-        if (!this.skipParameter(options.filters)) {
+        if (!this.skipParameter(options, Parameter.FILTERS)) {
             output.filters = await this.parseFiltersAsync(
                 this.readParameter(data, Parameter.FILTERS),
                 parameterOptions,
             );
         }
 
-        if (!this.skipParameter(options.pagination)) {
+        if (!this.skipParameter(options, Parameter.PAGINATION)) {
             output.pagination = await this.parsePaginationAsync(
                 this.readParameter(data, Parameter.PAGINATION),
                 parameterOptions,
             );
         }
 
-        if (!this.skipParameter(options.sort)) {
+        if (!this.skipParameter(options, Parameter.SORT)) {
             output.sorts = await this.parseSortAsync(
                 this.readParameter(data, Parameter.SORT),
                 parameterOptions,
@@ -317,7 +317,27 @@ export abstract class BaseQueryParser extends BaseParser<ParseQueryOptions, Quer
         return undefined;
     }
 
-    protected skipParameter(input?: boolean) : boolean {
-        return typeof input === 'boolean' && !input;
+    /**
+     * A parameter is skipped when the `parameters` allow-list
+     * excludes it or its per-parameter option is `false`. A skipped
+     * parameter is neither parsed nor defaulted — the query leaves
+     * it empty, as if input and schema said nothing about it.
+     */
+    protected skipParameter<
+        RECORD extends ObjectLiteral = ObjectLiteral,
+    >(
+        options: ParseQueryOptions<RECORD>,
+        parameter: `${Parameter}`,
+    ) : boolean {
+        if (
+            typeof options.parameters !== 'undefined' &&
+            !options.parameters.includes(parameter)
+        ) {
+            return true;
+        }
+
+        const flag = options[parameter];
+
+        return typeof flag === 'boolean' && !flag;
     }
 }

--- a/packages/core/src/parser/types.ts
+++ b/packages/core/src/parser/types.ts
@@ -5,6 +5,7 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import type { Parameter } from '../constants';
 import type { Relations } from '../parameter';
 import type { Schema } from '../schema';
 import type { ObjectLiteral } from '../types';
@@ -25,6 +26,17 @@ export type ParseQueryOptions<
     pagination?: boolean,
     relations?: boolean,
     sort?: boolean,
+    /**
+     * Process only the listed parameters. A parameter that is not
+     * listed is neither parsed nor defaulted — the resulting query
+     * leaves it empty, exactly as if neither the input nor the schema
+     * had mentioned it (schema defaults such as `pagination.maxLimit`
+     * do not materialize). When relations are masked out, relation
+     * paths in the other parameters resolve as if the client had
+     * requested no relations. Omitting the option processes all
+     * parameters.
+     */
+    parameters?: `${Parameter}`[],
     schema?: Schema<RECORD> | string,
     /**
      * Strict-mode override: takes precedence over the schema-level setting.

--- a/packages/docs/guide/wire.md
+++ b/packages/docs/guide/wire.md
@@ -48,6 +48,21 @@ app.get('/users', (req, res) => {
 If your input already uses canonical parameter keys (`filters`, `pagination`, …), use a [parser](/packages/parser-simple) directly. MongoDB-style filter documents have their [own parser](/packages/parser-mongo).
 :::
 
+### Decoding a subset of parameters
+
+Sometimes only part of a query should apply — a bulk delete, for example, must honor the request's filters but never its pagination. Pass `parameters` to decode only the listed parameters; everything else stays empty and, importantly, schema defaults such as `pagination.maxLimit` do **not** materialize for masked parameters:
+
+```typescript
+app.delete('/sessions', (req, res) => {
+    const query = codec.decode(req.query, {
+        schema: 'session',
+        parameters: ['filters'],
+    });
+    // query.pagination is empty — the schema's maxLimit cannot
+    // silently truncate the delete's row selection.
+});
+```
+
 ## Migration dispatch
 
 The v2 codec follows a read-both/write-expression migration:

--- a/packages/docs/packages/codec-url.md
+++ b/packages/docs/packages/codec-url.md
@@ -99,6 +99,15 @@ const decoded = codec.decode(wire!, { schema: 'user' });
 
 Allow-lists, aliases, defaults, pagination clamps and filter validation then use parser-exact semantics. Parameters absent from the input query remain absent from the wire.
 
+Both directions accept a `parameters` allow-list to process only a subset of the query. On decode, an unlisted parameter is neither parsed nor defaulted (no `pagination.maxLimit` cap, no `sort.default`); on encode, only the listed parameters are emitted:
+
+```typescript
+const decoded = codec.decode(req.query, {
+    schema: 'user',
+    parameters: ['filters'],
+});
+```
+
 Schema-aware encoding validates by piping the output through the schema-bound decoder — a `filters.validate` hook therefore runs once during a schema-aware `encode()` and again when the receiver decodes. Keep validators **idempotent** (re-validating an accepted filter must return it unchanged), or the two sides will disagree about the transported values.
 
 ## Custom codecs

--- a/packages/docs/packages/parser-simple.md
+++ b/packages/docs/packages/parser-simple.md
@@ -41,6 +41,7 @@ const query = parser.parse({
 |---|---|
 | `schema` | A `Schema` instance or the name of a registered schema. Omit to parse without validation. |
 | `strict` | Override the schema's [strict mode](/guide/schemas#strict-mode) for this call. |
+| `parameters` | Allow-list of parameters to parse, e.g. `['filters']`. A parameter not listed is neither parsed nor defaulted — the resulting `Query` leaves it empty, exactly as if neither input nor schema mentioned it. |
 | `fields` / `filters` / `relations` / `pagination` / `sort` | Set to `false` to skip a parameter entirely. |
 
 If `filters.validate` may return a Promise, use `await parser.parseAsync(input, options)`. `parse()` remains synchronous for schemas whose validators are synchronous and throws `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER` if it encounters an async result.
@@ -48,6 +49,19 @@ If `filters.validate` may return a Promise, use `await parser.parseAsync(input, 
 ## Schema defaults
 
 A parameter absent from the input is still parsed, so schema defaults always apply: `fields.default` (or, without one, the `fields.allowed` selection), `filters.default`, `sort.default` and `pagination.maxLimit` shape the resulting `Query` even when the input is empty.
+
+To keep schema defaults from materializing for parameters you do not intend to apply, mask them with the `parameters` option:
+
+```typescript
+// a bulk delete must apply filters only — masking pagination keeps
+// the schema's maxLimit from silently truncating the row selection.
+const query = parser.parse(input, {
+    schema: 'user',
+    parameters: ['filters'],
+});
+```
+
+Masked-out relations do not gate relation paths in the other parameters — they resolve exactly as if the client had requested no relations.
 
 ## Input formats
 

--- a/packages/parser-simple/test/unit/parser/parser.spec.ts
+++ b/packages/parser-simple/test/unit/parser/parser.spec.ts
@@ -139,6 +139,122 @@ describe('src/parser', () => {
         });
     });
 
+    describe('parameter masking', () => {
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema({
+            name: 'foo',
+            fields: { allowed: ['id', 'name'] },
+            filters: { allowed: ['id', 'name'] },
+            relations: { allowed: ['realm'] },
+            sort: { default: { id: 'DESC' } },
+            pagination: { maxLimit: 25 },
+        }));
+
+        const input = {
+            fields: ['id'],
+            filters: { name: 'admin' },
+            relations: ['realm'],
+            sort: '-id',
+            pagination: { limit: 100 },
+        };
+
+        it('should parse only the listed parameters', async () => {
+            const parser = new SimpleParser(registry);
+
+            const output = parser.parse(input, {
+                schema: 'foo',
+                parameters: ['filters'],
+            });
+
+            expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+            ]));
+            expect(output.fields).toEqual(new Fields());
+            expect(output.relations).toEqual(new Relations());
+            expect(output.sorts).toEqual(new Sorts());
+            expect(output.pagination.limit).toBeUndefined();
+            expect(output.pagination.offset).toBeUndefined();
+        });
+
+        it('should not materialize schema defaults for masked parameters', async () => {
+            const parser = new SimpleParser(registry);
+
+            // without a mask, maxLimit and the sort default apply.
+            let output = parser.parse({}, { schema: 'foo' });
+            expect(output.pagination.limit).toEqual(25);
+            expect(output.sorts).toEqual(new Sorts([
+                new Sort('id', SortDirection.DESC),
+            ]));
+
+            // with the mask, masked parameters stay empty.
+            output = parser.parse({}, { schema: 'foo', parameters: ['filters'] });
+            expect(output.pagination.limit).toBeUndefined();
+            expect(output.sorts).toEqual(new Sorts());
+        });
+
+        it('should intersect with the per-parameter skip options', async () => {
+            const parser = new SimpleParser(registry);
+
+            const output = parser.parse(input, {
+                schema: 'foo',
+                parameters: ['filters', 'pagination'],
+                pagination: false,
+            });
+
+            expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+            ]));
+            expect(output.pagination.limit).toBeUndefined();
+        });
+
+        it('should honor the mask through parseAsync', async () => {
+            const parser = new SimpleParser(registry);
+
+            const output = await parser.parseAsync(input, {
+                schema: 'foo',
+                parameters: ['filters'],
+            });
+
+            expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'),
+            ]));
+            expect(output.pagination.limit).toBeUndefined();
+            expect(output.relations).toEqual(new Relations());
+        });
+
+        it('should resolve relation paths as if no relations were requested', async () => {
+            // masked-out relations do not gate relation paths in the
+            // other parameters — exactly as when the client requests
+            // no relations at all.
+            const relationRegistry = new SchemaRegistry();
+            relationRegistry.add(defineSchema({
+                name: 'realm',
+                filters: { allowed: ['id'] },
+            }));
+            relationRegistry.add(defineSchema({
+                name: 'user',
+                filters: { allowed: ['id'] },
+                relations: { allowed: ['realm'] },
+                schemaMapping: { realm: 'realm' },
+            }));
+
+            const parser = new SimpleParser(relationRegistry);
+
+            const output = parser.parse({
+                filters: { 'realm.id': 1 },
+                relations: ['realm'],
+            }, {
+                schema: 'user',
+                parameters: ['filters'],
+            });
+
+            expect(output.relations).toEqual(new Relations());
+            expect(output.filters).toEqual(new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'realm.id', 1),
+            ]));
+        });
+    });
+
     it('should enforce the relations allow-list in full-query parsing', async () => {
         const registry = new SchemaRegistry();
         registry.add(defineSchema({


### PR DESCRIPTION
## Motivation

Consumers sometimes need to apply only a subset of a parsed query's parameters. authup's session bulk-revoke decodes with the session schema but must apply **filters only** — applying the schema's `pagination.maxLimit` would default the limit to the cap and silently truncate the delete's row selection. Until now the workaround was rebuilding a `Query` by hand from the parsed one.

## Design

Parse/decode-side masking, implemented once in `@rapiq/core`'s shared orchestration:

- **`ParseQueryOptions.parameters?: `${Parameter}`[]`** — an allow-list of parameters to process. A parameter not listed is **neither parsed nor defaulted**: the resulting `Query` leaves it empty, exactly as if neither the input nor the schema had said anything about it. Schema defaults (`pagination.maxLimit`, `sort.default`, `filters.default`, …) do not materialize for masked parameters. Omitting the option keeps behavior unchanged.
- **Relations interplay**: when relations are masked out, relation paths in the other parameters resolve as if the client had requested no relations (relation gating only ever applies when a relations input was actually processed) — consistent with "as if input said nothing".
- The option intersects with the existing per-parameter `false` toggles: a parameter is processed only if the allow-list contains it *and* its toggle is not `false`.
- `SimpleParser`, `ExpressionParser` and `MongoParser` inherit the behavior from `BaseQueryParser`; `URLCodec.decode()`/`decodeAsync()` thread the option through unchanged.
- **Codec unification**: the URL codec's internal boolean `QueryParameterMask` (used by schema-aware encode to keep defaults off the wire) is now expressed through the same public option — the schema-aware pass decodes with `parameters` restricted to the parameters present on the input query, and `encode()` also honors a caller-provided `parameters` list (emit only those parameters).

Adapter-side `ExecuteOptions.parameters` (sql/typeorm) is **deferred**: the decode-side option covers the motivating use case, and the adapters can gain a mirrored option later if a query arrives pre-parsed from elsewhere.

## Changes

- `@rapiq/core`: `ParseQueryOptions.parameters` + `BaseQueryParser.skipParameter(options, parameter)` honoring allow-list and toggles (`parser/types.ts`, `parser/query.ts`).
- `@rapiq/codec-url`: replaced internal `QueryParameterMask` with `` `${Parameter}`[] `` helpers (`buildQueryParameters`, `intersectQueryParameters`); simple + expression encoders mask their first pass by `options.parameters` and run the schema-aware validation decode with the restricted parameter list.
- Docs: `guide/wire.md` (decoding a subset of parameters), `packages/parser-simple.md` (option row + defaults-masking example), `packages/codec-url.md` (schema-aware transport note).

## Testing

- `packages/parser-simple/test/unit/parser/parser.spec.ts`: filters-only mask leaves fields/relations/sort/pagination empty (no `maxLimit` default), no defaults for masked parameters vs. unmasked baseline, intersection with `pagination: false`, `parseAsync` parity, relation-path resolution with masked relations.
- `packages/codec-url/test/unit/codec.spec.ts`: `decode`/`decodeAsync` with `{ schema, parameters: ['filters'] }` skip pagination/sort defaults; `encode` with `parameters` emits only the listed parameters, plain and schema-aware.
- `nx run-many -t build` (all 9 projects) and `nx run-many -t test` (all 8 test targets, `--skip-nx-cache`) pass; changed files lint clean.

Closes #778
