### PR TITLE
fix(core): restore index-signature relation keys & thread build-input DEPTH

### DIFF
--- a/packages/core/src/build/parameter/fields/types.ts
+++ b/packages/core/src/build/parameter/fields/types.ts
@@ -22,7 +22,8 @@ export type FieldsBuildSimpleKeyInput<
 
 export type FieldsBuildNestedKeyInput<
     T extends ObjectLiteral = ObjectLiteral,
-> = FieldWithOperator<NestedKeys<T>>;
+    DEPTH extends number = 5,
+> = FieldWithOperator<NestedKeys<T, DEPTH>>;
 
 export type FieldsBuildRecordInput<
     T extends Record<PropertyKey, any>,
@@ -52,5 +53,5 @@ export type FieldsBuildInput<
 > = [DEPTH] extends [0] ? never :
     FieldsBuildRecordInput<T, PrevIndex[DEPTH]> |
     FieldsBuildTupleInput<T, PrevIndex[DEPTH]> |
-    FieldsBuildNestedKeyInput<T>[] |
-    FieldsBuildNestedKeyInput<T>;
+    FieldsBuildNestedKeyInput<T, DEPTH>[] |
+    FieldsBuildNestedKeyInput<T, DEPTH>;

--- a/packages/core/src/build/parameter/filters/types.ts
+++ b/packages/core/src/build/parameter/filters/types.ts
@@ -94,5 +94,5 @@ export type FiltersBuildInput<
     {
         [K in keyof T & string]?: FiltersBuildKeyValueInput<T[K], PrevIndex[DEPTH]>
     } & {
-        [K in NestedKeys<T>]?: FiltersBuildValueInput<TypeFromNestedKeyPath<T, K>>
+        [K in NestedKeys<T, DEPTH>]?: FiltersBuildValueInput<TypeFromNestedKeyPath<T, K, DEPTH>>
     };

--- a/packages/core/src/build/parameter/relations/types.ts
+++ b/packages/core/src/build/parameter/relations/types.ts
@@ -22,5 +22,5 @@ export type RelationsBuildInput<
                 RelationsBuildInput<T[K], PrevIndex[DEPTH]> | boolean :
                 never
     } |
-    NestedResourceKeys<T>[] |
-    NestedResourceKeys<T>;
+    NestedResourceKeys<T, DEPTH>[] |
+    NestedResourceKeys<T, DEPTH>;

--- a/packages/core/src/build/parameter/sorts/types.ts
+++ b/packages/core/src/build/parameter/sorts/types.ts
@@ -40,5 +40,5 @@ export type SortsBuildInput<
         SortWithOperator<SimpleKeys<T>>[],
         SortsBuildRecordInput<T, PrevIndex[DEPTH]>,
     ] |
-    SortWithOperator<NestedKeys<T>>[] |
-    SortWithOperator<NestedKeys<T>>;
+    SortWithOperator<NestedKeys<T, DEPTH>>[] |
+    SortWithOperator<NestedKeys<T, DEPTH>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -46,6 +46,18 @@ export type SimpleKeys<
 }[keyof T & string];
 
 /**
+ * The keys of `T` that are explicitly declared, with the `string`/`number`
+ * index signatures of a "bag" type stripped out. A pure `Record<string, any>`
+ * has none; an entity that merely *carries* an index signature (e.g.
+ * `{ id: string; name: string; [key: string]: any }`) still keeps its literal
+ * keys. Relies on a homomorphic mapped type iterating the declared members, so
+ * the `as`-filter removes the index signature without collapsing the literals.
+ */
+type KnownKeys<T> = keyof {
+    [K in keyof T as string extends K ? never : number extends K ? never : K]: 0
+};
+
+/**
  * A property is traversed as a nested branch only when it is a record with
  * known literal keys. Index-signature records (e.g. JSON columns typed
  * Record<string, any>) stay leaves — recursing into them would produce
@@ -55,6 +67,23 @@ type IsRecursiveKeyValue<T> = T extends Date ?
     never :
     T extends Record<PropertyKey, any> ?
         string extends keyof T ?
+            never :
+            T :
+        never;
+
+/**
+ * A property is a *resource* (relation target) when it is a record that carries
+ * at least one explicitly-declared key. Proper records qualify, and so does an
+ * entity that additionally carries a dynamic-attribute index signature (see
+ * #789) — the bag guard {@link IsRecursiveKeyValue} still stops the recursion,
+ * but it must not drop the relation key itself. A pure index-signature bag
+ * (`Record<string, any>`, e.g. a JSON column) has no declared structure and is
+ * therefore not a relation — it stays a leaf field.
+ */
+type IsRecordKeyValue<T> = T extends Date ?
+    never :
+    T extends Record<PropertyKey, any> ?
+        [KnownKeys<T>] extends [never] ?
             never :
             T :
         never;
@@ -80,11 +109,11 @@ export type SimpleResourceKeys<
 > = {
     [Key in keyof T & string]: NonNullable<T[Key]> extends Array<infer ELEMENT> ?
         (
-            NonNullable<ELEMENT> extends IsRecursiveKeyValue<NonNullable<ELEMENT>> ?
+            NonNullable<ELEMENT> extends IsRecordKeyValue<NonNullable<ELEMENT>> ?
                 Key :
                 never
         ) :
-        NonNullable<T[Key]> extends IsRecursiveKeyValue<NonNullable<T[Key]>> ?
+        NonNullable<T[Key]> extends IsRecordKeyValue<NonNullable<T[Key]>> ?
             Key :
             never
 }[keyof T & string];
@@ -96,11 +125,19 @@ export type NestedResourceKeys<
     {
         [Key in keyof T & string]: NonNullable<T[Key]> extends Array<infer ELEMENT> ?
             (
-                NonNullable<ELEMENT> extends IsRecursiveKeyValue<NonNullable<ELEMENT>> ?
-                    Key | `${Key}.${NestedResourceKeys<NonNullable<ELEMENT>, PrevIndex[DEPTH]>}` :
+                NonNullable<ELEMENT> extends IsRecordKeyValue<NonNullable<ELEMENT>> ?
+                    (
+                        NonNullable<ELEMENT> extends IsRecursiveKeyValue<NonNullable<ELEMENT>> ?
+                            Key | `${Key}.${NestedResourceKeys<NonNullable<ELEMENT>, PrevIndex[DEPTH]>}` :
+                            Key
+                    ) :
                     never
-            ) : NonNullable<T[Key]> extends IsRecursiveKeyValue<NonNullable<T[Key]>> ?
-                Key | `${Key}.${NestedResourceKeys<ArrayItem<NonNullable<T[Key]>>, PrevIndex[DEPTH]>}` :
+            ) : NonNullable<T[Key]> extends IsRecordKeyValue<NonNullable<T[Key]>> ?
+                (
+                    NonNullable<T[Key]> extends IsRecursiveKeyValue<NonNullable<T[Key]>> ?
+                        Key | `${Key}.${NestedResourceKeys<ArrayItem<NonNullable<T[Key]>>, PrevIndex[DEPTH]>}` :
+                        Key
+                ) :
                 never
     }[keyof T & string];
 

--- a/packages/core/test/data/type.ts
+++ b/packages/core/test/data/type.ts
@@ -39,6 +39,24 @@ export type Event = {
 
 // -----------------------------------------------------
 
+// A relation target that carries a dynamic-attribute index signature
+// (e.g. authup's `User`). It is a valid relation target — only its
+// *expansion* must stop at the bag. See #789.
+export type BagUser = {
+    id: string,
+    name: string,
+    // dynamically loaded extra attributes
+    [key: string]: any,
+};
+
+export type BagUserPermission = {
+    id: string,
+    user: BagUser,
+    userId: string,
+};
+
+// -----------------------------------------------------
+
 export type GrandChildEntity = {
     id: string,
 

--- a/packages/core/test/data/type.ts
+++ b/packages/core/test/data/type.ts
@@ -57,6 +57,24 @@ export type BagUserPermission = {
 
 // -----------------------------------------------------
 
+// A self-recursive entity graph (nullable + array relations pointing back
+// at themselves). Used to assert that the build-input DEPTH bound actually
+// truncates the key arms. See #790.
+export type Policy = {
+    id: string,
+    name: string,
+    children: Policy[],
+    parent: Policy | null,
+};
+
+export type Client = {
+    id: string,
+    name: string,
+    accessPolicy: Policy | null,
+};
+
+// -----------------------------------------------------
+
 export type GrandChildEntity = {
     id: string,
 

--- a/packages/core/test/unit/build/module.spec.ts
+++ b/packages/core/test/unit/build/module.spec.ts
@@ -5,7 +5,14 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
-import type { IFilter, QueryBuildInput } from '../../../src';
+import type {
+    FieldsBuildInput,
+    FiltersBuildInput,
+    IFilter,
+    QueryBuildInput,
+    RelationsBuildInput,
+    SortsBuildInput,
+} from '../../../src';
 import {
     BuildError,
     ErrorCode,
@@ -27,7 +34,7 @@ import {
     gte,
     or,
 } from '../../../src';
-import type { User } from '../../data';
+import type { Client, User } from '../../data';
 
 const leafs = (filters: { value: unknown[] }) => filters.value as IFilter[];
 
@@ -453,5 +460,55 @@ describe('src/build/module.ts', () => {
         expect(output.sorts.value.map((el) => [el.name, el.operator])).toEqual([
             ['realm.name', SortDirection.DESC],
         ]);
+    });
+});
+
+describe('src/build/parameter/*/types.ts — DEPTH threads into the key arms (#790)', () => {
+    // `Client.accessPolicy` -> `Policy` is self-recursive. A DEPTH of 2 must
+    // truncate the string-key arms one segment past `accessPolicy`; a
+    // 3-segment path (`accessPolicy.children.*`) is only reachable at DEPTH 3+.
+    // Before the fix the string-key arms ran at their default depth (4) and
+    // admitted the deeper path regardless of the declared DEPTH.
+
+    it('should bound the fields nested-key arm by DEPTH', () => {
+        const ok: FieldsBuildInput<Client, 2> = 'accessPolicy.name';
+
+        // @ts-expect-error DEPTH=2 must not admit a 3-segment field path
+        const tooDeep: FieldsBuildInput<Client, 2> = 'accessPolicy.children.name';
+
+        expect(ok).toBeDefined();
+        expect(tooDeep).toBeDefined();
+    });
+
+    it('should bound the sort nested-key arm by DEPTH', () => {
+        const ok: SortsBuildInput<Client, 2> = '-accessPolicy.name';
+
+        // @ts-expect-error DEPTH=2 must not admit a 3-segment sort path
+        const tooDeep: SortsBuildInput<Client, 2> = '-accessPolicy.children.name';
+
+        expect(ok).toBeDefined();
+        expect(tooDeep).toBeDefined();
+    });
+
+    it('should bound the relations nested-key arm by DEPTH', () => {
+        const ok: RelationsBuildInput<Client, 2> = 'accessPolicy.children';
+
+        // @ts-expect-error DEPTH=2 must not admit a 3-segment relation path
+        const tooDeep: RelationsBuildInput<Client, 2> = 'accessPolicy.children.parent';
+
+        expect(ok).toBeDefined();
+        expect(tooDeep).toBeDefined();
+    });
+
+    it('should bound the filters nested-key arm by DEPTH', () => {
+        const ok: FiltersBuildInput<Client, 2> = { 'accessPolicy.name': 'root' };
+
+        const tooDeep: FiltersBuildInput<Client, 2> = {
+            // @ts-expect-error DEPTH=2 must not admit a 3-segment filter key
+            'accessPolicy.children.name': 'root',
+        };
+
+        expect(ok).toBeDefined();
+        expect(tooDeep).toBeDefined();
     });
 });

--- a/packages/core/test/unit/types.spec.ts
+++ b/packages/core/test/unit/types.spec.ts
@@ -14,7 +14,11 @@ import type {
     SimpleResourceKeys,
     TypeFromNestedKeyPath,
 } from '../../src';
-import type { Event, User } from '../data/type';
+import type {
+    BagUserPermission, 
+    Event, 
+    User,
+} from '../data/type';
 
 describe('src/types.ts', () => {
     describe('SimpleKeys', () => {
@@ -91,7 +95,29 @@ describe('src/types.ts', () => {
         });
     });
 
+    describe('SimpleResourceKeys (index-signature target, #789)', () => {
+        it('should keep a relation whose target carries an index signature', () => {
+            const keys: SimpleResourceKeys<BagUserPermission>[] = ['user'];
+
+            // @ts-expect-error a scalar column is not a resource key
+            const invalid: SimpleResourceKeys<BagUserPermission>[] = ['userId'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+    });
+
     describe('NestedResourceKeys', () => {
+        it('should keep a relation whose target carries an index signature but not recurse into the bag (#789)', () => {
+            const keys: NestedResourceKeys<BagUserPermission>[] = ['user'];
+
+            // @ts-expect-error a bag relation target exposes no nested resource paths
+            const invalid: NestedResourceKeys<BagUserPermission>[] = ['user.realm'];
+
+            expect(keys).toBeDefined();
+            expect(invalid).toBeDefined();
+        });
+
         it('should cover nullable & optional relations (incl. nested)', () => {
             const keys: NestedResourceKeys<Event>[] = [
                 'realm',
@@ -147,6 +173,12 @@ describe('src/types.ts', () => {
             });
 
             expect(schema).toBeDefined();
+        });
+
+        it('should accept a relation whose target carries an index signature (#789)', () => {
+            const schema = defineSchema<BagUserPermission>({ relations: { allowed: ['user'] } });
+
+            expect(schema.relations.allowed).toEqual(['user']);
         });
     });
 });


### PR DESCRIPTION
Two core key-type regressions surfaced by `2.0.0-beta.2`, both blocking authup#3279 phase 1.

## #789 — `*ResourceKeys` drop relation keys whose target carries an index signature

beta.2's index-signature exclusion in `IsRecursiveKeyValue` correctly stops key-path recursion **at** attribute-bag types, but `SimpleResourceKeys` / `NestedResourceKeys` reused that same predicate for **key membership** — so a relation whose target type carries an index signature (e.g. an entity with `[key: string]: any` dynamic attributes) disappeared entirely.

The issue suggested treating *any* bag as a resource key, but that would regress #785 (a pure `Record<string, any>` JSON column must **not** be a relation). The precise distinction is **declared literal keys**:

- Added `KnownKeys<T>` — a homomorphic mapped type that strips `string`/`number` index signatures while keeping literal keys.
- Added `IsRecordKeyValue<T>` — a record that declares **at least one** literal key.
- `SimpleResourceKeys` / `NestedResourceKeys` now use `IsRecordKeyValue` for key membership and keep `IsRecursiveKeyValue` for the `${Key}.${…}` recursion arm.

Result: an entity that *carries* an index signature contributes its own relation key but is not expanded; a pure index-signature bag stays a leaf field. This removes the `@ts-expect-error` workaround called out in the issue.

## #790 — build-input `DEPTH` not threaded into the string-key arms

The `DEPTH` generic was only forwarded into the record-form arms; every string-key arm instantiated its key union at the `NestedKeys` / `NestedResourceKeys` default depth (4), so a caller-declared `DEPTH` never bounded the type. On a self-recursive entity graph (where beta.2 now expands previously-leaf nullable relations) the union grew past the declared bound and tripped `TS2590` downstream, with no depth choice able to help.

Now `DEPTH` is forwarded through every string-key arm: `FieldsBuildNestedKeyInput<T, DEPTH>`, `SortWithOperator<NestedKeys<T, DEPTH>>`, `NestedResourceKeys<T, DEPTH>`, and `NestedKeys<T, DEPTH>` + `TypeFromNestedKeyPath<T, K, DEPTH>` for filters. The declared `DEPTH` now bounds the whole type, so consumers can lower it on recursive graphs.

## Tests

Type-level tests were written first, confirmed failing (bug reproduced), then made green by the fix — validated via `tsc --noEmit` over the test-inclusive tsconfig (vitest does not type-check).

- New fixtures: `BagUser` / `BagUserPermission` (#789) and self-recursive `Policy` / `Client` (#790).
- `types.spec.ts`: index-signature relation targets stay resource keys but do not recurse; the exact `defineSchema` repro from #789 now compiles.
- `build/module.spec.ts`: each build-input arm rejects a 3-segment path at `DEPTH=2` (admitted before the fix), while the 2-segment path stays valid.

## Verification

`tsc --noEmit` (src + test) clean · full monorepo build green · all 1186 tests pass · lint clean on changed files.

Closes #789
Closes #790