### PR TITLE
refactor: one operator-semantics authority for all backends

### DIFF
--- a/packages/core/src/parameter/filters/plan/constants.ts
+++ b/packages/core/src/parameter/filters/plan/constants.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { FilterFieldOperator } from '../../../schema';
+import type { FilterOperatorSemantics } from './types';
+
+/**
+ * The operator-semantics table — one row per filter operator, the
+ * single source of truth for what an operator MEANS: its family,
+ * its negation twin (complement law), its anchor placement, its
+ * comparison range and its case-fold participation.
+ *
+ * The {@link planCondition} lowering derives every policy decision
+ * from this table; {@link Filter.accept} derives its per-operator
+ * visitor dispatch from the `visitorMethod` column. Adding an
+ * operator means adding a row (plus a lowering rule when it opens
+ * a new family) — not editing backends.
+ */
+export const FILTER_OPERATOR_SEMANTICS = {
+    eq: {
+        family: 'equality',
+        visitorMethod: 'visitFilterEqual',
+        foldable: true,
+    },
+    ne: {
+        family: 'equality',
+        complementOf: 'eq',
+        visitorMethod: 'visitFilterNotEqual',
+        foldable: true,
+    },
+    lt: {
+        family: 'ordering',
+        visitorMethod: 'visitFilterLessThan',
+        compare: { min: -1, max: -1 },
+        foldable: false,
+    },
+    lte: {
+        family: 'ordering',
+        visitorMethod: 'visitFilterLessThanEqual',
+        compare: { min: -1, max: 0 },
+        foldable: false,
+    },
+    gt: {
+        family: 'ordering',
+        visitorMethod: 'visitFilterGreaterThan',
+        compare: { min: 1, max: 1 },
+        foldable: false,
+    },
+    gte: {
+        family: 'ordering',
+        visitorMethod: 'visitFilterGreaterThanEqual',
+        compare: { min: 0, max: 1 },
+        foldable: false,
+    },
+    in: {
+        family: 'membership',
+        visitorMethod: 'visitFilterIn',
+        foldable: true,
+    },
+    nin: {
+        family: 'membership',
+        complementOf: 'in',
+        visitorMethod: 'visitFilterNotIn',
+        foldable: true,
+    },
+    startsWith: {
+        family: 'anchored',
+        visitorMethod: 'visitFilterStartsWith',
+        anchor: { start: true, end: false },
+        foldable: false,
+    },
+    notStartsWith: {
+        family: 'anchored',
+        complementOf: 'startsWith',
+        visitorMethod: 'visitFilterNotStartsWith',
+        anchor: { start: true, end: false },
+        foldable: false,
+    },
+    endsWith: {
+        family: 'anchored',
+        visitorMethod: 'visitFilterEndsWith',
+        anchor: { start: false, end: true },
+        foldable: false,
+    },
+    notEndsWith: {
+        family: 'anchored',
+        complementOf: 'endsWith',
+        visitorMethod: 'visitFilterNotEndsWith',
+        anchor: { start: false, end: true },
+        foldable: false,
+    },
+    contains: {
+        family: 'anchored',
+        visitorMethod: 'visitFilterContains',
+        anchor: { start: false, end: false },
+        foldable: false,
+    },
+    notContains: {
+        family: 'anchored',
+        complementOf: 'contains',
+        visitorMethod: 'visitFilterNotContains',
+        anchor: { start: false, end: false },
+        foldable: false,
+    },
+    regex: {
+        family: 'regex',
+        visitorMethod: 'visitFilterRegex',
+        foldable: false,
+    },
+    mod: {
+        family: 'arithmetic',
+        visitorMethod: 'visitFilterMod',
+        foldable: false,
+    },
+    size: {
+        family: 'cardinality',
+        visitorMethod: 'visitFilterSize',
+        foldable: false,
+    },
+    exists: {
+        family: 'existence',
+        visitorMethod: 'visitFilterExists',
+        foldable: false,
+    },
+    elemMatch: {
+        family: 'structural',
+        visitorMethod: 'visitFilterElemMatch',
+        foldable: false,
+    },
+} satisfies Record<`${FilterFieldOperator}`, FilterOperatorSemantics>;

--- a/packages/core/src/parameter/filters/plan/index.ts
+++ b/packages/core/src/parameter/filters/plan/index.ts
@@ -1,14 +1,10 @@
 /*
- * Copyright (c) 2025.
+ * Copyright (c) 2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './collection';
-export * from './condition';
 export * from './constants';
-export * from './helpers';
-export * from './plan';
-export * from './record';
-export * from './regex';
+export * from './module';
+export * from './types';

--- a/packages/core/src/parameter/filters/plan/module.ts
+++ b/packages/core/src/parameter/filters/plan/module.ts
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError } from '../../../errors';
+import type { IFilters } from '../collection';
+import { isFilters } from '../collection';
+import type { ICondition } from '../condition';
+import { ITSELF } from '../constants';
+import type { IFilter } from '../record';
+import { isFilter } from '../record';
+import { FilterRegexFlag, createFilterRegexPattern } from '../regex';
+import { FILTER_OPERATOR_SEMANTICS } from './constants';
+import type {
+    ConditionPlan,
+    IPlanInterpreter,
+    MatchPlan,
+    PlanCompareOperator,
+    PlanConditionOptions,
+} from './types';
+
+/**
+ * Lower a condition tree (`IFilter | IFilters`) into a
+ * {@link ConditionPlan} with every semantic policy decision already
+ * made: negation twins resolved to `negated` leaf flags, null
+ * equality turned into null checks, in/nin decomposed (empty list,
+ * null members), the case-fold policy verdict computed, anchored
+ * operators derived into positive patterns, value shapes validated
+ * and ITSELF placement checked.
+ *
+ * Backends interpret the plan via {@link interpretPlan} — they
+ * render or compile primitives, they never re-derive operator
+ * semantics.
+ *
+ * Returns `null` when the tree is empty (an empty compound
+ * vanishes).
+ */
+export function planCondition(
+    input: ICondition,
+    options: PlanConditionOptions = {},
+) : ConditionPlan | null {
+    return new ConditionLowering(options).lower(input);
+}
+
+/**
+ * Dispatch a plan node to the matching interpreter handler.
+ *
+ * The single support-enforcement point: a missing optional handler
+ * (`mod`/`size`/`elemMatch`) and an ITSELF leaf without the
+ * `itself` declaration throw the typed feature error here — never
+ * inside a backend.
+ */
+export function interpretPlan<R>(
+    plan: ConditionPlan,
+    interpreter: IPlanInterpreter<R>,
+) : R {
+    if (
+        'field' in plan &&
+        plan.field === ITSELF &&
+        !interpreter.itself
+    ) {
+        throw AdapterError.featureUnsupported('filters:itself');
+    }
+
+    switch (plan.kind) {
+        case 'compound': {
+            return interpreter.compound(plan);
+        }
+        case 'constant': {
+            return interpreter.constant(plan);
+        }
+        case 'null-check': {
+            return interpreter.nullCheck(plan);
+        }
+        case 'compare': {
+            return interpreter.compare(plan);
+        }
+        case 'one-of': {
+            return interpreter.oneOf(plan);
+        }
+        case 'match': {
+            return interpreter.match(plan);
+        }
+        case 'mod': {
+            if (!interpreter.mod) {
+                throw AdapterError.featureUnsupported('filters:mod');
+            }
+
+            return interpreter.mod(plan);
+        }
+        case 'size': {
+            if (!interpreter.size) {
+                throw AdapterError.featureUnsupported('filters:size');
+            }
+
+            return interpreter.size(plan);
+        }
+        case 'elem-match': {
+            if (!interpreter.elemMatch) {
+                throw AdapterError.featureUnsupported('filters:elemMatch');
+            }
+
+            return interpreter.elemMatch(plan);
+        }
+        default: {
+            throw AdapterError.featureUnsupported(
+                `filters:${(plan as { kind: string }).kind}`,
+            );
+        }
+    }
+}
+
+// -----------------------------------------------------------
+
+class ConditionLowering {
+    protected caseSensitiveAll : boolean;
+
+    protected caseSensitiveFields : Set<string>;
+
+    protected fieldPrefix : string;
+
+    protected elementDepth : number;
+
+    constructor(options: PlanConditionOptions) {
+        this.caseSensitiveAll = options.caseSensitive === true;
+        this.caseSensitiveFields = new Set(
+            Array.isArray(options.caseSensitive) ? options.caseSensitive : [],
+        );
+        this.fieldPrefix = '';
+        this.elementDepth = 0;
+    }
+
+    // -----------------------------------------------------------
+
+    lower(input: ICondition) : ConditionPlan | null {
+        if (isFilters(input)) {
+            return this.lowerCompound(input);
+        }
+
+        if (isFilter(input)) {
+            return this.lowerLeaf(input);
+        }
+
+        throw AdapterError.operatorUnsupported(String(
+            (input as Partial<ICondition>)?.operator,
+        ));
+    }
+
+    // -----------------------------------------------------------
+
+    protected lowerCompound(input: IFilters) : ConditionPlan | null {
+        let operator : 'and' | 'or';
+        let negated = false;
+
+        switch (input.operator) {
+            case 'and': {
+                operator = 'and';
+                break;
+            }
+            case 'or': {
+                operator = 'or';
+                break;
+            }
+            // plain boolean NOT over the group; the null-inclusive
+            // complement law applies to negated LEAF operators only.
+            case 'nor': {
+                operator = 'or';
+                negated = true;
+                break;
+            }
+            case 'not': {
+                operator = 'and';
+                negated = true;
+                break;
+            }
+            default: {
+                throw AdapterError.operatorUnsupported(input.operator);
+            }
+        }
+
+        const children : ConditionPlan[] = [];
+        for (let i = 0; i < input.value.length; i++) {
+            const child = input.value[i];
+            if (!child) {
+                continue;
+            }
+
+            if (isFilter(child) || isFilters(child)) {
+                const plan = this.lower(child);
+                if (plan) {
+                    children.push(plan);
+                }
+            }
+        }
+
+        // an empty compound vanishes.
+        if (children.length === 0) {
+            return null;
+        }
+
+        return {
+            kind: 'compound', 
+            operator, 
+            negated, 
+            children,
+        };
+    }
+
+    // -----------------------------------------------------------
+
+    protected lowerLeaf(input: IFilter) : ConditionPlan | null {
+        const semantics = FILTER_OPERATOR_SEMANTICS[
+            input.operator as keyof typeof FILTER_OPERATOR_SEMANTICS
+        ];
+        if (!semantics) {
+            throw AdapterError.operatorUnsupported(input.operator);
+        }
+
+        // the ITSELF marker addresses the element bound by an
+        // enclosing elemMatch scope; outside one it has no referent.
+        if (input.field === ITSELF && this.elementDepth === 0) {
+            throw AdapterError.featureUnsupported('filters:itself');
+        }
+
+        const negated = typeof (
+            semantics as { complementOf?: string }
+        ).complementOf === 'string';
+
+        // a single absent value: unify undefined and null so every
+        // downstream decision only reasons about null.
+        const value = input.value === undefined ? null : input.value;
+
+        switch (semantics.family) {
+            case 'equality': {
+                if (value === null) {
+                    return {
+                        kind: 'null-check', 
+                        field: input.field, 
+                        negated, 
+                        elementwise: true,
+                    };
+                }
+
+                return {
+                    kind: 'compare',
+                    field: input.field,
+                    op: 'eq',
+                    value,
+                    caseFold: typeof value === 'string' && this.isFoldableField(input.field),
+                    negated,
+                };
+            }
+            case 'ordering': {
+                return {
+                    kind: 'compare',
+                    field: input.field,
+                    op: input.operator as PlanCompareOperator,
+                    value,
+                    caseFold: false,
+                    negated: false,
+                };
+            }
+            case 'membership': {
+                return this.lowerMembership(input.field, value, negated);
+            }
+            case 'anchored': {
+                const anchor = (
+                    semantics as { anchor?: { start: boolean, end: boolean } }
+                ).anchor || { start: false, end: false };
+                const text = `${value}`;
+
+                let mode : 'starts' | 'ends' | 'contains';
+                let flag : number;
+                if (anchor.start) {
+                    mode = 'starts';
+                    flag = FilterRegexFlag.STARTS_WITH;
+                } else if (anchor.end) {
+                    mode = 'ends';
+                    flag = FilterRegexFlag.ENDS_WITH;
+                } else {
+                    mode = 'contains';
+                    flag = FilterRegexFlag.CONTAINS;
+                }
+
+                return {
+                    kind: 'match',
+                    field: input.field,
+                    pattern: { mode, text },
+                    regexSource: createFilterRegexPattern(text, flag),
+                    ignoreCase: true,
+                    negated,
+                };
+            }
+            case 'regex': {
+                return this.lowerRegex(input.field, value);
+            }
+            case 'existence': {
+                return {
+                    kind: 'null-check', 
+                    field: input.field, 
+                    negated: !!value, 
+                    elementwise: false,
+                };
+            }
+            case 'arithmetic': {
+                return this.lowerMod(input.field, value);
+            }
+            case 'cardinality': {
+                const valid = typeof value === 'number' &&
+                    Number.isInteger(value) &&
+                    value >= 0;
+
+                return {
+                    kind: 'size',
+                    field: input.field,
+                    count: valid ? value as number : null,
+                };
+            }
+            case 'structural': {
+                return this.lowerElemMatch(input);
+            }
+            default: {
+                throw AdapterError.operatorUnsupported(input.operator);
+            }
+        }
+    }
+
+    protected lowerMembership(
+        field: string,
+        value: unknown,
+        negated: boolean,
+    ) : ConditionPlan {
+        if (!Array.isArray(value) || value.length === 0) {
+            return { kind: 'constant', verdict: negated };
+        }
+
+        const normalized = value.map(
+            (item) => (item === undefined ? null : item),
+        );
+        const values = normalized.filter((item) => item !== null);
+
+        if (values.length === 0) {
+            return {
+                kind: 'null-check', 
+                field, 
+                negated, 
+                elementwise: true,
+            };
+        }
+
+        return {
+            kind: 'one-of',
+            field,
+            values,
+            includesNull: values.length !== normalized.length,
+            caseFold: this.isFoldableField(field),
+            negated,
+        };
+    }
+
+    protected lowerRegex(field: string, value: unknown) : MatchPlan {
+        if (value instanceof RegExp) {
+            // strip the stateful flags, so repeated test() calls
+            // never depend on lastIndex.
+            const flags = value.flags.replace(/[gy]/g, '');
+
+            return {
+                kind: 'match',
+                field,
+                pattern: {
+                    mode: 'regex', 
+                    source: value.source, 
+                    flags, 
+                },
+                regexSource: value.source,
+                ignoreCase: value.ignoreCase,
+                negated: false,
+            };
+        }
+
+        // a string pattern passes through unvalidated — the
+        // consuming engine (database or RegExp) interprets it.
+        if (typeof value === 'string') {
+            return {
+                kind: 'match',
+                field,
+                pattern: {
+                    mode: 'regex', 
+                    source: value, 
+                    flags: '', 
+                },
+                regexSource: value,
+                ignoreCase: false,
+                negated: false,
+            };
+        }
+
+        throw AdapterError.featureUnsupported('filters:regex:value');
+    }
+
+    protected lowerMod(field: string, value: unknown) : ConditionPlan {
+        if (
+            !Array.isArray(value) ||
+            value.length !== 2 ||
+            typeof value[0] !== 'number' ||
+            !Number.isFinite(value[0]) ||
+            typeof value[1] !== 'number' ||
+            !Number.isFinite(value[1]) ||
+            value[0] === 0
+        ) {
+            // a malformed divisor/remainder pair matches nothing
+            // (mongo parity), on every backend.
+            return { kind: 'constant', verdict: false };
+        }
+
+        return {
+            kind: 'mod', 
+            field, 
+            divisor: value[0], 
+            remainder: value[1],
+        };
+    }
+
+    protected lowerElemMatch(input: IFilter) : ConditionPlan | null {
+        const interior = input.value;
+        if (
+            !isFilter(interior) &&
+            !isFilters(interior as ICondition)
+        ) {
+            throw AdapterError.featureUnsupported('filters:elemMatch:value');
+        }
+
+        const oldPrefix = this.fieldPrefix;
+
+        this.fieldPrefix = `${oldPrefix}${input.field}.`;
+        this.elementDepth += 1;
+
+        try {
+            const condition = this.lower(interior as ICondition);
+            if (!condition) {
+                return null;
+            }
+
+            return {
+                kind: 'elem-match', 
+                field: input.field, 
+                condition, 
+            };
+        } finally {
+            this.fieldPrefix = oldPrefix;
+            this.elementDepth -= 1;
+        }
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * The settled case policy: equality-family comparisons on the
+     * field fold unless opted out via `caseSensitive` (matched on
+     * the full path composed through elemMatch scopes). Backends
+     * apply only their remaining capability veto.
+     */
+    protected isFoldableField(field: string) : boolean {
+        if (this.caseSensitiveAll) {
+            return false;
+        }
+
+        return !this.caseSensitiveFields.has(`${this.fieldPrefix}${field}`);
+    }
+}

--- a/packages/core/src/parameter/filters/plan/types.ts
+++ b/packages/core/src/parameter/filters/plan/types.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { FilterFieldOperator } from '../../../schema';
+import type { IFilterVisitor } from '../record';
+
+/**
+ * Semantic classification of a filter operator — the row shape of
+ * {@link FILTER_OPERATOR_SEMANTICS}. The table is the single source
+ * of truth the {@link planCondition} lowering derives its decisions
+ * from; backends never branch on operator names.
+ */
+export type FilterOperatorFamily =    | 'equality' |
+    'ordering' |
+    'membership' |
+    'anchored' |
+    'regex' |
+    'existence' |
+    'arithmetic' |
+    'cardinality' |
+    'structural';
+
+export type FilterOperatorSemantics = {
+    family: FilterOperatorFamily,
+
+    /**
+     * Negation twin: this operator is the null-inclusive complement
+     * of the named positive operator (complement law). Only set on
+     * negated operators; the target must itself be positive.
+     */
+    complementOf?: `${FilterFieldOperator}`,
+
+    /**
+     * Method the per-operator {@link IFilterVisitor} dispatch
+     * ({@link Filter.accept}) routes to.
+     */
+    visitorMethod: Exclude<keyof IFilterVisitor<unknown>, 'visitFilter'>,
+
+    /**
+     * Anchored family only: anchor placement of the derived pattern.
+     */
+    anchor?: { start: boolean, end: boolean },
+
+    /**
+     * Ordering family only: accepted three-way comparison range
+     * (result of a compare(value, condition) in {-1, 0, 1}).
+     */
+    compare?: { min: -1 | 0 | 1, max: -1 | 0 | 1 },
+
+    /**
+     * Whether the operator participates in the case-insensitive
+     * default for string values (equality family + membership).
+     */
+    foldable: boolean,
+};
+
+// -----------------------------------------------------------
+
+/**
+ * Comparison primitive of a {@link ComparePlan}.
+ */
+export type PlanCompareOperator = 'eq' | 'lt' | 'lte' | 'gt' | 'gte';
+
+/**
+ * and/or group. `negated` is a plain boolean NOT over the whole
+ * group (`nor`/`not` input compounds) — unlike negated leaves it is
+ * NOT null-inclusive; SQL renders it with three-valued semantics.
+ */
+export type CompoundPlan = {
+    kind: 'compound',
+    operator: 'and' | 'or',
+    negated: boolean,
+    /**
+     * Never empty — compounds whose children all vanish are lowered
+     * to `null` themselves.
+     */
+    children: ConditionPlan[],
+};
+
+/**
+ * Verdict known at plan time: `in([])` matches nothing,
+ * `nin([])` matches everything, an invalid `mod` value matches
+ * nothing (mongo parity).
+ */
+export type ConstantPlan = {
+    kind: 'constant',
+    verdict: boolean,
+};
+
+/**
+ * `exists`, `eq(field, null)` and `ne(field, null)`.
+ * `negated` reads IS NOT NULL. `elementwise` distributes the test
+ * over array-valued fields by element (the equality family does,
+ * `exists` addresses the value itself).
+ */
+export type NullCheckPlan = {
+    kind: 'null-check',
+    field: string,
+    negated: boolean,
+    elementwise: boolean,
+};
+
+/**
+ * Binary comparison on a scalar. `op` is `'eq'` for the equality
+ * family (`negated` marks `ne`; ordering operators are never
+ * negated). `caseFold` carries the settled policy verdict — the
+ * value is a string and the field is not opted out via
+ * `caseSensitive`; backends apply only their remaining capability
+ * veto (column foldability) and the folding mechanism.
+ *
+ * Contract for `negated`: the exact null-inclusive complement of
+ * the positive form — null/missing values match.
+ */
+export type ComparePlan = {
+    kind: 'compare',
+    field: string,
+    op: PlanCompareOperator,
+    value: unknown,
+    caseFold: boolean,
+    negated: boolean,
+};
+
+/**
+ * `in`/`nin`. `values` is null-free and non-empty; null members are
+ * extracted into `includesNull` (they stay leaf-local because a
+ * null member participates in element quantification — `in([x, null])`
+ * matches an array-valued field containing null).
+ *
+ * The four-case contract every backend must satisfy:
+ * - positive, no null:  v ∈ values
+ * - positive, null:     v ∈ values OR v IS NULL
+ * - negated, no null:   complement (v ∉ values OR v IS NULL)
+ * - negated, null:      v ∉ values AND v IS NOT NULL
+ */
+export type OneOfPlan = {
+    kind: 'one-of',
+    field: string,
+    values: unknown[],
+    includesNull: boolean,
+    caseFold: boolean,
+    negated: boolean,
+};
+
+/**
+ * String matching — the anchored family and the regex operator in
+ * one node. Anchored literals keep their text so LIKE-only dialects
+ * can derive a wildcard pattern; `regexSource` is always a usable
+ * POSITIVE pattern (metacharacters escaped, anchors applied — never
+ * a negative lookahead; negation is the `negated` flag, with the
+ * null-inclusive leaf contract).
+ */
+export type MatchPattern =    | { mode: 'starts' | 'ends' | 'contains', text: string } |
+    {
+        mode: 'regex', 
+        source: string, 
+        flags: string 
+    };
+
+export type MatchPlan = {
+    kind: 'match',
+    field: string,
+    pattern: MatchPattern,
+    regexSource: string,
+    ignoreCase: boolean,
+    negated: boolean,
+};
+
+/**
+ * `mod` — value already validated ([divisor, remainder], finite,
+ * divisor non-zero); invalid input lowers to a false constant.
+ */
+export type ModPlan = {
+    kind: 'mod',
+    field: string,
+    divisor: number,
+    remainder: number,
+};
+
+/**
+ * `size` — addresses the array itself, not its elements.
+ * `count` is null when the condition value is invalid (not a
+ * non-negative integer): the condition then never matches, but the
+ * node keeps its identity so backends without array-length support
+ * still fail typed instead of silently rendering a constant.
+ */
+export type SizePlan = {
+    kind: 'size',
+    field: string,
+    count: number | null,
+};
+
+/**
+ * `elemMatch` — the interior is recursively planned. ITSELF
+ * placement legality is already verified during lowering.
+ */
+export type ElemMatchPlan = {
+    kind: 'elem-match',
+    field: string,
+    condition: ConditionPlan,
+};
+
+export type ConditionPlan =    | CompoundPlan |
+    ConstantPlan |
+    NullCheckPlan |
+    ComparePlan |
+    OneOfPlan |
+    MatchPlan |
+    ModPlan |
+    SizePlan |
+    ElemMatchPlan;
+
+// -----------------------------------------------------------
+
+/**
+ * The backend contract over a {@link ConditionPlan} — and its
+ * declared support matrix: an optional handler that is absent means
+ * the feature is unsupported ({@link interpretPlan} throws the
+ * typed error, in exactly one place). `itself` declares whether
+ * leaf fields may be the ITSELF (`$this`) marker.
+ *
+ * `compound` and `elemMatch` handlers recurse via
+ * {@link interpretPlan} on their children.
+ */
+export interface IPlanInterpreter<R> {
+    readonly itself?: boolean;
+
+    compound(plan: CompoundPlan): R;
+
+    constant(plan: ConstantPlan): R;
+
+    nullCheck(plan: NullCheckPlan): R;
+
+    compare(plan: ComparePlan): R;
+
+    oneOf(plan: OneOfPlan): R;
+
+    match(plan: MatchPlan): R;
+
+    mod?(plan: ModPlan): R;
+
+    size?(plan: SizePlan): R;
+
+    elemMatch?(plan: ElemMatchPlan): R;
+}
+
+export type PlanConditionOptions = {
+    /**
+     * Field keys whose equality comparisons (eq/ne/in/nin) stay
+     * case-sensitive instead of the case-insensitive default —
+     * matched against the full path composed through elemMatch
+     * scopes. `true` keeps every comparison case-sensitive.
+     */
+    caseSensitive?: string[] | boolean,
+};

--- a/packages/core/src/parameter/filters/record/module.ts
+++ b/packages/core/src/parameter/filters/record/module.ts
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2025-2025.
+ * Copyright (c) 2025.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { FilterFieldOperator } from '../../../schema';
+import type { FilterFieldOperator } from '../../../schema';
+import { FILTER_OPERATOR_SEMANTICS } from '../plan/constants';
 import type { IFilter, IFilterVisitor } from './types';
 
 export class Filter<
@@ -25,92 +26,16 @@ export class Filter<
     }
 
     accept<R>(visitor: IFilterVisitor<R>) : R {
-        if (this.operator === FilterFieldOperator.EQUAL) {
-            return this.acceptWithFallback(visitor, 'visitFilterEqual');
-        }
-
-        if (this.operator === FilterFieldOperator.NOT_EQUAL) {
-            return this.acceptWithFallback(visitor, 'visitFilterNotEqual');
-        }
-
-        if (this.operator === FilterFieldOperator.LESS_THAN) {
-            return this.acceptWithFallback(visitor, 'visitFilterLessThan');
-        }
-
-        if (this.operator === FilterFieldOperator.LESS_THAN_EQUAL) {
-            return this.acceptWithFallback(visitor, 'visitFilterLessThanEqual');
-        }
-
-        if (this.operator === FilterFieldOperator.GREATER_THAN) {
-            return this.acceptWithFallback(visitor, 'visitFilterGreaterThan');
-        }
-
-        if (this.operator === FilterFieldOperator.GREATER_THAN_EQUAL) {
-            return this.acceptWithFallback(visitor, 'visitFilterGreaterThanEqual');
-        }
-
-        if (this.operator === FilterFieldOperator.EXISTS) {
-            return this.acceptWithFallback(visitor, 'visitFilterExists');
-        }
-
-        if (this.operator === FilterFieldOperator.IN) {
-            return this.acceptWithFallback(visitor, 'visitFilterIn');
-        }
-
-        if (this.operator === FilterFieldOperator.NOT_IN) {
-            return this.acceptWithFallback(visitor, 'visitFilterNotIn');
-        }
-
-        if (this.operator === FilterFieldOperator.MOD) {
-            return this.acceptWithFallback(visitor, 'visitFilterMod');
-        }
-
-        if (this.operator === FilterFieldOperator.SIZE) {
-            return this.acceptWithFallback(visitor, 'visitFilterSize');
-        }
-
-        if (this.operator === FilterFieldOperator.ELEM_MATCH) {
-            return this.acceptWithFallback(visitor, 'visitFilterElemMatch');
-        }
-
-        if (this.operator === FilterFieldOperator.CONTAINS) {
-            return this.acceptWithFallback(visitor, 'visitFilterContains');
-        }
-
-        if (this.operator === FilterFieldOperator.NOT_CONTAINS) {
-            return this.acceptWithFallback(visitor, 'visitFilterNotContains');
-        }
-
-        if (this.operator === FilterFieldOperator.STARTS_WITH) {
-            return this.acceptWithFallback(visitor, 'visitFilterStartsWith');
-        }
-
-        if (this.operator === FilterFieldOperator.NOT_STARTS_WITH) {
-            return this.acceptWithFallback(visitor, 'visitFilterNotStartsWith');
-        }
-
-        if (this.operator === FilterFieldOperator.ENDS_WITH) {
-            return this.acceptWithFallback(visitor, 'visitFilterEndsWith');
-        }
-
-        if (this.operator === FilterFieldOperator.NOT_ENDS_WITH) {
-            return this.acceptWithFallback(visitor, 'visitFilterNotEndsWith');
-        }
-
-        if (this.operator === FilterFieldOperator.REGEX) {
-            return this.acceptWithFallback(visitor, 'visitFilterRegex');
-        }
-
-        return visitor.visitFilter(this);
-    }
-
-    private acceptWithFallback<R, P extends keyof IFilterVisitor<R>>(
-        visitor: IFilterVisitor<R>,
-        property: P,
-    ) : R {
-        const method = visitor[property] as ((expr: IFilter) => R) | undefined;
-        if (method) {
-            return method.call(visitor, this);
+        const semantics = FILTER_OPERATOR_SEMANTICS[
+            this.operator as keyof typeof FILTER_OPERATOR_SEMANTICS
+        ];
+        if (semantics) {
+            const method = visitor[semantics.visitorMethod] as (
+                (expr: IFilter) => R
+            ) | undefined;
+            if (method) {
+                return method.call(visitor, this);
+            }
         }
 
         return visitor.visitFilter(this);

--- a/packages/core/test/unit/parameter/filters-plan.spec.ts
+++ b/packages/core/test/unit/parameter/filters-plan.spec.ts
@@ -1,0 +1,465 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    CompoundPlan,
+    ConditionPlan,
+    IPlanInterpreter,
+} from '../../../src';
+import {
+    AdapterError,
+    ErrorCode,
+    FILTER_OPERATOR_SEMANTICS,
+    Filter,
+    FilterFieldOperator,
+    Filters,
+    ITSELF,
+    interpretPlan,
+    planCondition,
+} from '../../../src';
+
+describe('src/parameter/filters/plan/constants.ts', () => {
+    it('should cover every filter operator', () => {
+        const operators = Object.values(FilterFieldOperator);
+        const covered = Object.keys(FILTER_OPERATOR_SEMANTICS);
+
+        expect(covered.sort()).toEqual([...operators].sort());
+    });
+
+    it('should only point complements at positive operators', () => {
+        const table = FILTER_OPERATOR_SEMANTICS as Record<
+            string, 
+            { complementOf?: string }
+        >;
+
+        for (const key of Object.keys(table)) {
+            const target = table[key].complementOf;
+            if (target) {
+                expect(table[target]).toBeDefined();
+                expect(table[target].complementOf).toBeUndefined();
+            }
+        }
+    });
+
+    it('should classify families consistently', () => {
+        const table = FILTER_OPERATOR_SEMANTICS as Record<
+            string, 
+            {
+                family: string, 
+                anchor?: unknown, 
+                compare?: unknown 
+            }
+        >;
+
+        for (const key of Object.keys(table)) {
+            const entry = table[key];
+            expect(!!entry.anchor).toEqual(entry.family === 'anchored');
+            expect(!!entry.compare).toEqual(entry.family === 'ordering');
+        }
+    });
+
+    it('should dispatch through unique visitor methods', () => {
+        const methods = Object.values(FILTER_OPERATOR_SEMANTICS)
+            .map((entry) => entry.visitorMethod);
+
+        expect(new Set(methods).size).toEqual(methods.length);
+    });
+});
+
+describe('src/parameter/filters/plan/module.ts', () => {
+    describe('equality', () => {
+        it('should lower eq on a string with the fold verdict', () => {
+            expect(planCondition(new Filter('eq', 'name', 'John'))).toEqual({
+                kind: 'compare',
+                field: 'name',
+                op: 'eq',
+                value: 'John',
+                caseFold: true,
+                negated: false,
+            });
+        });
+
+        it('should keep non-string equality typed and exact', () => {
+            expect(planCondition(new Filter('eq', 'age', 18))).toMatchObject({ kind: 'compare', caseFold: false });
+        });
+
+        it('should respect the caseSensitive opt-out list', () => {
+            expect(planCondition(
+                new Filter('eq', 'name', 'John'),
+                { caseSensitive: ['name'] },
+            )).toMatchObject({ caseFold: false });
+
+            expect(planCondition(
+                new Filter('eq', 'name', 'John'),
+                { caseSensitive: true },
+            )).toMatchObject({ caseFold: false });
+        });
+
+        it('should lower null equality to a null check', () => {
+            expect(planCondition(new Filter('eq', 'age', null))).toEqual({
+                kind: 'null-check', 
+                field: 'age', 
+                negated: false, 
+                elementwise: true,
+            });
+
+            expect(planCondition(new Filter('ne', 'age', null))).toEqual({
+                kind: 'null-check', 
+                field: 'age', 
+                negated: true, 
+                elementwise: true,
+            });
+
+            expect(planCondition(new Filter('eq', 'age', undefined))).toMatchObject({ kind: 'null-check' });
+        });
+
+        it('should mark ne as negated', () => {
+            expect(planCondition(new Filter('ne', 'name', 'John'))).toMatchObject({
+                kind: 'compare', 
+                op: 'eq', 
+                negated: true, 
+                caseFold: true,
+            });
+        });
+    });
+
+    describe('ordering', () => {
+        it('should lower ordering operators without folding', () => {
+            expect(planCondition(new Filter('gte', 'age', 18))).toEqual({
+                kind: 'compare',
+                field: 'age',
+                op: 'gte',
+                value: 18,
+                caseFold: false,
+                negated: false,
+            });
+        });
+    });
+
+    describe('membership', () => {
+        it('should fold an empty list to a constant', () => {
+            expect(planCondition(new Filter('in', 'age', []))).toEqual({ kind: 'constant', verdict: false });
+
+            expect(planCondition(new Filter('nin', 'age', []))).toEqual({ kind: 'constant', verdict: true });
+        });
+
+        it('should fold a non-array value to a constant', () => {
+            expect(planCondition(new Filter('in', 'age', 5 as never))).toEqual({ kind: 'constant', verdict: false });
+        });
+
+        it('should lower an all-null list to a null check', () => {
+            expect(planCondition(new Filter('in', 'age', [null]))).toEqual({
+                kind: 'null-check', 
+                field: 'age', 
+                negated: false, 
+                elementwise: true,
+            });
+
+            expect(planCondition(new Filter('nin', 'age', [null, undefined]))).toEqual({
+                kind: 'null-check', 
+                field: 'age', 
+                negated: true, 
+                elementwise: true,
+            });
+        });
+
+        it('should extract null members', () => {
+            expect(planCondition(new Filter('in', 'age', [18, null, 21]))).toEqual({
+                kind: 'one-of',
+                field: 'age',
+                values: [18, 21],
+                includesNull: true,
+                caseFold: true,
+                negated: false,
+            });
+        });
+
+        it('should keep a null-free list intact', () => {
+            expect(planCondition(new Filter('nin', 'status', ['a', 'b']))).toEqual({
+                kind: 'one-of',
+                field: 'status',
+                values: ['a', 'b'],
+                includesNull: false,
+                caseFold: true,
+                negated: true,
+            });
+        });
+    });
+
+    describe('anchored', () => {
+        it('should derive an escaped, anchored positive pattern', () => {
+            expect(planCondition(new Filter('startsWith', 'name', 'Jo.'))).toEqual({
+                kind: 'match',
+                field: 'name',
+                pattern: { mode: 'starts', text: 'Jo.' },
+                regexSource: '^Jo\\.',
+                ignoreCase: true,
+                negated: false,
+            });
+        });
+
+        it('should never derive a lookahead for negations', () => {
+            expect(planCondition(new Filter('notContains', 'name', 'oh'))).toEqual({
+                kind: 'match',
+                field: 'name',
+                pattern: { mode: 'contains', text: 'oh' },
+                regexSource: 'oh',
+                ignoreCase: true,
+                negated: true,
+            });
+        });
+
+        it('should stringify non-string anchored values', () => {
+            expect(planCondition(new Filter('endsWith', 'code', 5))).toMatchObject({
+                pattern: { mode: 'ends', text: '5' },
+                regexSource: '5$',
+            });
+        });
+    });
+
+    describe('regex', () => {
+        it('should strip stateful flags from a RegExp value', () => {
+            expect(planCondition(new Filter('regex', 'name', /^jo/gi))).toEqual({
+                kind: 'match',
+                field: 'name',
+                pattern: {
+                    mode: 'regex', 
+                    source: '^jo', 
+                    flags: 'i', 
+                },
+                regexSource: '^jo',
+                ignoreCase: true,
+                negated: false,
+            });
+        });
+
+        it('should pass string patterns through unvalidated', () => {
+            expect(planCondition(new Filter('regex', 'name', '[[:alpha:]]+'))).toMatchObject({
+                pattern: {
+                    mode: 'regex', 
+                    source: '[[:alpha:]]+', 
+                    flags: '', 
+                },
+                ignoreCase: false,
+            });
+        });
+
+        it('should reject non-pattern values typed', () => {
+            expect(() => planCondition(new Filter('regex', 'name', 5)))
+                .toThrowError(AdapterError);
+        });
+    });
+
+    describe('existence, arithmetic, cardinality', () => {
+        it('should lower exists by truthiness', () => {
+            expect(planCondition(new Filter('exists', 'age', true))).toEqual({
+                kind: 'null-check', 
+                field: 'age', 
+                negated: true, 
+                elementwise: false,
+            });
+
+            expect(planCondition(new Filter('exists', 'age', false))).toMatchObject({ negated: false });
+        });
+
+        it('should validate mod values centrally', () => {
+            expect(planCondition(new Filter('mod', 'age', [2, 0]))).toEqual({
+                kind: 'mod', 
+                field: 'age', 
+                divisor: 2, 
+                remainder: 0,
+            });
+
+            expect(planCondition(new Filter('mod', 'age', [0, 1]))).toEqual({ kind: 'constant', verdict: false });
+
+            expect(planCondition(new Filter('mod', 'age', 'x'))).toEqual({ kind: 'constant', verdict: false });
+        });
+
+        it('should keep the identity of an invalid size condition', () => {
+            expect(planCondition(new Filter('size', 'items', 3))).toEqual({
+                kind: 'size', 
+                field: 'items', 
+                count: 3,
+            });
+
+            expect(planCondition(new Filter('size', 'items', -1))).toEqual({
+                kind: 'size', 
+                field: 'items', 
+                count: null,
+            });
+        });
+    });
+
+    describe('elemMatch & ITSELF', () => {
+        it('should plan the interior recursively', () => {
+            const plan = planCondition(new Filter(
+                'elemMatch',
+                'items',
+                new Filter('eq', 'title', 'a'),
+            ));
+
+            expect(plan).toEqual({
+                kind: 'elem-match',
+                field: 'items',
+                condition: {
+                    kind: 'compare',
+                    field: 'title',
+                    op: 'eq',
+                    value: 'a',
+                    caseFold: true,
+                    negated: false,
+                },
+            });
+        });
+
+        it('should match case opt-outs on the composed path', () => {
+            const plan = planCondition(
+                new Filter('elemMatch', 'items', new Filter('eq', 'title', 'a')),
+                { caseSensitive: ['items.title'] },
+            );
+
+            expect(plan).toMatchObject({ condition: { caseFold: false } });
+        });
+
+        it('should reject a non-condition interior typed', () => {
+            expect(() => planCondition(new Filter('elemMatch', 'items', { title: 'a' })))
+                .toThrowError(AdapterError);
+        });
+
+        it('should vanish with an empty interior', () => {
+            expect(planCondition(new Filter(
+                'elemMatch',
+                'items',
+                new Filters('and', []),
+            ))).toBeNull();
+        });
+
+        it('should allow ITSELF only inside an element scope', () => {
+            expect(planCondition(new Filter(
+                'elemMatch',
+                'scores',
+                new Filter('gt', ITSELF, 5),
+            ))).toMatchObject({
+                kind: 'elem-match',
+                condition: { kind: 'compare', field: ITSELF },
+            });
+
+            expect(() => planCondition(new Filter('gt', ITSELF, 5)))
+                .toThrowError(AdapterError);
+
+            expect(() => planCondition(new Filter('elemMatch', ITSELF, new Filter('gt', ITSELF, 5))))
+                .toThrowError(AdapterError);
+        });
+    });
+
+    describe('compounds', () => {
+        it('should lower and/or groups', () => {
+            const plan = planCondition(new Filters('or', [
+                new Filter('eq', 'age', 12),
+                new Filters('and', [
+                    new Filter('gt', 'age', 20),
+                    new Filter('lt', 'age', 30),
+                ]),
+            ])) as CompoundPlan;
+
+            expect(plan.kind).toEqual('compound');
+            expect(plan.operator).toEqual('or');
+            expect(plan.negated).toBeFalsy();
+            expect(plan.children).toHaveLength(2);
+            expect(plan.children[1]).toMatchObject({ kind: 'compound', operator: 'and' });
+        });
+
+        it('should lower nor/not to negated groups', () => {
+            expect(planCondition(new Filters('nor', [
+                new Filter('eq', 'age', 1),
+            ]))).toMatchObject({ operator: 'or', negated: true });
+
+            expect(planCondition(new Filters('not', [
+                new Filter('eq', 'age', 1),
+            ]))).toMatchObject({ operator: 'and', negated: true });
+        });
+
+        it('should vanish empty compounds', () => {
+            expect(planCondition(new Filters('and', []))).toBeNull();
+            expect(planCondition(new Filters('and', [new Filters('or', [])])))
+                .toBeNull();
+        });
+
+        it('should reject unknown compound operators typed', () => {
+            expect(() => planCondition(new Filters('xor', [new Filter('eq', 'a', 1)])))
+                .toThrowError(AdapterError);
+        });
+
+        it('should reject unknown leaf operators typed', () => {
+            expect(() => planCondition(new Filter('like', 'a', 1)))
+                .toThrowError(AdapterError);
+        });
+    });
+});
+
+describe('src/parameter/filters/plan/module.ts interpretPlan', () => {
+    const createInterpreter = () : IPlanInterpreter<string> => ({
+        compound(plan: CompoundPlan) {
+            return `compound(${plan.children
+                .map((child) => interpretPlan(child, this))
+                .join(', ')})`;
+        },
+        constant: () => 'constant',
+        nullCheck: () => 'null-check',
+        compare: () => 'compare',
+        oneOf: () => 'one-of',
+        match: () => 'match',
+    });
+
+    it('should dispatch nodes to their handlers', () => {
+        const plan = planCondition(new Filters('and', [
+            new Filter('eq', 'a', 1),
+            new Filter('contains', 'b', 'x'),
+        ])) as ConditionPlan;
+
+        expect(interpretPlan(plan, createInterpreter()))
+            .toEqual('compound(compare, match)');
+    });
+
+    it('should throw typed on a missing optional handler', () => {
+        const size = planCondition(new Filter('size', 'items', 3)) as ConditionPlan;
+
+        expect(() => interpretPlan(size, createInterpreter()))
+            .toThrowError(AdapterError);
+
+        try {
+            interpretPlan(size, createInterpreter());
+        } catch (e) {
+            expect((e as AdapterError).code).toEqual(ErrorCode.FEATURE_UNSUPPORTED);
+        }
+    });
+
+    it('should gate ITSELF on the interpreter declaration', () => {
+        const plan = planCondition(new Filter(
+            'elemMatch',
+            'scores',
+            new Filter('gt', ITSELF, 5),
+        )) as ConditionPlan;
+
+        const withElemMatch : IPlanInterpreter<string> = {
+            ...createInterpreter(),
+            elemMatch(input) {
+                return interpretPlan(input.condition, this);
+            },
+        };
+
+        expect(() => interpretPlan(plan, withElemMatch))
+            .toThrowError(AdapterError);
+
+        const withItself : IPlanInterpreter<string> = {
+            ...withElemMatch,
+            itself: true,
+        };
+
+        expect(interpretPlan(plan, withItself)).toEqual('compare');
+    });
+});

--- a/packages/memory/src/parameter/filters/compiler.ts
+++ b/packages/memory/src/parameter/filters/compiler.ts
@@ -5,21 +5,23 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { 
-    FilterFieldOperator, 
-    IFilter, 
-    IFilterVisitor, 
-    IFilters, 
-    IFiltersVisitor, 
+import type {
+    ComparePlan,
+    CompoundPlan,
+    ConstantPlan,
+    ElemMatchPlan,
+    IPlanInterpreter,
+    MatchPlan,
+    ModPlan,
+    NullCheckPlan,
+    OneOfPlan,
+    SizePlan,
 } from '@rapiq/core';
 import {
     AdapterError,
-    FilterCompoundOperator,
-    FilterRegexFlag,
+    FILTER_OPERATOR_SEMANTICS,
     ITSELF,
-    createFilterRegex,
-    isFilter,
-    isFilters,
+    interpretPlan,
 } from '@rapiq/core';
 import {
     compareValues,
@@ -29,7 +31,7 @@ import {
     toText,
 } from '../../helpers';
 import { BINDING_ELEMENT_FLAG, BINDING_SCOPE_SEPARATOR } from './constants';
-import type { FilterCompileResult, FiltersVisitorOptions, ValueTest } from './types';
+import type { ConditionEval, ValueTest } from './types';
 
 /**
  * Positive leaf tests treat an array value by element
@@ -46,131 +48,134 @@ function anyValue(test: ValueTest) : ValueTest {
 }
 
 /**
- * Compiles a condition tree into per-binding evaluation functions and
- * collects the relation paths the tree references. Field prefixes compose
- * through elemMatch exactly like the SQL adapter, so conditions sharing a
- * relation path bind to the same array element.
+ * Compiles a condition plan into per-binding evaluation functions and
+ * collects the relation paths the tree references. Operator semantics
+ * (complement law, IN decomposition, case-fold policy, pattern
+ * derivation, value validation) are decided by the core lowering —
+ * this interpreter only compiles primitives into value tests. Field
+ * prefixes compose through elemMatch exactly like the SQL adapter, so
+ * conditions sharing a relation path bind to the same array element.
  */
-export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
-    IFilterVisitor<FilterCompileResult> {
+export class FiltersCompiler implements IPlanInterpreter<ConditionEval> {
     public readonly paths : Set<string>;
 
-    protected fieldPrefix : string;
+    public readonly itself = true;
 
     protected bindingPrefix : string;
 
     protected scopeSequence : number;
 
-    protected caseSensitiveAll : boolean;
-
-    protected caseSensitiveFields : Set<string>;
-
-    constructor(options: FiltersVisitorOptions = {}) {
+    constructor() {
         this.paths = new Set();
-        this.fieldPrefix = '';
         this.bindingPrefix = '';
         this.scopeSequence = 0;
-        this.caseSensitiveAll = options.caseSensitive === true;
-        this.caseSensitiveFields = new Set(
-            Array.isArray(options.caseSensitive) ? options.caseSensitive : [],
-        );
     }
 
     // -----------------------------------------------------------
 
-    visitFilterEqual(expr: IFilter<FilterFieldOperator.EQUAL>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildEqualTest(expr.value, expr.field));
-    }
+    compound(plan: CompoundPlan) : ConditionEval {
+        const children = plan.children.map(
+            (child) => interpretPlan(child, this),
+        );
 
-    visitFilterNotEqual(expr: IFilter<FilterFieldOperator.NOT_EQUAL>) : FilterCompileResult {
-        const test = this.buildEqualTest(expr.value, expr.field);
-
-        return this.leaf(expr.field, (value) => !test(value));
-    }
-
-    visitFilterLessThan(expr: IFilter<FilterFieldOperator.LESS_THAN>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildCompareTest(expr.value, -1, -1));
-    }
-
-    visitFilterLessThanEqual(expr: IFilter<FilterFieldOperator.LESS_THAN_EQUAL>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildCompareTest(expr.value, -1, 0));
-    }
-
-    visitFilterGreaterThan(expr: IFilter<FilterFieldOperator.GREATER_THAN>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildCompareTest(expr.value, 1, 1));
-    }
-
-    visitFilterGreaterThanEqual(expr: IFilter<FilterFieldOperator.GREATER_THAN_EQUAL>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildCompareTest(expr.value, 0, 1));
-    }
-
-    visitFilterExists(expr: IFilter<FilterFieldOperator.EXISTS, boolean>) : FilterCompileResult {
-        if (expr.value) {
-            return this.leaf(expr.field, (value) => value !== null);
+        let combined : ConditionEval;
+        if (plan.operator === 'or') {
+            combined = (ctx, root) => children.some((child) => child(ctx, root));
+        } else {
+            combined = (ctx, root) => children.every((child) => child(ctx, root));
         }
 
-        return this.leaf(expr.field, (value) => value === null);
-    }
-
-    visitFilterIn(expr: IFilter<FilterFieldOperator.IN, unknown[]>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildInTest(expr.value, expr.field));
-    }
-
-    visitFilterNotIn(expr: IFilter<FilterFieldOperator.NOT_IN, unknown[]>) : FilterCompileResult {
-        const test = this.buildInTest(expr.value, expr.field);
-
-        return this.leaf(expr.field, (value) => !test(value));
-    }
-
-    visitFilterMod(expr: IFilter<FilterFieldOperator.MOD, [number, number]>) : FilterCompileResult {
-        if (
-            !Array.isArray(expr.value) ||
-            expr.value.length !== 2 ||
-            !Number.isFinite(expr.value[0]) ||
-            !Number.isFinite(expr.value[1]) ||
-            expr.value[0] === 0
-        ) {
-            return this.leaf(expr.field, () => false);
+        if (plan.negated) {
+            return (ctx, root) => !combined(ctx, root);
         }
 
-        const [divisor, remainder] = expr.value;
+        return combined;
+    }
 
-        return this.leaf(expr.field, anyValue(
+    constant(plan: ConstantPlan) : ConditionEval {
+        return () => plan.verdict;
+    }
+
+    nullCheck(plan: NullCheckPlan) : ConditionEval {
+        const base : ValueTest = (value) => normalizeValue(value) === null;
+        const test = plan.elementwise ? anyValue(base) : base;
+
+        return this.leaf(plan.field, this.negate(test, plan.negated));
+    }
+
+    compare(plan: ComparePlan) : ConditionEval {
+        if (plan.op === 'eq') {
+            const test = anyValue(this.buildValueEqualTest(plan.value, plan.caseFold));
+
+            return this.leaf(plan.field, this.negate(test, plan.negated));
+        }
+
+        const range = FILTER_OPERATOR_SEMANTICS[plan.op].compare;
+
+        return this.leaf(plan.field, this.buildCompareTest(plan.value, range.min, range.max));
+    }
+
+    oneOf(plan: OneOfPlan) : ConditionEval {
+        const tests = plan.values.map(
+            (value) => this.buildValueEqualTest(value, plan.caseFold),
+        );
+        if (plan.includesNull) {
+            tests.push((value) => isValueEqual(value, null));
+        }
+
+        const test = anyValue(
+            (value) => tests.some((item) => item(value)),
+        );
+
+        return this.leaf(plan.field, this.negate(test, plan.negated));
+    }
+
+    match(plan: MatchPlan) : ConditionEval {
+        let regex : RegExp;
+        if (plan.pattern.mode === 'regex') {
+            try {
+                regex = new RegExp(plan.pattern.source, plan.pattern.flags);
+            } catch {
+                throw AdapterError.featureUnsupported('filters:regex:value');
+            }
+        } else {
+            regex = new RegExp(plan.regexSource, 'i');
+        }
+
+        const test = anyValue((value) => {
+            const text = toText(value);
+            if (text === undefined) {
+                return false;
+            }
+
+            return regex.test(text);
+        });
+
+        return this.leaf(plan.field, this.negate(test, plan.negated));
+    }
+
+    mod(plan: ModPlan) : ConditionEval {
+        return this.leaf(plan.field, anyValue(
             (value) => typeof value === 'number' &&
                 Number.isFinite(value) &&
-                value % divisor === remainder,
+                value % plan.divisor === plan.remainder,
         ));
     }
 
-    visitFilterSize(expr: IFilter<FilterFieldOperator.SIZE, number>) : FilterCompileResult {
-        if (
-            typeof expr.value !== 'number' ||
-            !Number.isInteger(expr.value) ||
-            expr.value < 0
-        ) {
-            return this.leaf(expr.field, () => false);
+    size(plan: SizePlan) : ConditionEval {
+        if (plan.count === null) {
+            return this.leaf(plan.field, () => false);
         }
 
-        const length = expr.value;
+        const { count } = plan;
 
         // the condition addresses the array itself, not its elements —
         // missing or non-array values never match (mongo parity).
-        return this.leaf(expr.field, (value) => Array.isArray(value) &&
-            value.length === length);
+        return this.leaf(plan.field, (value) => Array.isArray(value) &&
+            value.length === count);
     }
 
-    visitFilterElemMatch(expr: IFilter<FilterFieldOperator.ELEM_MATCH, IFilter | IFilters>) : FilterCompileResult {
-        if (!isFilter(expr.value) && !isFilters(expr.value)) {
-            throw AdapterError.featureUnsupported('filters:elemMatch:value');
-        }
-
-        // an elemMatch on the element itself (arrays of arrays) is
-        // only meaningful inside another elemMatch scope.
-        if (expr.field === ITSELF && !this.bindingPrefix) {
-            throw AdapterError.featureUnsupported('filters:itself');
-        }
-
-        const oldFieldPrefix = this.fieldPrefix;
+    elemMatch(plan: ElemMatchPlan) : ConditionEval {
         const oldBindingPrefix = this.bindingPrefix;
 
         // every elemMatch opens its own quantifier scope: the
@@ -178,94 +183,18 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
         // of its own, so two elemMatches on one field quantify
         // independently (e.g. one per $all value).
         this.scopeSequence += 1;
-        this.fieldPrefix = `${oldFieldPrefix}${expr.field}.`;
-        this.bindingPrefix = `${oldBindingPrefix}${expr.field}${BINDING_SCOPE_SEPARATOR}${this.scopeSequence}.`;
+        this.bindingPrefix = `${oldBindingPrefix}${plan.field}${BINDING_SCOPE_SEPARATOR}${this.scopeSequence}.`;
 
         try {
-            return expr.value.accept(this);
+            return interpretPlan(plan.condition, this);
         } finally {
-            this.fieldPrefix = oldFieldPrefix;
             this.bindingPrefix = oldBindingPrefix;
         }
     }
 
-    visitFilterStartsWith(expr: IFilter<FilterFieldOperator.STARTS_WITH>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildAnchoredTest(expr.value, FilterRegexFlag.STARTS_WITH));
-    }
-
-    visitFilterNotStartsWith(expr: IFilter<FilterFieldOperator.NOT_STARTS_WITH>) : FilterCompileResult {
-        const test = this.buildAnchoredTest(expr.value, FilterRegexFlag.STARTS_WITH);
-
-        return this.leaf(expr.field, (value) => !test(value));
-    }
-
-    visitFilterEndsWith(expr: IFilter<FilterFieldOperator.ENDS_WITH>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildAnchoredTest(expr.value, FilterRegexFlag.ENDS_WITH));
-    }
-
-    visitFilterNotEndsWith(expr: IFilter<FilterFieldOperator.NOT_ENDS_WITH>) : FilterCompileResult {
-        const test = this.buildAnchoredTest(expr.value, FilterRegexFlag.ENDS_WITH);
-
-        return this.leaf(expr.field, (value) => !test(value));
-    }
-
-    visitFilterContains(expr: IFilter<FilterFieldOperator.CONTAINS>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildAnchoredTest(expr.value, FilterRegexFlag.CONTAINS));
-    }
-
-    visitFilterNotContains(expr: IFilter<FilterFieldOperator.NOT_CONTAINS>) : FilterCompileResult {
-        const test = this.buildAnchoredTest(expr.value, FilterRegexFlag.CONTAINS);
-
-        return this.leaf(expr.field, (value) => !test(value));
-    }
-
-    visitFilterRegex(expr: IFilter<FilterFieldOperator.REGEX, RegExp | string>) : FilterCompileResult {
-        return this.leaf(expr.field, this.buildRegexTest(this.buildRegex(expr.value)));
-    }
-
-    visitFilter(expr: IFilter) : FilterCompileResult {
-        throw AdapterError.operatorUnsupported(expr.operator);
-    }
-
-    visitFilters(expr: IFilters) : FilterCompileResult {
-        if (
-            expr.operator !== FilterCompoundOperator.AND &&
-            expr.operator !== FilterCompoundOperator.OR
-        ) {
-            throw AdapterError.operatorUnsupported(expr.operator);
-        }
-
-        const children : NonNullable<FilterCompileResult>[] = [];
-        for (let i = 0; i < expr.value.length; i++) {
-            const child = expr.value[i];
-            if (!child) {
-                continue;
-            }
-
-            if (isFilter(child) || isFilters(child)) {
-                const compiled = child.accept(this);
-                if (compiled) {
-                    children.push(compiled);
-                }
-            }
-        }
-
-        // an empty compound vanishes, exactly like an empty
-        // child adapter in the SQL merge step.
-        if (children.length === 0) {
-            return null;
-        }
-
-        if (expr.operator === FilterCompoundOperator.OR) {
-            return (ctx, root) => children.some((child) => child(ctx, root));
-        }
-
-        return (ctx, root) => children.every((child) => child(ctx, root));
-    }
-
     // -----------------------------------------------------------
 
-    protected leaf(field: string, test: ValueTest) : FilterCompileResult {
+    protected leaf(field: string, test: ValueTest) : ConditionEval {
         if (field === ITSELF) {
             // the marker addresses the element bound by the enclosing
             // elemMatch scope; outside one it has no referent.
@@ -307,22 +236,31 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
 
     // -----------------------------------------------------------
 
-    protected buildEqualTest(input: unknown, field: string) : ValueTest {
-        return anyValue(this.buildValueEqualTest(input, field));
+    /**
+     * Complement law: the negation wraps OUTSIDE element
+     * quantification, so a negated leaf is the exact complement of
+     * its positive twin — null/missing values match.
+     */
+    protected negate(test: ValueTest, negated: boolean) : ValueTest {
+        if (negated) {
+            return (value) => !test(value);
+        }
+
+        return test;
     }
 
     /**
-     * Single-value equality: string conditions compare case-insensitively
-     * (mirroring the SQL adapter's lower()-wrapped rendering) unless the
-     * field is opted out via the `caseSensitive` option — either listed
-     * by key or globally via `caseSensitive: true`.
+     * Single-value equality: `caseFold` carries the settled policy
+     * verdict (string condition, field not opted out) — string
+     * comparisons then fold on both sides, mirroring the SQL
+     * adapter's lower()-wrapped rendering.
      */
-    protected buildValueEqualTest(input: unknown, field: string) : ValueTest {
+    protected buildValueEqualTest(input: unknown, caseFold: boolean) : ValueTest {
         const condition = normalizeValue(input);
 
         if (
-            typeof condition === 'string' &&
-            !this.isCaseSensitive(field)
+            caseFold &&
+            typeof condition === 'string'
         ) {
             const lowered = condition.toLowerCase();
 
@@ -331,11 +269,6 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
         }
 
         return (value) => isValueEqual(value, condition);
-    }
-
-    protected isCaseSensitive(field: string) : boolean {
-        return this.caseSensitiveAll ||
-            this.caseSensitiveFields.has(`${this.fieldPrefix}${field}`);
     }
 
     protected buildCompareTest(input: unknown, min: number, max: number) : ValueTest {
@@ -349,50 +282,5 @@ export class FiltersCompiler implements IFiltersVisitor<FilterCompileResult>,
 
             return result >= min && result <= max;
         });
-    }
-
-    protected buildInTest(input: unknown[], field: string) : ValueTest {
-        if (!Array.isArray(input)) {
-            return () => false;
-        }
-
-        const tests = input.map((item) => this.buildValueEqualTest(item, field));
-
-        return anyValue(
-            (value) => tests.some((test) => test(value)),
-        );
-    }
-
-    protected buildAnchoredTest(input: unknown, flag: number) : ValueTest {
-        return this.buildRegexTest(createFilterRegex(`${input}`, flag));
-    }
-
-    protected buildRegexTest(regex: RegExp) : ValueTest {
-        return anyValue((value) => {
-            const text = toText(value);
-            if (text === undefined) {
-                return false;
-            }
-
-            return regex.test(text);
-        });
-    }
-
-    protected buildRegex(input: unknown) : RegExp {
-        if (input instanceof RegExp) {
-            // rebuild without the stateful flags, so repeated
-            // test() calls never depend on lastIndex.
-            return new RegExp(input.source, input.flags.replace(/[gy]/g, ''));
-        }
-
-        if (typeof input === 'string') {
-            try {
-                return new RegExp(input);
-            } catch {
-                throw AdapterError.featureUnsupported('filters:regex:value');
-            }
-        }
-
-        throw AdapterError.featureUnsupported('filters:regex:value');
     }
 }

--- a/packages/memory/src/parameter/filters/module.ts
+++ b/packages/memory/src/parameter/filters/module.ts
@@ -11,6 +11,10 @@ import type {
     IFilters,
     IFiltersVisitor,
 } from '@rapiq/core';
+import {
+    interpretPlan,
+    planCondition,
+} from '@rapiq/core';
 import type { Predicate } from '../../types';
 import { createBoundPredicate } from './binding';
 import { FiltersCompiler } from './compiler';
@@ -34,17 +38,18 @@ export class FiltersVisitor implements IFiltersVisitor<Predicate>, IFilterVisito
     // -----------------------------------------------------------
 
     protected compile(expr: IFilter | IFilters) : Predicate {
-        const compiler = this.createCompiler();
-
-        const evaluate = expr.accept(compiler);
-        if (!evaluate) {
+        const plan = planCondition(expr, { caseSensitive: this.options.caseSensitive });
+        if (!plan) {
             return () => true;
         }
+
+        const compiler = this.createCompiler();
+        const evaluate = interpretPlan(plan, compiler);
 
         return createBoundPredicate(evaluate, compiler.paths);
     }
 
     protected createCompiler() : FiltersCompiler {
-        return new FiltersCompiler(this.options);
+        return new FiltersCompiler();
     }
 }

--- a/packages/memory/test/unit/filters/compound.spec.ts
+++ b/packages/memory/test/unit/filters/compound.spec.ts
@@ -77,8 +77,26 @@ describe('filters: compounds', () => {
         expect(predicate({ id: 2 })).toBeFalsy();
     });
 
+    it('should negate nor/not groups (plain boolean not, sql parity)', () => {
+        const nor = compileFilters(new Filters('nor', [
+            eq('id', 1),
+            eq('id', 2),
+        ]));
+
+        expect(nor({ id: 3 })).toBeTruthy();
+        expect(nor({ id: 1 })).toBeFalsy();
+        expect(nor({ id: 2 })).toBeFalsy();
+
+        const not = compileFilters(new Filters('not', [
+            and(eq('name', 'Peter'), gte('age', 18)),
+        ]));
+
+        expect(not({ name: 'Peter', age: 28 })).toBeFalsy();
+        expect(not({ name: 'Peter', age: 17 })).toBeTruthy();
+    });
+
     it('should throw on an unknown compound operator', () => {
-        expect(() => compileFilters(new Filters('nor', [eq('id', 1)])))
+        expect(() => compileFilters(new Filters('xor', [eq('id', 1)])))
             .toThrow(AdapterError);
 
         try {

--- a/packages/sql/src/visitor/filters.ts
+++ b/packages/sql/src/visitor/filters.ts
@@ -6,29 +6,49 @@
  */
 
 import type {
+    ComparePlan,
+    CompoundPlan,
+    ConstantPlan,
+    ElemMatchPlan,
+    ICondition,
     IFilterVisitor,
     IFiltersVisitor,
+    IPlanInterpreter,
+    MatchPlan,
+    ModPlan,
+    NullCheckPlan,
+    OneOfPlan,
+    PlanCompareOperator,
 } from '@rapiq/core';
 import {
-    AdapterError,
-    Filter,
-    FilterFieldOperator,
-
-    FilterRegexFlag,
-    Filters,
-    createFilterRegex,
+    interpretPlan,
+    planCondition,
 } from '@rapiq/core';
 import type { IFiltersAdapter } from '../adapter';
 import { escapeLikePattern } from '../helpers';
 import type { VisitorOptions } from './types';
 
+const COMPARE_SYMBOLS : Record<PlanCompareOperator, string> = {
+    eq: '=',
+    lt: '<',
+    lte: '<=',
+    gt: '>',
+    gte: '>=',
+};
+
+/**
+ * Renders a condition tree into SQL fragments by interpreting its
+ * {@link ConditionPlan}: operator semantics (complement law, IN
+ * decomposition, case-fold policy, pattern derivation, value
+ * validation) are decided by the core lowering — this visitor only
+ * renders primitives through the adapter's dialect hooks.
+ */
 export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
-    IFilterVisitor<IFiltersAdapter> {
+    IFilterVisitor<IFiltersAdapter>,
+    IPlanInterpreter<IFiltersAdapter> {
     protected adapter : IFiltersAdapter;
 
     protected options : VisitorOptions;
-
-    protected caseSensitiveFields : Set<string>;
 
     constructor(
         adapter: IFiltersAdapter,
@@ -36,235 +56,104 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     ) {
         this.adapter = adapter;
         this.options = options;
-
-        this.caseSensitiveFields = new Set(options.caseSensitive || []);
-    }
-
-    visitFilterEqual(expr: Filter<FilterFieldOperator.EQUAL>): IFiltersAdapter {
-        if (expr.value === null) {
-            return this.adapter.whereRaw(`${this.adapter.buildField(expr.field)} is null`);
-        }
-
-        if (this.isCaseInsensitive(expr.field, expr.value)) {
-            const field = this.adapter.buildField(expr.field);
-            return this.adapter.whereRaw(
-                `${this.adapter.caseFold(field)} = ${this.adapter.caseFold(this.adapter.buildParamPlaceholder())}`,
-                expr.value,
-            );
-        }
-
-        return this.adapter.where(expr.field, '=', expr.value);
-    }
-
-    visitFilterNotEqual(expr: Filter<FilterFieldOperator.NOT_EQUAL>): IFiltersAdapter {
-        const field = this.adapter.buildField(expr.field);
-        if (expr.value === null) {
-            return this.adapter.whereRaw(`${field} is not null`);
-        }
-
-        if (this.isCaseInsensitive(expr.field, expr.value)) {
-            return this.whereComplement(
-                field,
-                `${this.adapter.caseFold(field)} <> ${this.adapter.caseFold(this.adapter.buildParamPlaceholder())}`,
-                expr.value,
-            );
-        }
-
-        return this.whereComplement(
-            field,
-            `${field} <> ${this.adapter.buildParamPlaceholder()}`,
-            expr.value,
-        );
-    }
-
-    visitFilterLessThan(expr: Filter<FilterFieldOperator.LESS_THAN>): IFiltersAdapter {
-        return this.adapter.where(expr.field, '<', expr.value);
-    }
-
-    visitFilterLessThanEqual(expr: Filter<FilterFieldOperator.LESS_THAN_EQUAL>): IFiltersAdapter {
-        return this.adapter.where(expr.field, '<=', expr.value);
-    }
-
-    visitFilterGreaterThan(expr: Filter<FilterFieldOperator.GREATER_THAN>): IFiltersAdapter {
-        return this.adapter.where(expr.field, '>', expr.value);
-    }
-
-    visitFilterGreaterThanEqual(expr: Filter<FilterFieldOperator.GREATER_THAN_EQUAL>): IFiltersAdapter {
-        return this.adapter.where(expr.field, '>=', expr.value);
-    }
-
-    visitFilterExists(expr: Filter<FilterFieldOperator.EXISTS, boolean>): IFiltersAdapter {
-        return this.adapter.whereRaw(`${this.adapter.buildField(expr.field)} is ${expr.value ? 'not ' : ''}null`);
-    }
-
-    visitFilterIn(expr: Filter<FilterFieldOperator.IN, unknown[]>): IFiltersAdapter {
-        return this.whereIn(expr.field, expr.value, false);
-    }
-
-    visitFilterNotIn(expr: Filter<FilterFieldOperator.NOT_IN, unknown[]>): IFiltersAdapter {
-        return this.whereIn(expr.field, expr.value, true);
-    }
-
-    visitFilterMod(expr: Filter<FilterFieldOperator.MOD, [number, number]>): IFiltersAdapter {
-        const params = this.adapter.buildParamsPlaceholders(expr.value);
-        const sql = `mod(${this.adapter.buildField(expr.field)}, ${params[0]}) = ${params[1]}`;
-        return this.adapter.whereRaw(sql, ...expr.value);
-    }
-
-    visitFilterSize(): IFiltersAdapter {
-        // no SQL rendering yet — an array-length check needs per-dialect
-        // JSON-array support (json_array_length/JSON_LENGTH/cardinality).
-        throw AdapterError.featureUnsupported('filters:size');
-    }
-
-    visitFilterElemMatch(expr: Filter<FilterFieldOperator.ELEM_MATCH, Filter | Filters>): IFiltersAdapter {
-        const oldPrefix = this.adapter.getFieldPrefix();
-
-        this.adapter.setFieldPrefix(`${oldPrefix}${expr.field}.`);
-
-        expr.value.accept(this);
-
-        this.adapter.setFieldPrefix(oldPrefix);
-
-        return this.adapter;
-    }
-
-    visitFilterStartsWith(expr: Filter<FilterFieldOperator.STARTS_WITH, unknown>): IFiltersAdapter {
-        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.STARTS_WITH);
-    }
-
-    visitFilterNotStartsWith(expr: Filter<FilterFieldOperator.NOT_STARTS_WITH, unknown>): IFiltersAdapter {
-        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.STARTS_WITH | FilterRegexFlag.NEGATION);
-    }
-
-    visitFilterEndsWith(expr: Filter<FilterFieldOperator.ENDS_WITH, unknown>): IFiltersAdapter {
-        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.ENDS_WITH);
-    }
-
-    visitFilterNotEndsWith(expr: Filter<FilterFieldOperator.NOT_ENDS_WITH, unknown>): IFiltersAdapter {
-        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.ENDS_WITH | FilterRegexFlag.NEGATION);
-    }
-
-    visitFilterContains(expr: Filter<FilterFieldOperator.CONTAINS, unknown>): IFiltersAdapter {
-        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.CONTAINS);
-    }
-
-    visitFilterNotContains(expr: Filter<FilterFieldOperator.NOT_CONTAINS, unknown>): IFiltersAdapter {
-        return this.whereAnchored(expr.field, expr.value, FilterRegexFlag.CONTAINS | FilterRegexFlag.NEGATION);
-    }
-
-    visitFilterRegex(expr: Filter<FilterFieldOperator.REGEX, RegExp | string>): IFiltersAdapter {
-        const isRegExp = expr.value instanceof RegExp;
-
-        // anything else (a cross-realm RegExp, a number, null) must not be
-        // bound raw as the pattern parameter — fail typed, like @rapiq/memory.
-        if (!isRegExp && typeof expr.value !== 'string') {
-            throw AdapterError.featureUnsupported('filters:regex:value');
-        }
-
-        const source = isRegExp ? expr.value.source : expr.value;
-        const ignoreCase = isRegExp ? expr.value.ignoreCase : false;
-
-        const sql = this.adapter.regexp(
-            this.adapter.buildField(expr.field),
-            this.adapter.buildParamPlaceholder(),
-            ignoreCase,
-        );
-
-        return this.adapter.whereRaw(sql, source);
-    }
-
-    visitFilters(expr: Filters): IFiltersAdapter {
-        const adapter = this.adapter.child();
-        const visitor = new FiltersVisitor(
-            adapter,
-            this.options,
-        );
-
-        for (let i = 0; i < expr.value.length; i++) {
-            const child = expr.value[i];
-            if (child instanceof Filter) {
-                child.accept(visitor);
-            }
-
-            if (child instanceof Filters) {
-                child.accept(visitor);
-            }
-        }
-
-        switch (expr.operator) {
-            case 'or': {
-                this.adapter.merge(
-                    adapter,
-                    'or',
-                );
-                break;
-            }
-            case 'nor': {
-                this.adapter.merge(
-                    adapter,
-                    'or',
-                    true,
-                );
-                break;
-            }
-            case 'not': {
-                this.adapter.merge(
-                    adapter,
-                    'and',
-                    true,
-                );
-                break;
-            }
-            default: {
-                this.adapter.merge(
-                    adapter,
-                    'and',
-                );
-            }
-        }
-
-        return adapter;
-    }
-
-    visitFilter(expr: Filter): IFiltersAdapter {
-        throw AdapterError.operatorUnsupported(expr.operator);
     }
 
     // -----------------------------------------------------------
 
-    /**
-     * Render an IN/NOT IN condition.
-     * A null element also matches the absence of a value (IS NULL);
-     * an empty list matches no row (every row when negated).
-     */
-    protected whereIn(fieldName: string, input: unknown[], negated: boolean) : IFiltersAdapter {
-        if (input.length === 0) {
-            return this.adapter.whereRaw(negated ? '1 = 1' : '1 = 0');
+    visitFilters(expr: ICondition): IFiltersAdapter {
+        return this.run(expr);
+    }
+
+    visitFilter(expr: ICondition): IFiltersAdapter {
+        return this.run(expr);
+    }
+
+    protected run(expr: ICondition) : IFiltersAdapter {
+        const plan = planCondition(expr, { caseSensitive: this.options.caseSensitive });
+        if (!plan) {
+            return this.adapter;
         }
 
-        const values = input.filter((value) => value !== null);
-        const field = this.adapter.buildField(fieldName);
-        const nullCondition = `${field} is ${negated ? 'not ' : ''}null`;
-        if (values.length === 0) {
-            return this.adapter.whereRaw(nullCondition);
+        return interpretPlan(plan, this);
+    }
+
+    // -----------------------------------------------------------
+
+    compound(plan: CompoundPlan): IFiltersAdapter {
+        const adapter = this.adapter.child();
+        const visitor = new FiltersVisitor(adapter, this.options);
+
+        for (const child of plan.children) {
+            interpretPlan(child, visitor);
         }
+
+        this.adapter.merge(adapter, plan.operator, plan.negated);
+
+        return adapter;
+    }
+
+    constant(plan: ConstantPlan): IFiltersAdapter {
+        return this.adapter.whereRaw(plan.verdict ? '1 = 1' : '1 = 0');
+    }
+
+    nullCheck(plan: NullCheckPlan): IFiltersAdapter {
+        return this.adapter.whereRaw(
+            `${this.adapter.buildField(plan.field)} is ${plan.negated ? 'not ' : ''}null`,
+        );
+    }
+
+    compare(plan: ComparePlan): IFiltersAdapter {
+        const fold = plan.caseFold && this.isCaseFoldableField(plan.field);
+
+        if (plan.negated) {
+            const field = this.adapter.buildField(plan.field);
+            const placeholder = this.adapter.buildParamPlaceholder();
+            const sql = fold ?
+                `${this.adapter.caseFold(field)} <> ${this.adapter.caseFold(placeholder)}` :
+                `${field} <> ${placeholder}`;
+
+            return this.whereComplement(field, sql, plan.value);
+        }
+
+        if (fold) {
+            const field = this.adapter.buildField(plan.field);
+
+            return this.adapter.whereRaw(
+                `${this.adapter.caseFold(field)} = ${this.adapter.caseFold(this.adapter.buildParamPlaceholder())}`,
+                plan.value,
+            );
+        }
+
+        return this.adapter.where(plan.field, COMPARE_SYMBOLS[plan.op], plan.value);
+    }
+
+    /**
+     * Render the IN/NOT IN four-case contract: a null member also
+     * matches the absence of a value (IS NULL); the negated form is
+     * the exact complement.
+     */
+    oneOf(plan: OneOfPlan): IFiltersAdapter {
+        const { values } = plan;
+        const field = this.adapter.buildField(plan.field);
+        const nullCondition = `${field} is ${plan.negated ? 'not ' : ''}null`;
 
         let inCondition : string;
         if (
-            this.isCaseFoldableField(fieldName) &&
+            plan.caseFold &&
+            this.isCaseFoldableField(plan.field) &&
             values.some((value) => typeof value === 'string')
         ) {
             const placeholders = values.map((value) => {
                 const placeholder = this.adapter.buildParamPlaceholder();
                 return typeof value === 'string' ? this.adapter.caseFold(placeholder) : placeholder;
             });
-            inCondition = `${this.adapter.caseFold(field)} ${negated ? 'not ' : ''}in(${placeholders.join(', ')})`;
+            inCondition = `${this.adapter.caseFold(field)} ${plan.negated ? 'not ' : ''}in(${placeholders.join(', ')})`;
         } else {
-            inCondition = `${field} ${negated ? 'not ' : ''}in(${this.adapter.buildParamsPlaceholders(values).join(', ')})`;
+            inCondition = `${field} ${plan.negated ? 'not ' : ''}in(${this.adapter.buildParamsPlaceholders(values).join(', ')})`;
         }
-        if (values.length === input.length) {
-            if (negated) {
+
+        if (!plan.includesNull) {
+            if (plan.negated) {
                 return this.whereComplement(field, inCondition, ...values);
             }
 
@@ -272,47 +161,72 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
         }
 
         return this.adapter.whereRaw(
-            `(${inCondition} ${negated ? 'and' : 'or'} ${nullCondition})`,
+            `(${inCondition} ${plan.negated ? 'and' : 'or'} ${nullCondition})`,
             ...values,
         );
     }
 
-    /**
-     * Render a startsWith/endsWith/contains condition (or its negation)
-     * as a regexp condition, falling back to LIKE on regexp-less dialects.
-     */
-    protected whereAnchored(field: string, value: unknown, flag: number) : IFiltersAdapter {
-        if (!this.adapter.isRegexpSupported()) {
-            const escaped = escapeLikePattern(`${value}`);
+    match(plan: MatchPlan): IFiltersAdapter {
+        if (
+            plan.pattern.mode !== 'regex' &&
+            !this.adapter.isRegexpSupported()
+        ) {
+            const escaped = escapeLikePattern(plan.pattern.text);
 
             let pattern : string;
-            if (flag & FilterRegexFlag.STARTS_WITH) {
+            if (plan.pattern.mode === 'starts') {
                 pattern = `${escaped}%`;
-            } else if (flag & FilterRegexFlag.ENDS_WITH) {
+            } else if (plan.pattern.mode === 'ends') {
                 pattern = `%${escaped}`;
             } else {
                 pattern = `%${escaped}%`;
             }
 
-            return this.whereLike(field, pattern, !!(flag & FilterRegexFlag.NEGATION));
+            return this.whereLike(plan.field, pattern, plan.negated);
         }
 
-        const regex = createFilterRegex(`${value}`, flag);
-        if (!(flag & FilterRegexFlag.NEGATION)) {
-            return this.visitFilterRegex(new Filter(FilterFieldOperator.REGEX, field, regex));
-        }
-
-        const fieldBuilt = this.adapter.buildField(field);
+        const field = this.adapter.buildField(plan.field);
         const sql = this.adapter.regexp(
-            fieldBuilt,
+            field,
             this.adapter.buildParamPlaceholder(),
-            regex.ignoreCase,
+            plan.ignoreCase,
         );
 
-        return this.whereComplement(fieldBuilt, sql, regex.source);
+        if (plan.negated) {
+            return this.whereComplement(field, `not (${sql})`, plan.regexSource);
+        }
+
+        return this.adapter.whereRaw(sql, plan.regexSource);
     }
 
-    protected whereLike(field: string, pattern: string, negated = false) : IFiltersAdapter {
+    mod(plan: ModPlan): IFiltersAdapter {
+        const values : [number, number] = [plan.divisor, plan.remainder];
+        const params = this.adapter.buildParamsPlaceholders(values);
+        const sql = `mod(${this.adapter.buildField(plan.field)}, ${params[0]}) = ${params[1]}`;
+
+        return this.adapter.whereRaw(sql, ...values);
+    }
+
+    // no `size` handler: an array-length check needs per-dialect
+    // JSON-array support (json_array_length/JSON_LENGTH/cardinality).
+    // no `itself` declaration: a joined relation row is not a scalar
+    // column, so SQL has no rendering for the element itself.
+
+    elemMatch(plan: ElemMatchPlan): IFiltersAdapter {
+        const oldPrefix = this.adapter.getFieldPrefix();
+
+        this.adapter.setFieldPrefix(`${oldPrefix}${plan.field}.`);
+
+        try {
+            return interpretPlan(plan.condition, this);
+        } finally {
+            this.adapter.setFieldPrefix(oldPrefix);
+        }
+    }
+
+    // -----------------------------------------------------------
+
+    protected whereLike(field: string, pattern: string, negated: boolean) : IFiltersAdapter {
         const fieldBuilt = this.adapter.buildField(field);
         const condition = `${fieldBuilt} ${negated ? 'not ' : ''}like ${this.adapter.buildParamPlaceholder()} escape '\\'`;
         if (negated) {
@@ -323,28 +237,20 @@ export class FiltersVisitor implements IFiltersVisitor<IFiltersAdapter>,
     }
 
     /**
-     * Render a negated condition null-inclusively. Negated operators are
-     * exact complements of their positive twins (complement law), but the
-     * bare SQL negation follows three-valued logic and drops NULL rows.
+     * Render a negated condition null-inclusively. Negated operators
+     * are exact complements of their positive twins (complement
+     * law), but the bare SQL negation follows three-valued logic
+     * and drops NULL rows.
      */
     protected whereComplement(field: string, sql: string, ...values: unknown[]) : IFiltersAdapter {
         return this.adapter.whereRaw(`(${sql} or ${field} is null)`, ...values);
     }
 
     /**
-     * Equality-family comparisons (eq/ne/in/nin) match string values
-     * case-insensitively unless the field is opted out via the
-     * `caseSensitive` visitor option or the adapter exempts it
-     * (non-string columns never fold).
+     * The adapter-side capability veto on the fold policy: backends
+     * with column metadata exempt non-string columns.
      */
-    protected isCaseInsensitive(field: string, value: unknown) : boolean {
-        return typeof value === 'string' && this.isCaseFoldableField(field);
-    }
-
     protected isCaseFoldableField(field: string) : boolean {
-        const path = `${this.adapter.getFieldPrefix()}${field}`;
-
-        return !this.caseSensitiveFields.has(path) &&
-            this.adapter.isCaseFoldable(path);
+        return this.adapter.isCaseFoldable(`${this.adapter.getFieldPrefix()}${field}`);
     }
 }

--- a/packages/sql/test/unit/interpreters/regex.spec.ts
+++ b/packages/sql/test/unit/interpreters/regex.spec.ts
@@ -200,13 +200,16 @@ describe('regex', () => {
     });
 
     it('generates anchored patterns for anchored operators on regexp dialects', () => {
+        // negations render a plain `not` over the POSITIVE pattern
+        // (null-inclusive via the complement arm) — never a
+        // negative-lookahead pattern.
         const cases : [string, string, boolean][] = [
             ['startsWith', '^foo', false],
             ['endsWith', 'foo$', false],
             ['contains', 'foo', false],
-            ['notStartsWith', '^(?!foo).*', true],
-            ['notEndsWith', '^(?!.*foo$).*', true],
-            ['notContains', '^(?!.*foo).*', true],
+            ['notStartsWith', '^foo', true],
+            ['notEndsWith', 'foo$', true],
+            ['notContains', 'foo', true],
         ];
 
         for (const [operator, pattern, negated] of cases) {
@@ -217,7 +220,7 @@ describe('regex', () => {
 
             const [sql, params] = adapter.getQueryAndParameters();
             expect(sql, operator).toEqual(negated ?
-                '("name" ~* $1 or "name" is null)' :
+                '(not ("name" ~* $1) or "name" is null)' :
                 '"name" ~* $1');
             expect(params, operator).toStrictEqual([pattern]);
         }

--- a/packages/typeorm/test/unit/parity.spec.ts
+++ b/packages/typeorm/test/unit/parity.spec.ts
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition } from '@rapiq/core';
+import {
+    AdapterError,
+    FILTER_OPERATOR_SEMANTICS,
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+    ITSELF,
+    Query,
+    isFilters,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/memory';
+import type { DataSource } from 'typeorm';
+import { TypeormAdapter } from '../../src';
+import { Role } from '../data/entity/role';
+import { User } from '../data/entity/user';
+import { createDataSource } from '../data/factory';
+import { createRealmSeed } from '../data/seeder/realm';
+import { createRoleSeed } from '../data/seeder/role';
+import { createUserSeed } from '../data/seeder/user';
+
+/**
+ * Plain-object mirror of the database seed — the same records the
+ * sqlite backend queries, evaluated by @rapiq/memory. The parity
+ * contract: the same condition selects the same rows on every
+ * backend ("one IR, same meaning everywhere").
+ */
+const FIXTURES = [
+    {
+        id: 1,
+        first_name: 'Caleb',
+        last_name: 'Barrows',
+        age: 18,
+        address: 'Hogwarts',
+        email: 'caleb.barrows@gmail.com',
+        nickName: null,
+        realm: null,
+    },
+    {
+        id: 2,
+        first_name: 'Aston',
+        last_name: 'Nel',
+        age: 60,
+        address: null,
+        email: 'ashton.nel@gmail.com',
+        nickName: 'Ash',
+        realm: { name: 'master' },
+    },
+];
+
+type ParityCase = {
+    operator: string,
+    label: string,
+    condition: ICondition,
+    /**
+     * ids expected from BOTH backends — computed by hand from the
+     * fixtures, so the suite asserts documented semantics rather
+     * than echoing either implementation.
+     */
+    expected: number[],
+    /**
+     * The sql/typeorm backend declares this condition unsupported:
+     * assert the typed error instead of row parity. Memory still
+     * must produce `expected`.
+     */
+    sqlThrows?: boolean,
+};
+
+const CASES : ParityCase[] = [
+    {
+        operator: 'eq',
+        label: 'eq folds string case by default',
+        condition: new Filter(FilterFieldOperator.EQUAL, 'first_name', 'CALEB'),
+        expected: [1],
+    },
+    {
+        operator: 'eq',
+        label: 'eq(null) is a null test',
+        condition: new Filter(FilterFieldOperator.EQUAL, 'nickName', null),
+        expected: [1],
+    },
+    {
+        operator: 'ne',
+        label: 'ne matches null values (complement law)',
+        condition: new Filter(FilterFieldOperator.NOT_EQUAL, 'nickName', 'Ash'),
+        expected: [1],
+    },
+    {
+        operator: 'ne',
+        label: 'ne(null) is a not-null test',
+        condition: new Filter(FilterFieldOperator.NOT_EQUAL, 'nickName', null),
+        expected: [2],
+    },
+    {
+        operator: 'lt',
+        label: 'lt',
+        condition: new Filter(FilterFieldOperator.LESS_THAN, 'age', 60),
+        expected: [1],
+    },
+    {
+        operator: 'lte',
+        label: 'lte',
+        condition: new Filter(FilterFieldOperator.LESS_THAN_EQUAL, 'age', 60),
+        expected: [1, 2],
+    },
+    {
+        operator: 'gt',
+        label: 'gt',
+        condition: new Filter(FilterFieldOperator.GREATER_THAN, 'age', 18),
+        expected: [2],
+    },
+    {
+        operator: 'gte',
+        label: 'gte',
+        condition: new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 60),
+        expected: [2],
+    },
+    {
+        operator: 'in',
+        label: 'in with a null member also matches absence',
+        condition: new Filter(FilterFieldOperator.IN, 'nickName', ['Ash', null]),
+        expected: [1, 2],
+    },
+    {
+        operator: 'in',
+        label: 'in([]) matches nothing',
+        condition: new Filter(FilterFieldOperator.IN, 'age', []),
+        expected: [],
+    },
+    {
+        operator: 'nin',
+        label: 'nin with a null member excludes absence',
+        condition: new Filter(FilterFieldOperator.NOT_IN, 'nickName', ['Ash', null]),
+        expected: [],
+    },
+    {
+        operator: 'nin',
+        label: 'nin matches null values (complement law)',
+        condition: new Filter(FilterFieldOperator.NOT_IN, 'nickName', ['Ash']),
+        expected: [1],
+    },
+    {
+        operator: 'startsWith',
+        label: 'startsWith is case-insensitive',
+        condition: new Filter(FilterFieldOperator.STARTS_WITH, 'first_name', 'cal'),
+        expected: [1],
+    },
+    {
+        operator: 'notStartsWith',
+        label: 'notStartsWith',
+        condition: new Filter(FilterFieldOperator.NOT_STARTS_WITH, 'first_name', 'Cal'),
+        expected: [2],
+    },
+    {
+        operator: 'endsWith',
+        label: 'endsWith is case-insensitive',
+        condition: new Filter(FilterFieldOperator.ENDS_WITH, 'email', 'GMAIL.COM'),
+        expected: [1, 2],
+    },
+    {
+        operator: 'notEndsWith',
+        label: 'notEndsWith',
+        condition: new Filter(FilterFieldOperator.NOT_ENDS_WITH, 'email', '@gmail.com'),
+        expected: [],
+    },
+    {
+        operator: 'contains',
+        label: 'contains never matches null values',
+        condition: new Filter(FilterFieldOperator.CONTAINS, 'address', 'warts'),
+        expected: [1],
+    },
+    {
+        operator: 'notContains',
+        label: 'notContains matches null values (complement law)',
+        condition: new Filter(FilterFieldOperator.NOT_CONTAINS, 'address', 'warts'),
+        expected: [2],
+    },
+    {
+        operator: 'regex',
+        label: 'regex is declared unsupported on regexp-less dialects',
+        condition: new Filter(FilterFieldOperator.REGEX, 'last_name', /nel$/i),
+        expected: [2],
+        sqlThrows: true,
+    },
+    {
+        operator: 'mod',
+        label: 'mod',
+        condition: new Filter(FilterFieldOperator.MOD, 'age', [2, 0]),
+        expected: [1, 2],
+    },
+    {
+        operator: 'mod',
+        label: 'an invalid mod value matches nothing everywhere',
+        condition: new Filter(FilterFieldOperator.MOD, 'age', [0, 1]),
+        expected: [],
+    },
+    {
+        operator: 'size',
+        label: 'size is declared unsupported without array columns',
+        condition: new Filter(FilterFieldOperator.SIZE, 'age', 1),
+        expected: [],
+        sqlThrows: true,
+    },
+    {
+        operator: 'exists',
+        label: 'exists(true)',
+        condition: new Filter(FilterFieldOperator.EXISTS, 'nickName', true),
+        expected: [2],
+    },
+    {
+        operator: 'exists',
+        label: 'exists(false)',
+        condition: new Filter(FilterFieldOperator.EXISTS, 'nickName', false),
+        expected: [1],
+    },
+    {
+        operator: 'elemMatch',
+        label: 'elemMatch binds join rows and objects alike',
+        condition: new Filter(
+            FilterFieldOperator.ELEM_MATCH,
+            'realm',
+            new Filter(FilterFieldOperator.EQUAL, 'name', 'master'),
+        ),
+        expected: [2],
+    },
+    {
+        operator: 'elemMatch',
+        label: 'ITSELF is declared unsupported on scalar columns',
+        condition: new Filter(
+            FilterFieldOperator.ELEM_MATCH,
+            'scores',
+            new Filter(FilterFieldOperator.GREATER_THAN, ITSELF, 5),
+        ),
+        expected: [],
+        sqlThrows: true,
+    },
+    {
+        operator: 'and',
+        label: 'compound and',
+        condition: new Filters(FilterCompoundOperator.AND, [
+            new Filter(FilterFieldOperator.GREATER_THAN, 'age', 10),
+            new Filter(FilterFieldOperator.EQUAL, 'first_name', 'Aston'),
+        ]),
+        expected: [2],
+    },
+    {
+        operator: 'or',
+        label: 'compound or',
+        condition: new Filters(FilterCompoundOperator.OR, [
+            new Filter(FilterFieldOperator.EQUAL, 'age', 18),
+            new Filter(FilterFieldOperator.EQUAL, 'age', 60),
+        ]),
+        expected: [1, 2],
+    },
+    {
+        operator: 'nor',
+        label: 'compound nor (plain boolean not)',
+        condition: new Filters('nor', [
+            new Filter(FilterFieldOperator.EQUAL, 'age', 18),
+            new Filter(FilterFieldOperator.GREATER_THAN, 'age', 50),
+        ]),
+        expected: [],
+    },
+    {
+        operator: 'not',
+        label: 'compound not (plain boolean not)',
+        condition: new Filters('not', [
+            new Filter(FilterFieldOperator.GREATER_THAN, 'age', 50),
+        ]),
+        expected: [1],
+    },
+];
+
+describe('cross-backend operator parity', () => {
+    let dataSource : DataSource;
+
+    beforeAll(async () => {
+        dataSource = createDataSource();
+        await dataSource.initialize();
+        await dataSource.synchronize();
+
+        const [master] = await createRealmSeed(dataSource);
+
+        const [admin] = await createRoleSeed(dataSource);
+        const roleRepository = dataSource.getRepository(Role);
+        admin.realm = master;
+        await roleRepository.save(admin);
+
+        const [, aston] = await createUserSeed(dataSource);
+        const userRepository = dataSource.getRepository(User);
+        aston.role = admin;
+        aston.realm = master;
+
+        await userRepository.save(aston);
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    const applyTypeorm = async (condition: ICondition) : Promise<number[]> => {
+        const repository = dataSource.getRepository(User);
+        const queryBuilder = repository.createQueryBuilder('user');
+
+        const filters = isFilters(condition) ?
+            condition :
+            new Filters(FilterCompoundOperator.AND, [condition]);
+
+        const adapter = new TypeormAdapter({ queryBuilder });
+        adapter.execute(new Query({ filters: filters as Filters }));
+
+        const data = await queryBuilder.getMany();
+
+        return data.map((row) => row.id).sort();
+    };
+
+    const applyMemory = (condition: ICondition) : number[] => {
+        const predicate = compileFilters(condition as Filter | Filters);
+
+        return FIXTURES
+            .filter((row) => predicate(row))
+            .map((row) => row.id)
+            .sort();
+    };
+
+    it('should enroll every operator of the semantics table', () => {
+        const covered = new Set(CASES.map((entry) => entry.operator));
+
+        for (const operator of Object.keys(FILTER_OPERATOR_SEMANTICS)) {
+            expect(covered, `operator ${operator} has no parity case`)
+                .toContain(operator);
+        }
+    });
+
+    for (const entry of CASES) {
+        it(`${entry.operator}: ${entry.label}`, async () => {
+            expect(applyMemory(entry.condition)).toEqual(entry.expected);
+
+            if (entry.sqlThrows) {
+                await expect(applyTypeorm(entry.condition))
+                    .rejects.toThrowError(AdapterError);
+
+                return;
+            }
+
+            expect(await applyTypeorm(entry.condition)).toEqual(entry.expected);
+        });
+    }
+});


### PR DESCRIPTION
Closes #791

## What

Filter-operator semantics now have one home. `@rapiq/core` gains a declarative operator-semantics table plus a lowering pass, and both backends become thin interpreters over pre-decided primitives:

- **`FILTER_OPERATOR_SEMANTICS`** (`core/parameter/filters/plan/constants.ts`) — one row per operator: family, negation twin (`complementOf`), visitor dispatch method, anchor placement, comparison range, case-fold participation. `Filter.accept` derives its per-operator dispatch from this table (runtime behavior identical; the 19-branch if-chain is gone).
- **`planCondition(condition, { caseSensitive })`** lowers any condition tree into ~9 plan-node kinds with every policy decision already made: negation twins resolved to `negated` leaf flags (complement law), `eq/ne(null)` → null checks, in/nin decomposed (empty list → constant, null members extracted, non-array → constant), fold verdicts computed (string value + `caseSensitive` opt-out, composed through elemMatch prefixes), anchored operators derived into escaped positive patterns, mod/size values validated, ITSELF placement checked, `nor`/`not` mapped to negated groups.
- **`interpretPlan(plan, interpreter)`** is the single support-enforcement point: optional handler presence (`mod`/`size`/`elemMatch`) and the `itself` declaration *are* the support matrix; the typed `featureUnsupported` throw lives here and nowhere else.
- **`@rapiq/sql`**: `visitor/filters.ts` drops `whereIn`/`whereAnchored`/`isCaseInsensitive` and all 19 visit methods for one handler per plan node (350 → ~250 lines, pure rendering). The adapter surface is untouched — **`@rapiq/typeorm` needed zero source changes**.
- **`@rapiq/memory`**: `compiler.ts` same treatment (398 → ~270 lines); `binding.ts` (quantification) untouched.
- **Parity suite** (`typeorm/test/unit/parity.spec.ts`): 31 hand-computed cases asserting the same condition selects the same rows on typeorm-over-better-sqlite3 and `@rapiq/memory`; a coverage test forces at least one case per table operator, so a future operator cannot ship without parity coverage. Declared-unsupported conditions assert the typed error.

## Deliberate behavior changes

- **Negated anchored rendering (sql)**: `notContains` & co. now render `(not (<regexp positive>) or <field> is null)` instead of a negative-lookahead pattern. Semantically identical; lookaheads are gone entirely (one snapshot assertion updated).
- **`@rapiq/memory` gains `nor`/`not` compound support** (plain boolean negation, sql parity) — it previously threw `operatorUnsupported` while sql supported them.
- **Uniform degenerate-input laws** (previously divergent or broken): a malformed `mod` value renders a never-match constant on sql (was: invalid SQL) exactly as memory always did; a non-array `in`/`nin` value lowers to a constant (sql previously crashed with a TypeError); an invalid `elemMatch` interior throws the typed error on sql too (previously a crash); `eq/ne(undefined)` is unified to `null` everywhere.
- The per-operator `IFilterVisitor` methods are **kept** — removing them in favor of the plan is a later, separately-deliberate step once downstream consumers migrate.

## Not in scope

- Slimming `IFilterVisitor` / removing `createFilterRegex`'s negation flags from the public surface.
- Dialect-level `size` support (JSON array length) — the plan node + support matrix make that a per-dialect follow-up.
- Docs: `guide/filters.md`'s support statements (size/ITSELF) remain accurate as written.

## Testing

- New: core lowering + table-law spec (`filters-plan.spec.ts`, 32 tests), cross-backend parity suite (31 cases + coverage guard).
- Updated: one sql regex snapshot (rendering change above), one memory compound spec (`nor` now supported; unknown operators still throw typed).
- All 8 packages green: 1,248 tests; lint clean; full `nx run-many` build passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a unified filter planning system for consistent condition handling across memory and SQL backends.
  - Expanded support for negation, null values, membership, pattern matching, arithmetic, array sizes, and nested element matching.
  - Added centralized validation and clearer errors for unsupported filter capabilities.

- **Bug Fixes**
  - Improved consistency of filter behavior and case handling across backends.
  - Added cross-backend parity coverage to detect differing results.

- **Tests**
  - Expanded coverage for compound filters, regular expressions, operator semantics, and backend parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->