### PR TITLE
feat(typeorm): add assertSchemaMatchesEntity validation helper

### DIFF
--- a/packages/core/src/errors/code.ts
+++ b/packages/core/src/errors/code.ts
@@ -30,6 +30,8 @@ export enum ErrorCode {
 
     CODEC_UNRESOLVABLE = 'codecUnresolvable',
 
+    SCHEMA_ENTITY_MISMATCH = 'schemaEntityMismatch',
+
     SCHEMA_NAME_INVALID = 'schemaNameInvalid',
 
     SCHEMA_UNRESOLVABLE = 'schemaUnresolvable',

--- a/packages/docs/guide/errors.md
+++ b/packages/docs/guide/errors.md
@@ -17,6 +17,7 @@ BaseError { code: ErrorCode }
 ├── AdapterError          backends & encoders — query exceeds the target's subset
 ├── CodecError            codec registry — unresolvable dialect
 └── SchemaError           schema registry — misconfigured or unresolvable schema
+    └── SchemaEntityMismatchError   @rapiq/typeorm — schema keys unknown to the entity
 ```
 
 ## Where errors come from
@@ -76,6 +77,7 @@ The URL encoders throw these too — a codec never silently changes what a query
 | `SCHEMA_NAME_INVALID` | `registry.add()` with a schema that has no `name` |
 | `SCHEMA_UNRESOLVABLE` | `registry.getOrFail()` for a name that isn't registered |
 | `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER` | `parse()` (or a synchronous codec method) encountered an async filter validator; use the corresponding `Async` method |
+| `SCHEMA_ENTITY_MISMATCH` | `assertSchemaMatchesEntity` (`@rapiq/typeorm`) found schema keys unknown to the entity — thrown as `SchemaEntityMismatchError`, which carries the offending `schema`, `entity` and `keys`; see [validating schemas against entities](/packages/typeorm#validating-schemas-against-entities) |
 
 ## Mapping to HTTP responses
 

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -133,6 +133,41 @@ Derivation never sets [`strict`](/guide/schemas#strict-mode) — combined with `
 The data source only needs built metadata, not an open connection — deriving schemas at startup before `dataSource.initialize()` completes is fine as long as the metadata was built.
 :::
 
+## Validating schemas against entities
+
+Hand-written schemas drift silently: a renamed column leaves a dead key in an allow-list that either never matches again or surfaces as a runtime adapter error on first client use. `assertSchemaMatchesEntity` checks every key a schema references against the entity metadata — call it at boot so drift fails the deploy, not a request:
+
+```typescript
+import { assertSchemaMatchesEntity } from '@rapiq/typeorm';
+
+assertSchemaMatchesEntity(userSchema, User, dataSource);
+// or, mirroring defineSchemaWithEntity, with metadata directly:
+assertSchemaMatchesEntity(userSchema, dataSource.getMetadata(User));
+```
+
+Validated keys: `fields.default` and `fields.allowed`, `filters.allowed` and the leaf fields of a `filters.default` condition tree, `sort.allowed` (tuple groups included) and the keys of `sort.default`, and `relations.allowed`. The rules:
+
+- Plain keys must be column property paths — embedded paths like `profile.firstName` included.
+- Dotted keys that aren't a column path must be headed by a relation. Only the head is checked; the remainder belongs to the related entity — validate that schema against its own entity.
+- `relations.allowed` keys must be relation property names (dotted keys headed by a relation).
+
+On a mismatch the helper throws a `SchemaEntityMismatchError` (code `schemaEntityMismatch`, a `SchemaError` subclass) that collects **every** offending key rather than stopping at the first, and exposes `schema`, `entity` and `keys` as properties:
+
+```typescript
+import { SchemaEntityMismatchError } from '@rapiq/typeorm';
+
+try {
+    assertSchemaMatchesEntity(userSchema, User, dataSource);
+} catch (e) {
+    if (e instanceof SchemaEntityMismatchError) {
+        console.error(e.schema, e.entity, e.keys); // 'user', 'User', ['renamedAway']
+    }
+    throw e;
+}
+```
+
+Schemas produced by `defineSchemaWithEntity` don't need this — their structure comes from the metadata in the first place. The helper targets curated, hand-written schemas kept next to derived ones.
+
 ## Applying a single parameter
 
 A `Query` with only some parameters set applies just those — the rest are empty and become no-ops. To apply, say, only the filters of a parsed query:

--- a/packages/typeorm/src/errors/index.ts
+++ b/packages/typeorm/src/errors/index.ts
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2025.
+ * Copyright (c) 2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './assert';
 export * from './module';
 export * from './types';

--- a/packages/typeorm/src/errors/module.ts
+++ b/packages/typeorm/src/errors/module.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ErrorCode, SchemaError } from '@rapiq/core';
+import type { SchemaEntityMismatchErrorOptions } from './types';
+
+/**
+ * A schema references keys unknown to the entity it targets —
+ * thrown by `assertSchemaMatchesEntity` with **every** offending
+ * key collected, not just the first one.
+ */
+export class SchemaEntityMismatchError extends SchemaError {
+    public readonly schema : string | undefined;
+
+    public readonly entity : string;
+
+    public readonly keys : string[];
+
+    constructor(options: SchemaEntityMismatchErrorOptions) {
+        super({
+            message: `The ${options.schema ? `schema "${options.schema}"` : 'schema'} ` +
+                `references keys unknown to the entity ${options.entity}: ${options.keys.join(', ')}.`,
+            code: ErrorCode.SCHEMA_ENTITY_MISMATCH,
+        });
+
+        this.schema = options.schema;
+        this.entity = options.entity;
+        this.keys = options.keys;
+    }
+}

--- a/packages/typeorm/src/errors/types.ts
+++ b/packages/typeorm/src/errors/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type SchemaEntityMismatchErrorOptions = {
+    /**
+     * Name of the offending schema (a schema may be unnamed).
+     */
+    schema?: string,
+
+    /**
+     * Name of the entity the schema was validated against.
+     */
+    entity: string,
+
+    /**
+     * Every schema key unknown to the entity.
+     */
+    keys: string[],
+};

--- a/packages/typeorm/src/index.ts
+++ b/packages/typeorm/src/index.ts
@@ -7,4 +7,5 @@
 
 export * from './adapter';
 export * from './dialect';
+export * from './errors';
 export * from './schema';

--- a/packages/typeorm/src/schema/assert.ts
+++ b/packages/typeorm/src/schema/assert.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition, ObjectLiteral, Schema } from '@rapiq/core';
+import { isFilter, isFilters } from '@rapiq/core';
+import { DataSource, EntityMetadata } from 'typeorm';
+import type { EntityTarget } from 'typeorm';
+import { SchemaEntityMismatchError } from '../errors';
+
+/**
+ * Verify that every key referenced by the schema exists on the entity:
+ * plain keys must be column property paths (embedded paths included),
+ * dotted keys must be headed by a relation, and `relations.allowed`
+ * keys must be relation property names. Turns silent schema/entity
+ * drift (e.g. a renamed column) into a boot-time failure instead of
+ * a dead allow-list entry or a runtime adapter error.
+ *
+ * @throws SchemaEntityMismatchError carrying every offending key.
+ */
+export function assertSchemaMatchesEntity<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    schema: Schema<RECORD>,
+    metadata: EntityMetadata,
+) : void;
+export function assertSchemaMatchesEntity<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    schema: Schema<RECORD>,
+    target: EntityTarget<RECORD>,
+    dataSource: DataSource,
+) : void;
+export function assertSchemaMatchesEntity<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    schema: Schema<RECORD>,
+    target: EntityMetadata | EntityTarget<RECORD>,
+    dataSource?: DataSource,
+) : void {
+    let metadata : EntityMetadata;
+    if (target instanceof EntityMetadata) {
+        metadata = target;
+    } else {
+        if (!(dataSource instanceof DataSource)) {
+            throw new Error('A data source is required to resolve the metadata of an entity target.');
+        }
+
+        metadata = dataSource.getMetadata(target);
+    }
+
+    const columns = new Set<string>(metadata.columns.map(
+        (column) => column.propertyPath,
+    ));
+    const relations = new Set<string>(metadata.relations.map(
+        (relation) => relation.propertyName,
+    ));
+
+    const invalid = new Set<string>();
+
+    const headOf = (key: string) => {
+        const index = key.indexOf('.');
+        return index === -1 ? key : key.substring(0, index);
+    };
+
+    const checkColumnKey = (key: unknown) => {
+        if (typeof key !== 'string' || columns.has(key)) {
+            return;
+        }
+
+        // dotted keys not matching a column path (embedded)
+        // must be headed by a relation — the remainder belongs
+        // to the related entity's own schema.
+        const head = headOf(key);
+        if (head !== key && relations.has(head)) {
+            return;
+        }
+
+        invalid.add(key);
+    };
+    const checkColumnKeys = (keys: string[] | string[][]) => {
+        for (const key of keys.flat()) {
+            checkColumnKey(key);
+        }
+    };
+    // a filters default is a condition tree, not a key list — walk it
+    // and validate every leaf field like a filters allow-list entry.
+    const checkCondition = (condition: ICondition) => {
+        if (isFilters(condition)) {
+            for (const child of condition.value) {
+                checkCondition(child);
+            }
+            return;
+        }
+
+        if (isFilter(condition)) {
+            checkColumnKey(condition.field);
+        }
+    };
+
+    checkColumnKeys(schema.fields.default);
+    checkColumnKeys(schema.fields.allowed);
+
+    checkColumnKeys(schema.filters.allowed);
+    if (schema.filters.default) {
+        checkCondition(schema.filters.default);
+    }
+
+    checkColumnKeys(schema.sort.allowed);
+    checkColumnKeys(schema.sort.defaultKeys);
+
+    // relation keys resolve against relations only — the first
+    // (or sole) segment must be a relation property name.
+    for (const key of schema.relations.allowed || []) {
+        if (!relations.has(headOf(key))) {
+            invalid.add(key);
+        }
+    }
+
+    if (invalid.size > 0) {
+        throw new SchemaEntityMismatchError({
+            schema: schema.name,
+            entity: metadata.name,
+            keys: [...invalid],
+        });
+    }
+}

--- a/packages/typeorm/test/unit/schema/assert.spec.ts
+++ b/packages/typeorm/test/unit/schema/assert.spec.ts
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { SchemaOptions } from '@rapiq/core';
+import { and, defineSchema, eq } from '@rapiq/core';
+import type { DataSource } from 'typeorm';
+import {
+    SchemaEntityMismatchError,
+    assertSchemaMatchesEntity,
+} from '../../../src';
+import { createUnconnectedDataSource } from '../../data/factory';
+import { Role } from '../../data/entity/role';
+import { User } from '../../data/entity/user';
+
+function grabError(fn: () => void) : SchemaEntityMismatchError {
+    try {
+        fn();
+    } catch (e) {
+        expect(e).toBeInstanceOf(SchemaEntityMismatchError);
+        return e as SchemaEntityMismatchError;
+    }
+
+    throw new Error('Expected a SchemaEntityMismatchError to be thrown.');
+}
+
+describe('src/schema/assert.ts', () => {
+    let dataSource : DataSource;
+
+    // metadata-only DataSource (unconnected) — validation reads the
+    // entity metadata, never the tables.
+    beforeAll(async () => {
+        dataSource = await createUnconnectedDataSource();
+    });
+
+    it('should accept a schema matching the entity', () => {
+        const schema = defineSchema({
+            name: 'user',
+            fields: {
+                default: ['id', 'email'],
+                allowed: ['id', 'email', 'age', 'profile.firstName'],
+            },
+            filters: {
+                allowed: ['id', 'email', 'realm_id'],
+                default: and(eq('age', 18), eq('realm.name', 'master')),
+            },
+            sort: {
+                allowed: ['id', 'first_name'],
+                default: { id: 'DESC' },
+            },
+            relations: { allowed: ['realm', 'role'] },
+        });
+
+        expect(() => assertSchemaMatchesEntity(schema, dataSource.getMetadata(User)))
+            .not.toThrow();
+    });
+
+    it('should collect a dead column key of each parameter', () => {
+        const check = (options: SchemaOptions, key: string) => {
+            const schema = defineSchema({ name: 'user', ...options });
+            const error = grabError(() => assertSchemaMatchesEntity(
+                schema,
+                dataSource.getMetadata(User),
+            ));
+            expect(error.keys).toEqual([key]);
+        };
+
+        check({ fields: { default: ['renamedAway'] } }, 'renamedAway');
+        check({ fields: { allowed: ['renamedAway'] } }, 'renamedAway');
+        check({ filters: { allowed: ['renamedAway'] } }, 'renamedAway');
+        check({ sort: { allowed: ['renamedAway'] } }, 'renamedAway');
+    });
+
+    it('should accept dotted keys headed by a relation and reject others', () => {
+        const valid = defineSchema({
+            name: 'valid',
+            sort: { allowed: ['realm.name'] },
+            filters: { allowed: ['role.detail'] },
+        });
+        expect(() => assertSchemaMatchesEntity(valid, dataSource.getMetadata(User)))
+            .not.toThrow();
+
+        const invalid = defineSchema({
+            name: 'invalid',
+            sort: { allowed: ['unknownRelation.name'] },
+        });
+        expect(grabError(() => assertSchemaMatchesEntity(invalid, dataSource.getMetadata(User))).keys)
+            .toEqual(['unknownRelation.name']);
+    });
+
+    it('should accept embedded column paths and reject embedded drift', () => {
+        const valid = defineSchema({
+            name: 'embedded-valid',
+            fields: { allowed: ['profile.firstName', 'profile.lastName'] },
+        });
+        expect(() => assertSchemaMatchesEntity(valid, dataSource.getMetadata(User)))
+            .not.toThrow();
+
+        // `profile` is an embedded, not a relation — a dead key
+        // inside it must not pass as a relation-headed path.
+        const invalid = defineSchema({
+            name: 'embedded-invalid',
+            fields: { allowed: ['profile.renamedAway'] },
+        });
+        expect(grabError(() => assertSchemaMatchesEntity(invalid, dataSource.getMetadata(User))).keys)
+            .toEqual(['profile.renamedAway']);
+    });
+
+    it('should accept relation property names in the relations allow-list only', () => {
+        const valid = defineSchema({
+            name: 'relations-valid',
+            relations: { allowed: ['realm', 'role.detail'] },
+        });
+        expect(() => assertSchemaMatchesEntity(valid, dataSource.getMetadata(User)))
+            .not.toThrow();
+
+        // a column is not joinable ...
+        const column = defineSchema({
+            name: 'relation-as-column',
+            relations: { allowed: ['email'] },
+        });
+        expect(grabError(() => assertSchemaMatchesEntity(column, dataSource.getMetadata(User))).keys)
+            .toEqual(['email']);
+
+        // ... and a relation is not a field.
+        const field = defineSchema({
+            name: 'column-as-relation',
+            fields: { allowed: ['realm'] },
+        });
+        expect(grabError(() => assertSchemaMatchesEntity(field, dataSource.getMetadata(User))).keys)
+            .toEqual(['realm']);
+    });
+
+    it('should validate the leaf fields of a filters default condition tree', () => {
+        const schema = defineSchema({
+            name: 'filters-default',
+            filters: { default: and(eq('name', 'admin'), eq('renamedAway', 'x')) },
+        });
+
+        expect(grabError(() => assertSchemaMatchesEntity(schema, dataSource.getMetadata(Role))).keys)
+            .toEqual(['renamedAway']);
+    });
+
+    it('should validate sort default keys and flatten tuple groups', () => {
+        const schema = defineSchema({
+            name: 'sort',
+            sort: {
+                allowed: [['first_name', 'last_name'], ['renamedAway']],
+                default: { deadDefault: 'DESC' },
+            },
+        });
+
+        expect(grabError(() => assertSchemaMatchesEntity(schema, dataSource.getMetadata(User))).keys)
+            .toEqual(['renamedAway', 'deadDefault']);
+    });
+
+    it('should aggregate offending keys across parameters', () => {
+        const schema = defineSchema({
+            name: 'drifted',
+            fields: { allowed: ['id', 'deadField'] },
+            filters: { allowed: ['email', 'deadFilter'] },
+            sort: { allowed: ['deadSort'] },
+            relations: { allowed: ['realm', 'deadRelation'] },
+        });
+
+        const error = grabError(() => assertSchemaMatchesEntity(
+            schema,
+            dataSource.getMetadata(User),
+        ));
+
+        expect(error.schema).toEqual('drifted');
+        expect(error.entity).toEqual('User');
+        expect(error.keys).toEqual(['deadField', 'deadFilter', 'deadSort', 'deadRelation']);
+        expect(error.code).toEqual('schemaEntityMismatch');
+        expect(error.message).toContain('drifted');
+        expect(error.message).toContain('deadField, deadFilter, deadSort, deadRelation');
+    });
+
+    it('should resolve the metadata of an entity target', () => {
+        const valid = defineSchema({
+            name: 'target-valid',
+            filters: { allowed: ['email'] },
+        });
+        expect(() => assertSchemaMatchesEntity(valid, User, dataSource))
+            .not.toThrow();
+
+        const invalid = defineSchema({
+            name: 'target-invalid',
+            filters: { allowed: ['renamedAway'] },
+        });
+        expect(grabError(() => assertSchemaMatchesEntity(invalid, User, dataSource)).keys)
+            .toEqual(['renamedAway']);
+    });
+});


### PR DESCRIPTION
## Motivation

Hand-written allow-list schemas drift silently from their entities: a renamed column leaves a dead key in `fields`/`filters`/`sort.allowed` that either never matches again or surfaces as a runtime adapter error on first client use. authup guards this downstream with a boot-time validator — this PR ports it upstream into `@rapiq/typeorm`, next to `defineSchemaWithEntity`.

## API

```ts
function assertSchemaMatchesEntity(schema: Schema, metadata: EntityMetadata): void;
// convenience overload mirroring defineSchemaWithEntity:
function assertSchemaMatchesEntity(schema: Schema, target: EntityTarget, dataSource: DataSource): void;
```

On a mismatch it throws a `SchemaEntityMismatchError` (new, exported from `@rapiq/typeorm`) — a `SchemaError` subclass with the new core `ErrorCode.SCHEMA_ENTITY_MISMATCH` (`schemaEntityMismatch`) that **collects every offending key** (not first-fail) and exposes `schema`, `entity` and `keys` as properties, so the failure is programmatically inspectable beyond the message.

## Validation rules

- `fields.default`, `fields.allowed`, `filters.allowed`, `sort.allowed` (tuple groups `string[][]` flattened one level), `sort.default` keys: plain keys must be column property paths (`metadata.columns[].propertyPath` — embedded paths like `profile.firstName` included); dotted keys that aren't a column path must be headed by a relation (`metadata.relations[].propertyName`). Only the head is checked — the remainder belongs to the related entity's own schema.
- A `filters.default` condition tree is walked (`isFilters`/`isFilter`) and every leaf field is validated like a filters allow-list entry; leaf *values* (e.g. `elemMatch` interiors with the `$this` marker) are not descended into.
- `relations.allowed`: keys must be relation property names (dotted keys headed by a relation). A plain column key in `relations.allowed` fails — stricter than the downstream original, matching the rule as stated in the issue.

The `schemaMapping`/`SchemaRegistry` validation extension mentioned in the issue is **left out as separate scope**.

## Implementation notes

- `packages/typeorm/src/schema/assert.ts` — the helper, exported via the existing `schema`/root barrels.
- `packages/typeorm/src/errors/` — the new error class; extends core's `SchemaError` so it slots into the documented hierarchy (schema misconfiguration → server bug).
- `packages/core/src/errors/code.ts` — one additive `ErrorCode` member (`BaseErrorOptions.code` is typed against the core enum, so a typed code requires it; matches the "add an ErrorCode member" convention).
- Docs: new "Validating schemas against entities" section on the `@rapiq/typeorm` page; error hierarchy/code table updated on the error-handling guide.

## Testing

- `packages/typeorm/test/unit/schema/assert.spec.ts` (metadata-only, unconnected DataSource — no live DB): valid schema passes; dead keys per parameter collected; dotted relation-headed keys pass, non-relation-headed fail; embedded paths pass and embedded drift fails; relations allow-list rejects column keys (and vice versa); sort tuple groups flattened; filters default tree and sort default keys validated; aggregation across parameters with `schema`/`entity`/`keys`/`code` property assertions; both overloads.
- `@rapiq/typeorm`: 15 files / 134 tests pass; `@rapiq/core`: 361 tests pass; full monorepo build and eslint on all changed files clean.

Closes #800