### PR TITLE
docs: document regex operator trust model and gating

### DIFF
--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -34,7 +34,7 @@ Every dialect maps onto the same operator set (`FilterFieldOperator`):
 | `EXISTS` | is not null | `$exists` | `exists` | — |
 | `ELEM_MATCH` | array element match | `$elemMatch` | `elemMatch` | — |
 
-`REGEX`, `MOD` and `EXISTS` have no representation in the URL dialects — they work in code, via the [MongoDB-style parser](/packages/parser-mongo), and in every [adapter](/guide/executing-queries). `ELEM_MATCH` and `SIZE` travel in the [expression dialect](/packages/parser-expression) only.
+`REGEX`, `MOD` and `EXISTS` have no representation in the URL dialects — they work in code, via the [MongoDB-style parser](/packages/parser-mongo), and in every [adapter](/guide/executing-queries). Before accepting `regex` from untrusted input, read the [trust model](#regex-trust-model) below. `ELEM_MATCH` and `SIZE` travel in the [expression dialect](/packages/parser-expression) only.
 
 `SIZE` matches arrays with exactly the given number of elements (a non-negative integer); missing or non-array values never match, and there is no negated form. It evaluates in [`@rapiq/memory`](/packages/memory) — the SQL adapters throw a typed `featureUnsupported` until dialect-level JSON-array support lands.
 
@@ -186,6 +186,44 @@ const encoded = await codec.encodeAsync(query, { schema });
 ```
 
 The async path awaits validators sequentially in filter-tree order. Calling a synchronous method when a validator returns a Promise/thenable throws a `SchemaError` with `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER`. Compound `and`/`or` structure is preserved; if every submitted leaf is rejected, the schema default is applied.
+
+## Regex trust model
+
+The `regex` operator's pattern is **passed through to the consuming engine** — rapiq does not analyze, rewrite or sandbox it:
+
+- [`@rapiq/sql`](/packages/sql) and [`@rapiq/typeorm`](/packages/typeorm) hand the pattern to the database engine to interpret and validate — the engine's own syntax checks, limits and timeouts govern it.
+- [`@rapiq/memory`](/packages/memory) compiles the pattern with JavaScript's backtracking `RegExp` engine and evaluates it against every record — a crafted pattern (nested quantifiers such as `(a+)+$`) over long field values can burn CPU (ReDoS). Compilation rejects invalid syntax, not pathological patterns.
+
+Whether a hostile pattern can reach an evaluator depends on the input dialect:
+
+- The **URL dialects cannot carry one** — `regex` has no wire spelling, so queries decoded by [`@rapiq/codec-url`](/packages/codec-url) never contain a regex condition.
+- The **[MongoDB-style parser](/packages/parser-mongo) accepts `$regex`** (a pattern string or `RegExp`) from client documents.
+
+::: warning Gate `$regex` for untrusted clients
+An application that parses untrusted mongo-style filter documents and evaluates them in-process with `@rapiq/memory` must gate the operator — the `allowed` list does not help, since `$regex` applies to allowed fields.
+:::
+
+The [`validate` hook](#schema-options) sees every parsed leaf and can reject regex conditions:
+
+```typescript
+import { FilterFieldOperator, defineSchema } from '@rapiq/core';
+
+const schema = defineSchema<User>({
+    filters: {
+        allowed: ['id', 'name'],
+        validate: (filter) => {
+            // reject client-submitted regex conditions
+            if (filter.operator === FilterFieldOperator.REGEX) {
+                return undefined;
+            }
+
+            return filter;
+        },
+    },
+});
+```
+
+A leaf rejected by `validate` is silently dropped, independent of the `throwOnFailure` policy — throw from the hook to turn a client-submitted regex into an error response instead. Softer gates work the same way: cap the pattern's source length or match it against a vetted list, and return the filter when it passes.
 
 ## On violation
 

--- a/packages/docs/packages/memory.md
+++ b/packages/docs/packages/memory.md
@@ -88,6 +88,10 @@ compileFilters(condition, { caseSensitive: true });
 
 The boolean only governs the equality family — `contains`/`startsWith`/`endsWith` stay case-insensitive, exactly like the list form. `caseSensitive: false` equals the default.
 
+::: warning Regex patterns run as-is
+The `regex` operator compiles the query's pattern with JavaScript's backtracking `RegExp` engine and evaluates it against every record — a crafted pattern (nested quantifiers) over long field values can burn CPU (ReDoS). Compilation only rejects invalid syntax. The URL dialects cannot carry a regex, but the [mongo dialect](/packages/parser-mongo) accepts `$regex` — when queries originate from untrusted input, gate the operator with the schema's `filters.validate` hook. See the [regex trust model](/guide/filters#regex-trust-model).
+:::
+
 ### Join-row binding
 
 Dotted paths emulate the SQL adapter's joins: all conditions on one relation path bind to the **same array element**, and the record matches if *some* assignment of elements satisfies the whole filter tree. An empty or absent array contributes one all-`null` row, like a LEFT JOIN.

--- a/packages/docs/packages/parser-mongo.md
+++ b/packages/docs/packages/parser-mongo.md
@@ -59,6 +59,10 @@ Multiple document entries combine with an implicit AND. `$and` / `$or` / `$nor` 
 - An empty sub-document `{}` inside a compound (MongoDB's match-all branch) is a grammar error.
 :::
 
+::: warning Untrusted `$regex`
+`$regex` patterns pass through the parser verbatim — this is the only dialect that lets a client submit one. If filter documents come from untrusted clients and are evaluated in-process with [`@rapiq/memory`](/packages/memory), gate the operator with the schema's `filters.validate` hook — see the [regex trust model](/guide/filters#regex-trust-model).
+:::
+
 ## Usage
 
 ```typescript


### PR DESCRIPTION
Documents the trust model of the `regex` filter operator and how to gate it for untrusted input (items 1 and 2 of #794).

## What was documented

**`packages/docs/guide/filters.md`** — new "Regex trust model" section:
- The pattern is passed through to the consuming engine — rapiq does not analyze, rewrite or sandbox it: SQL/TypeORM hand it to the database engine (its limits govern), `@rapiq/memory` compiles it with JavaScript's backtracking `RegExp` engine, where a crafted pattern over long field values can burn CPU (ReDoS); compilation rejects only invalid syntax, not pathological patterns.
- Exposure by dialect: the URL dialects have no wire spelling for `regex` (codec-url input cannot carry one); the MongoDB-style parser accepts `$regex` from client documents.
- Copy-pasteable gating example via the schema `filters.validate` hook (reject `FilterFieldOperator.REGEX` leaves by returning `undefined`), including drop-vs-throw semantics and softer variants (pattern-length cap, vetted list).
- Cross-link from the operator table's notes to the new section.

**`packages/docs/packages/parser-mongo.md`** — warning container after the operator table: `$regex` passes through verbatim and is the only client dialect that can submit one; gate via `filters.validate` when documents are untrusted and evaluated with `@rapiq/memory`.

**`packages/docs/packages/memory.md`** — warning container in the filter-semantics section: regex patterns run as-is on the backtracking engine; cross-link to the trust model.

## Out of scope

Item 3 of the issue — a first-class per-schema operator allow-list (e.g. `filters.operators`) — is intentionally **not** included. If still wanted, it should be re-filed as its own feature issue.

Closes #794