### PR TITLE
fix(parser-simple): decode boolean filter input to an equality condition

### DIFF
--- a/packages/parser-simple/src/parameter/filters/wire/module.ts
+++ b/packages/parser-simple/src/parameter/filters/wire/module.ts
@@ -71,7 +71,10 @@ function normalizeFilterValue(input: unknown) : Scalar | Scalar[] {
         return parseFilterScalar(trimmed);
     }
 
-    if (typeof input === 'number') {
+    if (
+        typeof input === 'number' ||
+        typeof input === 'boolean'
+    ) {
         return input;
     }
 
@@ -142,8 +145,9 @@ function decodeToken(input: string) : FilterWireCondition {
 }
 
 /**
- * Decode a complete simple-dialect wire value (string, number, or
- * qs-produced array) into the condition it expresses. Applies
+ * Decode a complete simple-dialect wire value (string, number,
+ * boolean, or qs-produced array) into the condition it expresses.
+ * Applies
  * value-shape normalization first (commas beat markers), then the
  * membership lifting (G3): an array decodes as in, lifted to nin
  * when its first element carries the negation modifier — later

--- a/packages/parser-simple/test/unit/parser/filters-wire.spec.ts
+++ b/packages/parser-simple/test/unit/parser/filters-wire.spec.ts
@@ -27,6 +27,8 @@ describe('src/parameter/filters/wire/*.ts', () => {
             ['null value', 'null', 'eq', null],
             ['negated null value', '!null', 'ne', null],
             ['boolean coercion', 'true', 'eq', true],
+            ['genuine boolean true (object input)', true, 'eq', true],
+            ['genuine boolean false (object input)', false, 'eq', false],
             ['contains with raw inner text', '~oh~', 'contains', 'oh'],
             ['negated contains', '!~oh~', 'notContains', 'oh'],
             ['startsWith', 'Jo~', 'startsWith', 'Jo'],
@@ -50,6 +52,7 @@ describe('src/parameter/filters/wire/*.ts', () => {
             ['negated first element lifts to nin', '!a,b', 'nin', ['a', 'b']],
             ['later elements stay unparsed', '!a,!b', 'nin', ['a', '!b']],
             ['markers are inert inside lists', '<5,10', 'in', ['<5', 10]],
+            ['genuine boolean array (false survives the falsy filter)', [true, false], 'in', [true, false]],
             ['empty comma list', ',', 'in', []],
         ])('should decode %s (membership is a value shape)', (_, wire, operator, value) => {
             expect(decodeFilterWireValue(wire)).toEqual({
@@ -86,7 +89,6 @@ describe('src/parameter/filters/wire/*.ts', () => {
 
         it.each([
             ['plain object', { nested: true }],
-            ['boolean input', true],
         ])('should return the valueInvalid verdict for %s', (_, input) => {
             expect(decodeFilterWireValue(input)).toEqual({
                 success: false,

--- a/packages/parser-simple/test/unit/parser/filters.spec.ts
+++ b/packages/parser-simple/test/unit/parser/filters.spec.ts
@@ -335,6 +335,27 @@ describe('src/filter/index.ts', () => {
         );
     });
 
+    it('should parse boolean input', async () => {
+        const schema = defineFiltersSchema({ allowed: ['active'] });
+
+        // genuine boolean (parseTyped advertises it for boolean record fields)
+        let output = parseFlat({ active: true }, { schema });
+        expect(output).toEqual(
+            new Filter(FilterFieldOperator.EQUAL, 'active', true),
+        );
+
+        output = parseFlat({ active: false }, { schema });
+        expect(output).toEqual(
+            new Filter(FilterFieldOperator.EQUAL, 'active', false),
+        );
+
+        // boolean array (false survives the falsy-value filter)
+        output = parseFlat({ active: [true, false] }, { schema });
+        expect(output).toEqual(
+            new Filter(FilterFieldOperator.IN, 'active', [true, false]),
+        );
+    });
+
     it('should parse different string match inputs', async () => {
         const schema = defineFiltersSchema({ allowed: ['name'] });
 


### PR DESCRIPTION
## Problem

`SimpleFiltersParserInput` advertises booleans for boolean record fields (`V | null | '!null'` for `V extends boolean`), so `parser.parseTyped<User>({ filters: { active: true } })` type-checks — but at runtime `normalizeFilterValue` had no boolean branch. A genuine `true`/`false` fell through to `throw new SyntaxError`, the decode verdict reported `valueInvalid`, and the condition was silently dropped (or threw `FiltersParseError.keyValueInvalid` under `throwOnFailure`). The string spelling `'true'` already coerced to a boolean `eq`.

## Fix

Booleans now pass through `normalizeFilterValue` like numbers, so:

- `decodeFilterWireValue(true)` → `{ operator: 'eq', value: true }` (same for `false`)
- `[true, false]` → `in [true, false]` (the falsy-value filter already keeps `false`)

This is object-input handling only — a genuine boolean can never arrive via a URL query string, so accepting it is a strict widening; the frozen wire grammar and the URL decode path are untouched. Encoding already worked (`serializeBareValue` spells booleans as `'true'`/`'false'`).

## Testing

- Wire boundary spec: booleans moved from the `valueInvalid` table to success coverage (`true`, `false`, and the `[true, false]` membership shape)
- End-to-end `SimpleFiltersParser` coverage: `{ active: true }` → `eq true`, `{ active: false }` → `eq false`, `{ active: [true, false] }` → `in [true, false]`
- `@rapiq/parser-simple` build + 194 tests green; downstream `@rapiq/codec-url` (234), `@rapiq/parser-expression` (69), `@rapiq/parser-mongo` (133) all green; eslint clean on changed files

Fixes #799

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Boolean filter values are now supported for equality and membership filters.
  * Boolean arrays preserve both `true` and `false` values when creating `IN` filters.

* **Bug Fixes**
  * Fixed handling of `false` values so they are no longer incorrectly discarded during filter processing.

* **Tests**
  * Added coverage for parsing boolean filters and boolean arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->