### PR TITLE
docs: note wire marker spellings accepted by typed simple filter input

### DIFF
--- a/packages/docs/packages/parser-simple.md
+++ b/packages/docs/packages/parser-simple.md
@@ -77,6 +77,35 @@ Per-parameter input shapes and the wire operator syntax are documented on the pa
 
 Each parameter also has a standalone parser class — `SimpleFieldsParser`, `SimpleFiltersParser`, `SimplePaginationParser`, `SimpleRelationsParser`, `SimpleSortParser` — with the same `(input, { schema })` signature, returning that parameter's AST node. Useful when only one parameter comes from user input. Every parser exposes `parseAsync()`; `SimpleFiltersParser` also exposes `parseTypedAsync()` alongside `parseTyped()`.
 
+### Typed filter input
+
+`SimpleFiltersParser.parseTyped<RECORD>(input, options)` behaves exactly like `parse()`, but checks field keys and value spellings against the record type. The value union is derived from the same wire-grammar table that drives decoding, so it advertises every spelling the runtime accepts. For a scalar value `V`:
+
+| Spelling | Operator |
+|---|---|
+| `V` / `!V` | equal / not equal |
+| `<V`, `<=V`, `>V`, `>=V` | comparisons |
+| `~V~` / `!~V~` | contains / not contains |
+| `V~` / `!V~` | starts with / not starts with |
+| `~V` / `!~V` | ends with / not ends with |
+| `null` / `'!null'` | is null / is not null |
+| array of values | in list (`!` on the first element → not in) |
+
+```typescript
+const filtersParser = new SimpleFiltersParser(registry);
+
+const filters = filtersParser.parseTyped<User>({
+    name: 'jo~',   // starts with; '~jo~' (contains) & '~jo' (ends with) type-check too
+    age: '>=18',
+}, { schema: 'user' });
+```
+
+Two deliberate gaps: the comparison family advertises no `!` spellings — a leading `!` before `<`/`>` markers is discarded on decode (a frozen v1 quirk) — and boolean fields accept no marker forms at all, only `true`/`false`/`null`/`'!null'`, because `'!true'` decodes to *not equal `true`*, which as an [exact complement](/guide/filters#null-semantics) also matches `null`/missing — it is not *equal `false`*.
+
+::: info Widened in v2
+Earlier v2 betas hand-wrote this union with prefix spellings only — `~V~` (contains), `V~` (starts with) and their negated forms `!~V~` / `!V~` were compile-time errors, even though the wire grammar always decoded them. The union now derives from the wire table, so those spellings type-check. This is a type-level widening only: the wire format is byte-for-byte unchanged and stays v1-compatible.
+:::
+
 ## Errors
 
 Schema violations follow the [drop-vs-throw policy](/guide/schemas#failure-behavior-drop-vs-throw); with `throwOnFailure`, the per-parameter `ParseError` subclasses are thrown. See [Error Handling](/guide/errors).


### PR DESCRIPTION
## Summary

#797 was implemented in #798 — the simple filter wire grammar is now single-sourced in `@rapiq/parser-simple`'s `wire/` module, and the typed-input union for `SimpleFiltersParser.parseTyped()` derives from the same table that drives runtime decode/encode. This PR completes the RFC's remaining item, the docs follow-up: note on the simple-dialect page that typed input now accepts the contains/startsWith spellings the wire always accepted.

## Changes

`packages/docs/packages/parser-simple.md` gains a **Typed filter input** section under *Per-parameter parsers* documenting the derived value union for a scalar `V`:

- positive: `V` (eq), `<V` / `<=V` / `>V` / `>=V`, `~V~` (contains), `V~` (starts with), `~V` (ends with)
- negated: `!V` (ne), `!~V~` (not contains), `!V~` (not starts with), `!~V` (not ends with)
- value-domain carve-outs: `null` / `'!null'`; arrays express `in` lists (leading `!` on the first element lifts to `nin`)

Newly accepted at the type level (previously missing from the hand-written union, always accepted by the runtime decoder): `~V~`, `V~`, `!~V~`, `!V~`.

The section also records the deliberate gaps — no `!` spellings for the comparison family (a leading `!` before `<`/`>` markers is discarded on decode, frozen v1 quirk) and no marker forms on booleans (`'!true'` is *ne true*, which under the complement law also matches `null`/missing — not *eq false*) — and states explicitly that this is a compile-time widening only; the wire format is byte-for-byte unchanged and v1-compatible.

`guide/filters.md`, `guide/building-queries.md` and `guide/migration-v1.md` were checked for stale spelling lists — all accurate, left untouched.

Closes #797