### PR TITLE
feat: first-class not() negation in the public condition IR

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -68,14 +68,16 @@ A `Schema<RECORD>` declares what a client *may* request per parameter (`allowed`
 // packages/core/src/parameter/module.ts
 class Query implements IQuery {
     readonly fields: IFields;        // Field { name, operator?: FieldOperator.INCLUDE|EXCLUDE }
-    readonly filters: IFilters;      // compound node: FilterCompoundOperator.AND|OR over ICondition[]
+    readonly filters: IFilters;      // compound node: FilterCompoundOperator.AND|OR|NOT over ICondition[]
     readonly pagination: IPagination;// { limit, offset }
     readonly relations: IRelations;  // Relation { name }
     readonly sorts: ISorts;          // Sort { name, operator: SortDirection.ASC|DESC }
 }
 ```
 
-Filters form a two-level tree: `Filters` (and/or compound, children are `ICondition[]` — nested `Filters` or leaf `Filter`) and `Filter` (leaf condition `{ field, operator, value }`, operators from `FilterFieldOperator`: `EQUAL`, `LT(E)`, `GT(E)`, `IN`, `CONTAINS`, `STARTS_WITH`, `REGEX`, …).
+Filters form a two-level tree: `Filters` (and/or/not compound, children are `ICondition[]` — nested `Filters` or leaf `Filter`) and `Filter` (leaf condition `{ field, operator, value }`, operators from `FilterFieldOperator`: `EQUAL`, `LT(E)`, `GT(E)`, `IN`, `CONTAINS`, `STARTS_WITH`, `REGEX`, …).
+
+**Negation semantics (settled 2026-07-21, issue #811)**: `not(condition)` (builder + `FilterCompoundOperator.NOT`) is the **exact null-inclusive complement** — it matches exactly the rows/bindings its interior does not, the leaf complement law extended to whole trees, identical across memory/sql/typeorm (pinned by the typeorm parity + complement suites). `planCondition` normalizes a single-child `not` onto the child plan's own negated form (`not(eq)` ≙ `ne`; constants flip verdict; double negation cancels); only interiors without a negated leaf form (ordering compares, mod, size, elemMatch, multi-child groups) stay a `CompoundPlan` with `negated: true`, which SQL renders two-valued via `case when (…) then 1 else 0 end = 0` (a bare `not (…)` would drop null-bearing rows per three-valued logic). The expression dialect parses/serializes `not(…)` first-class (single twin-able leaves normalize to their twin on decode); the legacy simple dialect throws typed. `Filters.flatten()` never hoists through NOT (not associative). Do not re-litigate: group negation is NOT SQL-three-valued, and `nor` stays an internal lowering alias (not public API, no wire form).
 
 ### Visitor interfaces (core)
 

--- a/packages/codec-url/src/expression/encoder/filters.ts
+++ b/packages/codec-url/src/expression/encoder/filters.ts
@@ -8,6 +8,7 @@
 import type { ICondition, IFilters } from '@rapiq/core';
 import {
     AdapterError,
+    FilterCompoundOperator,
     FilterFieldOperator,
     ITSELF,
     isFilter,
@@ -45,10 +46,15 @@ export function serializeFiltersExpression(input: IFilters) : string | null {
     }
 
     // a single root condition needs no compound wrapper — the parser
-    // wraps bare conditions back into a root AND.
+    // wraps bare conditions back into a root AND. Only and/or roots
+    // may unwrap: a NOT root changes the child's meaning.
     if (
         input.value.length === 1 &&
-        isFilter(input.value[0])
+        isFilter(input.value[0]) &&
+        (
+            input.operator === FilterCompoundOperator.AND ||
+            input.operator === FilterCompoundOperator.OR
+        )
     ) {
         return serializeCondition(input.value[0], false);
     }
@@ -67,7 +73,26 @@ function serializeCompound(input: IFilters, insideElemMatch: boolean) : string {
         (child) => serializeCondition(child, insideElemMatch),
     );
 
-    return `${input.operator}(${children.join(',')})`;
+    switch (input.operator) {
+        case FilterCompoundOperator.AND:
+        case FilterCompoundOperator.OR: {
+            return `${input.operator}(${children.join(',')})`;
+        }
+        case FilterCompoundOperator.NOT: {
+            // the grammar production takes a single interior —
+            // multiple children negate their conjunction.
+            if (children.length === 1) {
+                return `not(${children[0]})`;
+            }
+
+            return `not(and(${children.join(',')}))`;
+        }
+        default: {
+            // e.g. 'nor' — no expression grammar production; emitting
+            // it verbatim would produce an undecodable token.
+            throw AdapterError.operatorUnsupported(input.operator);
+        }
+    }
 }
 
 function serializeCondition(node: ICondition, insideElemMatch: boolean) : string {

--- a/packages/codec-url/src/simple/encoder/visitors/filters.ts
+++ b/packages/codec-url/src/simple/encoder/visitors/filters.ts
@@ -38,6 +38,16 @@ IFilterVisitor<RecordSerializer> {
             throw AdapterError.featureUnsupported('filters:or');
         }
 
+        // a negated group (or any non-and/or compound) has no simple
+        // wire form at all — serializing its children positively would
+        // silently drop the negation.
+        if (
+            expr.operator !== FilterCompoundOperator.AND &&
+            expr.operator !== FilterCompoundOperator.OR
+        ) {
+            throw AdapterError.featureUnsupported(`filters:${expr.operator}`);
+        }
+
         for (let i = 0; i < expr.value.length; i++) {
             const value = expr.value[i];
             if (value instanceof Filters) {

--- a/packages/codec-url/test/unit/expression-roundtrip.spec.ts
+++ b/packages/codec-url/test/unit/expression-roundtrip.spec.ts
@@ -30,11 +30,13 @@ import {
     gt,
     gte,
     inArray,
+    isFilters,
     lt,
     lte,
     mod,
     ne,
     nin,
+    not,
     notContains,
     notEndsWith,
     notStartsWith,
@@ -43,7 +45,12 @@ import {
     size,
     startsWith,
 } from '@rapiq/core';
-import type { IFilter, IFilters, IQuery } from '@rapiq/core';
+import type {
+    ICondition, 
+    IFilter, 
+    IFilters, 
+    IQuery,
+} from '@rapiq/core';
 import { ExpressionURLDecoder, ExpressionURLEncoder } from '../../src/expression';
 
 /**
@@ -164,6 +171,54 @@ describe('round-trip', () => {
             expect(roundTripFilter(filter)).toEqual(
                 new Filters(FilterCompoundOperator.AND, [expected]),
             );
+        });
+
+        it.each([
+            [
+                'not over an ordering comparison',
+                not(gt('age', 18)),
+            ],
+            [
+                'not over a group',
+                not(and(eq('name', 'John'), lt('age', 15))),
+            ],
+            [
+                'not over size',
+                not(size('tags', 2)),
+            ],
+            [
+                'not over elemMatch',
+                not(elemMatch('items', eq('name', 'chess'))),
+            ],
+            [
+                'not nested inside a group',
+                and(eq('realm_id', 'master'), not(gt('age', 18))),
+            ],
+        ])('should round-trip %s as a first-class NOT node', (_, filters) => {
+            expect(roundTripFilter(filters)).toEqual(
+                isFilters(filters as ICondition, FilterCompoundOperator.NOT) ?
+                    new Filters(FilterCompoundOperator.AND, [filters]) :
+                    filters,
+            );
+        });
+
+        it('should normalize a wire not() around a twin-able leaf to the twin', () => {
+            // not(eq) and ne lower to the identical plan — the twin is
+            // the canonical decoded form.
+            expect(roundTripFilter(not(eq('name', 'John')))).toEqual(
+                new Filters(FilterCompoundOperator.AND, [ne('name', 'John')]),
+            );
+
+            expect(roundTripFilter(not(inArray('id', [1, 2])))).toEqual(
+                new Filters(FilterCompoundOperator.AND, [nin('id', [1, 2])]),
+            );
+        });
+
+        it('should serialize a multi-child NOT as the negated conjunction', () => {
+            const encoded = encoder.encode(defineQuery({ filters: not(gt('age', 18), lt('age', 65)) }));
+
+            expect(decodeURIComponent(encoded!))
+                .toContain('not(and(gt(age,\'18\'),lt(age,\'65\')))');
         });
     });
 

--- a/packages/codec-url/test/unit/simple-roundtrip.spec.ts
+++ b/packages/codec-url/test/unit/simple-roundtrip.spec.ts
@@ -34,6 +34,7 @@ import {
     mod,
     ne,
     nin,
+    not,
     notContains,
     notEndsWith,
     notStartsWith,
@@ -165,6 +166,8 @@ describe('round-trip', () => {
         it.each([
             ['or compound', or(gte('age', 18), eq('email', null))],
             ['nested compound', and(eq('name', 'John'), or(gte('age', 18), eq('email', null)))],
+            ['not compound (serializing children positively would drop the negation)', not(gt('age', 18))],
+            ['nested not compound', and(eq('name', 'John'), not(gt('age', 18)))],
             ['two conditions on the same field', and(gte('age', 18), lt('age', 65))],
             ['eq comma string (would decode as in)', eq('name', 'a,b')],
             ['in element with comma', inArray('name', ['a,b', 'c'])],

--- a/packages/core/src/parameter/filters/collection/module.ts
+++ b/packages/core/src/parameter/filters/collection/module.ts
@@ -46,7 +46,12 @@ export class Filters<
         const flatConditions: F[] = aggregatedResult || [];
 
         for (const currentNode of conditions) {
-            if (isFilters(currentNode, operator)) {
+            // merging same-operator children relies on associativity —
+            // NOT groups are not associative (not(not(x)) ≠ not(x)).
+            if (
+                isFilters(currentNode, operator) &&
+                operator !== FilterCompoundOperator.NOT
+            ) {
                 currentNode.flatten(flatConditions);
             } else {
                 flatConditions.push(currentNode);

--- a/packages/core/src/parameter/filters/helpers/module.ts
+++ b/packages/core/src/parameter/filters/helpers/module.ts
@@ -180,3 +180,13 @@ export function and(...conditions: Condition[]) : Filters {
 export function or(...conditions: Condition[]) : Filters {
     return new Filters(FilterCompoundOperator.OR, conditions);
 }
+
+/**
+ * Negation: matches exactly what the interior does not match — the
+ * null-inclusive complement law extended from negated leaf operators
+ * to arbitrary condition trees. Multiple conditions negate their
+ * conjunction: not(a, b) ≙ not(and(a, b)).
+ */
+export function not(...conditions: Condition[]) : Filters {
+    return new Filters(FilterCompoundOperator.NOT, conditions);
+}

--- a/packages/core/src/parameter/filters/plan/module.ts
+++ b/packages/core/src/parameter/filters/plan/module.ts
@@ -164,8 +164,9 @@ class ConditionLowering {
                 operator = 'or';
                 break;
             }
-            // plain boolean NOT over the group; the null-inclusive
-            // complement law applies to negated LEAF operators only.
+            // group negation is the exact complement of the group
+            // verdict — the null-inclusive complement law extended
+            // from negated leaf operators to whole trees.
             case 'nor': {
                 operator = 'or';
                 negated = true;
@@ -201,11 +202,61 @@ class ConditionLowering {
             return null;
         }
 
+        // a single-child negation normalizes onto the child's own
+        // negated form where one exists (not(eq) ≙ ne — identical
+        // plan, identical rendering); only interiors without a
+        // negatable leaf form stay wrapped in a negated compound.
+        const [firstChild] = children;
+        if (negated && children.length === 1 && firstChild) {
+            return this.negatePlan(firstChild);
+        }
+
         return {
-            kind: 'compound', 
-            operator, 
-            negated, 
+            kind: 'compound',
+            operator,
+            negated,
             children,
+        };
+    }
+
+    /**
+     * The exact complement of a plan node. Leaf kinds carrying a
+     * `negated` flag flip it (their negated contract already IS the
+     * null-inclusive complement); a constant flips its verdict; a
+     * compound flips its group negation. Kinds without a negated
+     * form (ordering compare, mod, size, elemMatch) wrap in a
+     * negated single-child compound for the backend to complement.
+     */
+    protected negatePlan(plan: ConditionPlan) : ConditionPlan {
+        switch (plan.kind) {
+            case 'constant': {
+                return { ...plan, verdict: !plan.verdict };
+            }
+            case 'null-check':
+            case 'one-of':
+            case 'match': {
+                return { ...plan, negated: !plan.negated };
+            }
+            case 'compare': {
+                if (plan.op === 'eq') {
+                    return { ...plan, negated: !plan.negated };
+                }
+
+                break;
+            }
+            case 'compound': {
+                return { ...plan, negated: !plan.negated };
+            }
+            default: {
+                break;
+            }
+        }
+
+        return {
+            kind: 'compound',
+            operator: 'and',
+            negated: true,
+            children: [plan],
         };
     }
 

--- a/packages/core/src/parameter/filters/plan/types.ts
+++ b/packages/core/src/parameter/filters/plan/types.ts
@@ -66,9 +66,12 @@ export type FilterOperatorSemantics = {
 export type PlanCompareOperator = 'eq' | 'lt' | 'lte' | 'gt' | 'gte';
 
 /**
- * and/or group. `negated` is a plain boolean NOT over the whole
- * group (`nor`/`not` input compounds) — unlike negated leaves it is
- * NOT null-inclusive; SQL renders it with three-valued semantics.
+ * and/or group. `negated` (from `not`/`nor` input compounds) is the
+ * EXACT complement of the group verdict — the null-inclusive
+ * complement law of negated leaves, extended to whole trees. A
+ * backend must render it two-valued: rows where the interior does
+ * not evaluate to a match — including null-bearing rows — match the
+ * negation (SQL therefore cannot use a bare three-valued `not (…)`).
  */
 export type CompoundPlan = {
     kind: 'compound',

--- a/packages/core/src/schema/parameter/filters/constants.ts
+++ b/packages/core/src/schema/parameter/filters/constants.ts
@@ -38,4 +38,5 @@ export enum FilterFieldOperator {
 export enum FilterCompoundOperator {
     AND = 'and',
     OR = 'or',
+    NOT = 'not',
 }

--- a/packages/core/test/unit/parameter/filters-helpers.spec.ts
+++ b/packages/core/test/unit/parameter/filters-helpers.spec.ts
@@ -24,6 +24,7 @@ import {
     mod,
     ne,
     nin,
+    not,
     notContains,
     notEndsWith,
     notStartsWith,
@@ -117,6 +118,19 @@ describe('src/parameter/filters/helpers/*.ts', () => {
         const disjunction = or(left, right);
         expect(disjunction.operator).toBe(FilterCompoundOperator.OR);
         expect(disjunction.value).toEqual([left, right]);
+    });
+
+    it('should build a not compound', () => {
+        const interior = eq('name', 'John');
+
+        const negation = not(interior);
+        expect(negation).toBeInstanceOf(Filters);
+        expect(negation.operator).toBe(FilterCompoundOperator.NOT);
+        expect(negation.value).toEqual([interior]);
+
+        // multiple conditions negate their conjunction.
+        const multi = not(interior, gte('age', 18));
+        expect(multi.value).toHaveLength(2);
     });
 
     it('should support nesting compounds', () => {

--- a/packages/core/test/unit/parameter/filters-plan.spec.ts
+++ b/packages/core/test/unit/parameter/filters-plan.spec.ts
@@ -373,14 +373,94 @@ describe('src/parameter/filters/plan/module.ts', () => {
             expect(plan.children[1]).toMatchObject({ kind: 'compound', operator: 'and' });
         });
 
-        it('should lower nor/not to negated groups', () => {
+        it('should lower nor/not with multiple children to negated groups', () => {
             expect(planCondition(new Filters('nor', [
                 new Filter('eq', 'age', 1),
+                new Filter('eq', 'age', 2),
             ]))).toMatchObject({ operator: 'or', negated: true });
 
             expect(planCondition(new Filters('not', [
-                new Filter('eq', 'age', 1),
+                new Filter('gt', 'age', 1),
+                new Filter('lt', 'age', 9),
             ]))).toMatchObject({ operator: 'and', negated: true });
+        });
+
+        it('should normalize a single-child negation onto the leaf plan', () => {
+            // not(eq) lowers to the identical plan as ne (complement law).
+            expect(planCondition(new Filters('not', [
+                new Filter('eq', 'age', 1),
+            ]))).toEqual(planCondition(new Filter('ne', 'age', 1)));
+
+            expect(planCondition(new Filters('nor', [
+                new Filter('in', 'age', [1, 2]),
+            ]))).toEqual(planCondition(new Filter('nin', 'age', [1, 2])));
+
+            expect(planCondition(new Filters('not', [
+                new Filter('contains', 'name', 'pe'),
+            ]))).toEqual(planCondition(new Filter('notContains', 'name', 'pe')));
+
+            expect(planCondition(new Filters('not', [
+                new Filter('exists', 'name', true),
+            ]))).toEqual(planCondition(new Filter('exists', 'name', false)));
+
+            // a negated regex has no operator twin — the plan-level
+            // negated flag is its only surface.
+            expect(planCondition(new Filters('not', [
+                new Filter('regex', 'name', 'pe.*'),
+            ]))).toMatchObject({ kind: 'match', negated: true });
+
+            // constants flip their verdict: not(in([])) matches everything.
+            expect(planCondition(new Filters('not', [
+                new Filter('in', 'age', []),
+            ]))).toEqual({ kind: 'constant', verdict: true });
+        });
+
+        it('should cancel a double negation', () => {
+            expect(planCondition(new Filters('not', [
+                new Filters('not', [new Filter('gt', 'age', 1)]),
+            ]))).toEqual({
+                kind: 'compound',
+                operator: 'and',
+                negated: false,
+                children: [planCondition(new Filter('gt', 'age', 1))],
+            });
+        });
+
+        it('should wrap negations without a negated leaf form in a negated group', () => {
+            // ordering complements are null-inclusive — gte is NOT the
+            // complement of lt, so no twin normalization applies.
+            expect(planCondition(new Filters('not', [
+                new Filter('lt', 'age', 5),
+            ]))).toEqual({
+                kind: 'compound',
+                operator: 'and',
+                negated: true,
+                children: [planCondition(new Filter('lt', 'age', 5))],
+            });
+
+            expect(planCondition(new Filters('not', [
+                new Filter('mod', 'age', [2, 0]),
+            ]))).toMatchObject({
+                kind: 'compound',
+                negated: true,
+                children: [{ kind: 'mod' }],
+            });
+
+            expect(planCondition(new Filters('not', [
+                new Filter('size', 'items', 2),
+            ]))).toMatchObject({
+                kind: 'compound',
+                negated: true,
+                children: [{ kind: 'size' }],
+            });
+
+            expect(planCondition(new Filters('not', [
+                new Filter('elemMatch', 'items', new Filter('eq', 'id', 1)),
+            ]))).toMatchObject({
+                kind: 'compound',
+                negated: true,
+                children: [{ kind: 'elem-match' }],
+            });
         });
 
         it('should vanish empty compounds', () => {

--- a/packages/core/test/unit/parameter/filters.spec.ts
+++ b/packages/core/test/unit/parameter/filters.spec.ts
@@ -199,5 +199,18 @@ describe('src/parameter/filters/collection/*.ts', () => {
 
             expect(flat.value).toEqual([a, b]);
         });
+
+        it('should never hoist through a NOT group (not associative)', () => {
+            const a = new Filter(FilterFieldOperator.EQUAL, 'a', 1);
+
+            const inner = new Filters(FilterCompoundOperator.NOT, [a]);
+            const outer = new Filters(FilterCompoundOperator.NOT, [inner]);
+
+            // hoisting would turn not(not(a)) into not(a) — the
+            // opposite meaning.
+            const flat = outer.flatten();
+            expect(flat.operator).toBe(FilterCompoundOperator.NOT);
+            expect(flat.value).toEqual([inner]);
+        });
     });
 });

--- a/packages/docs/guide/building-queries.md
+++ b/packages/docs/guide/building-queries.md
@@ -81,7 +81,7 @@ const query = defineQuery<User>({
 });
 ```
 
-`eq` `ne` `lt` `lte` `gt` `gte` `inArray` `nin` `startsWith` `notStartsWith` `endsWith` `notEndsWith` `contains` `notContains` `regex` `mod` `size` `exists` `elemMatch` — plus `and` / `or` compounds.
+`eq` `ne` `lt` `lte` `gt` `gte` `inArray` `nin` `startsWith` `notStartsWith` `endsWith` `notEndsWith` `contains` `notContains` `regex` `mod` `size` `exists` `elemMatch` — plus the `and` / `or` / `not` compounds. `not(condition)` is the exact complement of its interior (see [Negation](/guide/filters#negation)); multiple arguments negate their conjunction.
 
 A few helpers deviate from the uniform `(field, value)` signature:
 

--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -91,11 +91,35 @@ defineQuery<User>({
 
 ## OR & compound trees
 
-The simple object/wire dialect only expresses flat **and** sets. For `or` and nested groups:
+The simple object/wire dialect only expresses flat **and** sets. For `or`, `not` and nested groups:
 
-- **in code** — condition helpers: `or(...)`, `and(...)`, arbitrarily nested;
+- **in code** — condition helpers: `or(...)`, `and(...)`, `not(...)`, arbitrarily nested;
 - **over a URL** — the [expression codec](/packages/codec-url#expression-dialect): `filter=or(gte(age,'18'),eq(status,'active'))`;
 - **in a request body** — the [MongoDB-style parser](/packages/parser-mongo): `{ $or: [...] }`.
+
+### Negation
+
+`not(condition)` matches exactly the records its interior does **not** match — the
+[complement law](#null-semantics) extended from the negated leaf operators to arbitrary trees:
+
+```typescript
+import { and, defineQuery, eq, gt, not } from '@rapiq/core';
+
+defineQuery<User>({
+    filters: not(and(eq('status', 'active'), gt('age', 65))),
+});
+```
+
+Where a negated leaf operator exists, `not` is the same condition (`not(eq(…))` ≡ `ne(…)`);
+its value is negating conditions **without** a negated twin — ordering comparisons
+(`not(gt(…))`), `size`, `elemMatch` and whole groups. Multiple arguments negate their
+conjunction: `not(a, b)` ≡ `not(and(a, b))`.
+
+On the wire, the expression dialect carries it as `filter=not(gt(age,'65'))`; the legacy
+simple dialect cannot express it (encoding throws a typed error). SQL adapters render the
+negation **null-inclusively** (a `CASE` wrapper collapses SQL's three-valued `UNKNOWN` to
+false), so a record with `age = NULL` matches `not(gt('age', 65))` on every backend — the
+same verdict `@rapiq/memory` produces.
 
 ## Nested fields
 
@@ -113,6 +137,8 @@ The simple object/wire dialect only expresses flat **and** sets. For `or` and ne
 | `exists(field)` | `field IS NOT NULL` |
 
 Negated operators (`ne`, `nin`, `notContains`, `notStartsWith`, `notEndsWith`) are **exact complements** of their positive twins — they also match records where the field is `NULL`/absent. Adapters render them null-inclusively, e.g. `ne(field, a)` → `(field <> ? OR field IS NULL)`.
+
+The same complement law governs [`not(...)`](#negation) over whole trees: `not(c)` selects exactly the records `c` does not, on every backend.
 
 ## Case sensitivity
 

--- a/packages/docs/guide/query-ast.md
+++ b/packages/docs/guide/query-ast.md
@@ -7,7 +7,7 @@ Under every rapiq feature sits one data structure: the `Query` — a tree of nod
 | Collection node | Record node | Holds |
 |---|---|---|
 | `Fields` | `Field` | `name`, optional `operator` (`FieldOperator.INCLUDE` / `EXCLUDE`) |
-| `Filters` | `Filter` | compound (`and` / `or`) tree of `{ operator, field, value }` conditions |
+| `Filters` | `Filter` | compound (`and` / `or` / `not`) tree of `{ operator, field, value }` conditions |
 | `Relations` | `Relation` | `name` (dot-notation for nested paths) |
 | `Sorts` | `Sort` | `name`, `operator` (`'ASC'` / `'DESC'`) |
 | `Pagination` | — | `limit`, `offset` |

--- a/packages/docs/guide/wire.md
+++ b/packages/docs/guide/wire.md
@@ -93,7 +93,7 @@ Every wire dialect expresses a subset of the query AST. Inside that subset, `dec
 |---|---|---|
 | Wire shape | `filter[age]=>=18` per field | one `filter=and(gte(age,'18'),…)` expression |
 | Flat AND filters | ✓ | ✓ |
-| `or(...)`, nested groups | ✗ throws | ✓ |
+| `or(...)`, `not(...)`, nested groups | ✗ throws | ✓ |
 | Several conditions on one field | ✗ throws | ✓ |
 | Commas / simple operator markers in values | ✗ throws | ✓ (quoted) |
 | `elemMatch` (incl. the `ITSELF` element marker, wire spelling `$this`) | ✗ throws | ✓ |

--- a/packages/docs/packages/codec-url.md
+++ b/packages/docs/packages/codec-url.md
@@ -47,7 +47,7 @@ The default filter wire shape is one function-call expression:
 codec=url-expression&filter=and(gte(age,'18'),or(eq(status,'active'),eq(status,'pending')))
 ```
 
-It carries flat filters, repeated fields, nested `and`/`or` trees and `elemMatch` conditions. Values are quoted, so commas and simple-dialect operator markers retain their literal meaning. Inside an `elemMatch` interior the element itself is addressed by the reserved `$this` marker (core's `ITSELF` constant):
+It carries flat filters, repeated fields, nested `and`/`or`/`not` trees and `elemMatch` conditions. Values are quoted, so commas and simple-dialect operator markers retain their literal meaning. Inside an `elemMatch` interior the element itself is addressed by the reserved `$this` marker (core's `ITSELF` constant):
 
 ```text
 filter=elemMatch(scores,gt($this,'5'))

--- a/packages/docs/packages/parser-expression.md
+++ b/packages/docs/packages/parser-expression.md
@@ -31,7 +31,7 @@ elemMatch(scores, gt($this, '5'))
 | `elemMatch(field, expr)` | array element match | `ELEM_MATCH` |
 | `size(field, n)` | array length (non-negative integer) | `SIZE` |
 | `and(expr, …)` / `or(expr, …)` | compound | `Filters` node |
-| `not(expr, …)` | negation | flips operators (`eq` → `NOT_EQUAL`, `contains` → `NOT_CONTAINS`, …), `and` ↔ `or`; `elemMatch` and `size` have no complement and throw |
+| `not(expr)` | [negation](/guide/filters#negation) — the exact complement of the interior | a single leaf with a negated twin normalizes to it (`not(eq(…))` → `NOT_EQUAL`, `not(in(…))` → `NOT_IN`, …), a double `not` cancels; everything else (ordering comparisons, `size`, `elemMatch`, groups) stays a first-class `NOT` `Filters` node |
 
 Rules:
 

--- a/packages/memory/test/unit/filters/compound.spec.ts
+++ b/packages/memory/test/unit/filters/compound.spec.ts
@@ -11,9 +11,13 @@ import {
     Filter,
     Filters,
     and,
+    elemMatch,
     eq,
+    gt,
     gte,
+    not,
     or,
+    size,
 } from '@rapiq/core';
 import { compileFilters } from '../../../src';
 
@@ -77,22 +81,61 @@ describe('filters: compounds', () => {
         expect(predicate({ id: 2 })).toBeFalsy();
     });
 
-    it('should negate nor/not groups (plain boolean not, sql parity)', () => {
-        const nor = compileFilters(new Filters('nor', [
+    it('should negate nor/not groups (exact complement, sql parity)', () => {
+        const norPredicate = compileFilters(new Filters('nor', [
             eq('id', 1),
             eq('id', 2),
         ]));
 
-        expect(nor({ id: 3 })).toBeTruthy();
-        expect(nor({ id: 1 })).toBeFalsy();
-        expect(nor({ id: 2 })).toBeFalsy();
+        expect(norPredicate({ id: 3 })).toBeTruthy();
+        expect(norPredicate({ id: 1 })).toBeFalsy();
+        expect(norPredicate({ id: 2 })).toBeFalsy();
 
-        const not = compileFilters(new Filters('not', [
+        const predicate = compileFilters(not(
             and(eq('name', 'Peter'), gte('age', 18)),
-        ]));
+        ));
 
-        expect(not({ name: 'Peter', age: 28 })).toBeFalsy();
-        expect(not({ name: 'Peter', age: 17 })).toBeTruthy();
+        expect(predicate({ name: 'Peter', age: 28 })).toBeFalsy();
+        expect(predicate({ name: 'Peter', age: 17 })).toBeTruthy();
+    });
+
+    it('should match null-bearing records under a negated group (complement law)', () => {
+        // not(c) matches exactly the records c does not match — the
+        // null-inclusive complement law extended to trees.
+        const predicate = compileFilters(not(gt('age', 50)));
+
+        expect(predicate({ age: 18 })).toBeTruthy();
+        expect(predicate({ age: null })).toBeTruthy();
+        expect(predicate({})).toBeTruthy();
+        expect(predicate({ age: 60 })).toBeFalsy();
+
+        const group = compileFilters(not(or(gt('age', 50), eq('name', 'Peter'))));
+
+        expect(group({ age: null, name: null })).toBeTruthy();
+        expect(group({ age: 60, name: null })).toBeFalsy();
+        expect(group({ age: null, name: 'Peter' })).toBeFalsy();
+    });
+
+    it('should cancel a double negation', () => {
+        const predicate = compileFilters(not(not(gt('age', 50))));
+
+        expect(predicate({ age: 60 })).toBeTruthy();
+        expect(predicate({ age: 18 })).toBeFalsy();
+        expect(predicate({ age: null })).toBeFalsy();
+    });
+
+    it('should complement size and elemMatch under not', () => {
+        const sizePredicate = compileFilters(not(size('items', 2)));
+
+        expect(sizePredicate({ items: [1, 2] })).toBeFalsy();
+        expect(sizePredicate({ items: [1] })).toBeTruthy();
+        expect(sizePredicate({})).toBeTruthy();
+
+        const element = compileFilters(not(elemMatch('items', eq('id', 1))));
+
+        expect(element({ items: [{ id: 1 }] })).toBeFalsy();
+        expect(element({ items: [{ id: 2 }] })).toBeTruthy();
+        expect(element({ items: [] })).toBeTruthy();
     });
 
     it('should throw on an unknown compound operator', () => {

--- a/packages/parser-expression/src/parameter/filters/module.ts
+++ b/packages/parser-expression/src/parameter/filters/module.ts
@@ -16,6 +16,7 @@ import {
     BaseParser,
     DEFAULT_ID,
     ErrorCode,
+    FILTER_OPERATOR_SEMANTICS,
     Filter,
     FilterCompoundOperator,
     FilterFieldOperator,
@@ -29,6 +30,7 @@ import {
     applyFiltersSchemaValidation,
     applyFiltersSchemaValidationAsync,
     buildFiltersDefaults,
+    isFilter,
     isFilters,
 } from '@rapiq/core';
 import { parseFilterScalar } from '@rapiq/parser-simple';
@@ -46,6 +48,21 @@ type FiltersScope = ResolutionScope<`${Parameter.FILTERS}`>;
  * aligned with the schema resolver and Mongo parser traversal caps.
  */
 const MAX_DEPTH = MAX_TRAVERSAL_DEPTH;
+
+/**
+ * Bidirectional complement twins derived from the semantics table:
+ * a not(…) around a single leaf normalizes to the leaf's twin
+ * (not(eq) → ne, not(nin) → in) instead of a symbolic NOT node —
+ * both lower to the identical plan, the twin is the canonical form.
+ */
+const COMPLEMENT_TWINS : Record<string, string> = {};
+for (const [operator, semantics] of Object.entries(FILTER_OPERATOR_SEMANTICS)) {
+    const twin = (semantics as { complementOf?: string }).complementOf;
+    if (twin) {
+        COMPLEMENT_TWINS[operator] = twin;
+        COMPLEMENT_TWINS[twin] = operator;
+    }
+}
 
 /**
  * @see https://www.jsonapi.net/usage/reading/filtering.html
@@ -261,7 +278,6 @@ export class ExpressionFiltersParser extends BaseParser<
 
     private parseFilterExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
         depth: number = 0,
     ) : Filters | Filter {
         if (depth > MAX_DEPTH) {
@@ -271,70 +287,80 @@ export class ExpressionFiltersParser extends BaseParser<
         const token = this.peek();
         switch (token.type) {
             case FilterTokenType.NOT:
-                return this.parseNotExpression(scope, negation, depth);
+                return this.parseNotExpression(scope, depth);
             case FilterTokenType.AND:
             case FilterTokenType.OR:
-                return this.parseLogicalExpression(scope, negation, depth);
+                return this.parseLogicalExpression(scope, depth);
             case FilterTokenType.EQUAL:
             case FilterTokenType.GREATER_THAN:
             case FilterTokenType.GREATER_OR_EQUAL:
             case FilterTokenType.LESS_THAN:
             case FilterTokenType.LESS_OR_EQUAL:
-                return this.parseComparisonExpression(scope, negation);
+                return this.parseComparisonExpression(scope);
             case FilterTokenType.CONTAINS:
             case FilterTokenType.STARTS_WITH:
             case FilterTokenType.ENDS_WITH:
-                return this.parseMatchExpression(scope, negation);
+                return this.parseMatchExpression(scope);
             case FilterTokenType.IN:
             case FilterTokenType.NIN:
-                return this.parseInExpression(scope, negation);
+                return this.parseInExpression(scope);
             case FilterTokenType.ELEM_MATCH:
-                return this.parseElemMatchExpression(scope, negation, depth);
+                return this.parseElemMatchExpression(scope, depth);
             case FilterTokenType.SIZE:
-                return this.parseSizeExpression(scope, negation);
+                return this.parseSizeExpression(scope);
             default:
                 throw FiltersParseError.syntaxInvalid(`Unexpected token in filter expression: ${token.type}`);
         }
     }
 
+    /**
+     * not(expr): the exact complement of the interior (null-inclusive
+     * complement law). A single leaf with a complement twin normalizes
+     * to the twin, a double negation cancels; everything else stays a
+     * first-class NOT node.
+     */
     private parseNotExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
         depth: number = 0,
     ): Filters | Filter {
         this.consume(FilterTokenType.NOT);
         this.consume(FilterTokenType.LPAREN);
-        const expr = this.parseFilterExpression(scope, !negation, depth + 1);
+        const expr = this.parseFilterExpression(scope, depth + 1);
         this.consume(FilterTokenType.RPAREN);
 
-        return expr;
+        if (isFilter(expr)) {
+            const twin = COMPLEMENT_TWINS[expr.operator];
+            if (twin) {
+                return new Filter(twin as FilterFieldOperator, expr.field, expr.value);
+            }
+        }
+
+        if (
+            isFilters(expr, FilterCompoundOperator.NOT) &&
+            expr.value.length === 1
+        ) {
+            return expr.value[0] as Filters | Filter;
+        }
+
+        return new Filters(FilterCompoundOperator.NOT, [expr]);
     }
 
     private parseLogicalExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
         depth: number = 0,
     ): Filters | Filter {
-        let op = this.consume().type; // AND / OR
+        const op = this.consume().type; // AND / OR
         if (op !== FilterTokenType.AND && op !== FilterTokenType.OR) {
             throw FiltersParseError.syntaxInvalid('Expected AND or OR token type.');
         }
 
         this.consume(FilterTokenType.LPAREN);
-        const expressions: (Filter | Filters)[] = [this.parseFilterExpression(scope, negation, depth + 1)];
+        const expressions: (Filter | Filters)[] = [this.parseFilterExpression(scope, depth + 1)];
         while (this.peek().type === FilterTokenType.COMMA) {
             this.consume(FilterTokenType.COMMA);
-            expressions.push(this.parseFilterExpression(scope, negation, depth + 1));
+            expressions.push(this.parseFilterExpression(scope, depth + 1));
         }
         this.consume(FilterTokenType.RPAREN);
-
-        if (negation) {
-            if (op === FilterTokenType.AND) {
-                op = FilterTokenType.OR;
-            } else {
-                op = FilterTokenType.AND;
-            }
-        }
 
         if (op === FilterTokenType.AND) {
             return new Filters(
@@ -348,7 +374,6 @@ export class ExpressionFiltersParser extends BaseParser<
 
     private parseComparisonExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
     ): Filters | Filter {
         const op = this.consume().type;
         this.consume(FilterTokenType.LPAREN);
@@ -359,14 +384,6 @@ export class ExpressionFiltersParser extends BaseParser<
 
         switch (op) {
             case FilterTokenType.EQUAL: {
-                if (negation) {
-                    return new Filter(
-                        FilterFieldOperator.NOT_EQUAL,
-                        left as string,
-                        right as string,
-                    );
-                }
-
                 return new Filter(
                     FilterFieldOperator.EQUAL,
                     left as string,
@@ -374,13 +391,6 @@ export class ExpressionFiltersParser extends BaseParser<
                 );
             }
             case FilterTokenType.GREATER_THAN: {
-                if (negation) {
-                    return new Filter(
-                        FilterFieldOperator.LESS_THAN_EQUAL,
-                        left as string,
-                        right as string,
-                    );
-                }
                 return new Filter(
                     FilterFieldOperator.GREATER_THAN,
                     left as string,
@@ -388,13 +398,6 @@ export class ExpressionFiltersParser extends BaseParser<
                 );
             }
             case FilterTokenType.GREATER_OR_EQUAL: {
-                if (negation) {
-                    return new Filter(
-                        FilterFieldOperator.LESS_THAN,
-                        left as string,
-                        right as string,
-                    );
-                }
                 return new Filter(
                     FilterFieldOperator.GREATER_THAN_EQUAL,
                     left as string,
@@ -402,13 +405,6 @@ export class ExpressionFiltersParser extends BaseParser<
                 );
             }
             case FilterTokenType.LESS_THAN: {
-                if (negation) {
-                    return new Filter(
-                        FilterFieldOperator.GREATER_THAN_EQUAL,
-                        left as string,
-                        right as string,
-                    );
-                }
                 return new Filter(
                     FilterFieldOperator.LESS_THAN,
                     left as string,
@@ -416,13 +412,6 @@ export class ExpressionFiltersParser extends BaseParser<
                 );
             }
             case FilterTokenType.LESS_OR_EQUAL: {
-                if (negation) {
-                    return new Filter(
-                        FilterFieldOperator.GREATER_THAN,
-                        left as string,
-                        right as string,
-                    );
-                }
                 return new Filter(
                     FilterFieldOperator.LESS_THAN_EQUAL,
                     left as string,
@@ -436,7 +425,6 @@ export class ExpressionFiltersParser extends BaseParser<
 
     private parseMatchExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
     ): Filters | Filter {
         const op = this.consume().type;
         this.consume(FilterTokenType.LPAREN);
@@ -453,27 +441,21 @@ export class ExpressionFiltersParser extends BaseParser<
         switch (op) {
             case FilterTokenType.CONTAINS: {
                 return new Filter(
-                    negation ?
-                        FilterFieldOperator.NOT_CONTAINS :
-                        FilterFieldOperator.CONTAINS,
+                    FilterFieldOperator.CONTAINS,
                     field,
                     normalized,
                 );
             }
             case FilterTokenType.ENDS_WITH: {
                 return new Filter(
-                    negation ?
-                        FilterFieldOperator.NOT_ENDS_WITH :
-                        FilterFieldOperator.ENDS_WITH,
+                    FilterFieldOperator.ENDS_WITH,
                     field,
                     normalized,
                 );
             }
             default: {
                 return new Filter(
-                    negation ?
-                        FilterFieldOperator.NOT_STARTS_WITH :
-                        FilterFieldOperator.STARTS_WITH,
+                    FilterFieldOperator.STARTS_WITH,
                     field,
                     normalized,
                 );
@@ -483,7 +465,6 @@ export class ExpressionFiltersParser extends BaseParser<
 
     private parseInExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
     ): Filters | Filter {
         const token = this.peek();
         if (token.type === FilterTokenType.NIN) {
@@ -504,10 +485,7 @@ export class ExpressionFiltersParser extends BaseParser<
         }
         this.consume(FilterTokenType.RPAREN);
 
-        const notIn = (token.type === FilterTokenType.NIN && !negation) ||
-            (token.type === FilterTokenType.IN && negation);
-
-        if (notIn) {
+        if (token.type === FilterTokenType.NIN) {
             return new Filter(
                 FilterFieldOperator.NOT_IN,
                 field,
@@ -525,17 +503,11 @@ export class ExpressionFiltersParser extends BaseParser<
     /**
      * size(field, n): the field holds an array of exactly n elements
      * (a non-negative integer — the wire is untyped, so the quoted
-     * value coerces back to a number). There is no complement — a
-     * negated size would silently widen and always throws.
+     * value coerces back to a number).
      */
     private parseSizeExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
     ): Filter {
-        if (negation) {
-            throw FiltersParseError.operatorUnsupported('size');
-        }
-
         this.consume(FilterTokenType.SIZE);
         this.consume(FilterTokenType.LPAREN);
         const field = this.parseExpressionFieldChain(scope);
@@ -557,18 +529,12 @@ export class ExpressionFiltersParser extends BaseParser<
     /**
      * elemMatch(field, expr): field paths inside the interior are
      * relative to the array element; the ITSELF marker addresses the
-     * element itself. There is no complement — a negated elemMatch
-     * would silently widen and always throws.
+     * element itself.
      */
     private parseElemMatchExpression(
         scope?: FiltersScope,
-        negation: boolean = false,
         depth: number = 0,
     ): Filter {
-        if (negation) {
-            throw FiltersParseError.operatorUnsupported('elemMatch');
-        }
-
         this.consume(FilterTokenType.ELEM_MATCH);
         this.consume(FilterTokenType.LPAREN);
 
@@ -580,7 +546,7 @@ export class ExpressionFiltersParser extends BaseParser<
 
         let condition : Filters | Filter;
         try {
-            condition = this.parseFilterExpression(target.scope, false, depth + 1);
+            condition = this.parseFilterExpression(target.scope, depth + 1);
         } finally {
             this.elemMatchDepth -= 1;
         }

--- a/packages/parser-expression/test/unit/parser/filters.spec.ts
+++ b/packages/parser-expression/test/unit/parser/filters.spec.ts
@@ -77,6 +77,22 @@ describe('filters/expr-parser', () => {
         expect(output).toEqual(new Filter(FilterFieldOperator.EQUAL, 'name', 'admin'));
     });
 
+    it('should keep a negated ordering comparison as a first-class NOT node', () => {
+        // the complement of gt is null-inclusive — lte is NOT its
+        // negation, so no twin rewrite applies.
+        const output = parser.parseExact('not(gt(age, \'18\'))');
+
+        expect(output).toEqual(new Filters(FilterCompoundOperator.NOT, [
+            new Filter(FilterFieldOperator.GREATER_THAN, 'age', 18),
+        ]));
+    });
+
+    it('should cancel a double negation around an ordering comparison', () => {
+        const output = parser.parseExact('not(not(gt(age, \'18\')))');
+
+        expect(output).toEqual(new Filter(FilterFieldOperator.GREATER_THAN, 'age', 18));
+    });
+
     it('should parse lt expression', () => {
         const output = parser.parseExact('lt(age, \'18\')');
 
@@ -384,19 +400,23 @@ describe('filters/expr-parser', () => {
     it('should negated nested expression', () => {
         const output = parser.parseExact('not(and(eq(name, \'foo\'), lt(age, \'15\')))');
 
+        // a negated group stays first-class — no De Morgan rewrite,
+        // its meaning is the exact complement of the interior.
         expect(output).toEqual(new Filters(
-            FilterCompoundOperator.OR,
+            FilterCompoundOperator.NOT,
             [
-                new Filter(
-                    FilterFieldOperator.NOT_EQUAL,
-                    'name',
-                    'foo',
-                ),
-                new Filter(
-                    FilterFieldOperator.GREATER_THAN_EQUAL,
-                    'age',
-                    15,
-                ),
+                new Filters(FilterCompoundOperator.AND, [
+                    new Filter(
+                        FilterFieldOperator.EQUAL,
+                        'name',
+                        'foo',
+                    ),
+                    new Filter(
+                        FilterFieldOperator.LESS_THAN,
+                        'age',
+                        15,
+                    ),
+                ]),
             ],
         ));
     });
@@ -493,10 +513,12 @@ describe('filters/expr-parser', () => {
             ));
         });
 
-        it('should throw on a negated size', () => {
-            const error = FiltersParseError.operatorUnsupported('size');
+        it('should keep a negated size as a first-class NOT node', () => {
+            const output = parser.parseExact('not(size(items,\'2\'))');
 
-            expect(() => parser.parseExact('not(size(items,\'2\'))')).toThrow(error);
+            expect(output).toEqual(new Filters(FilterCompoundOperator.NOT, [
+                new Filter(FilterFieldOperator.SIZE, 'items', 2),
+            ]));
         });
 
         it('should throw on a non integer, negative or non numeric value', () => {
@@ -555,10 +577,16 @@ describe('filters/expr-parser', () => {
             ));
         });
 
-        it('should throw on a negated elemMatch', () => {
-            const error = FiltersParseError.operatorUnsupported('elemMatch');
+        it('should keep a negated elemMatch as a first-class NOT node', () => {
+            const output = parser.parseExact('not(elemMatch(items,eq(id,\'1\')))');
 
-            expect(() => parser.parseExact('not(elemMatch(items,eq(id,\'1\')))')).toThrow(error);
+            expect(output).toEqual(new Filters(FilterCompoundOperator.NOT, [
+                new Filter(
+                    FilterFieldOperator.ELEM_MATCH,
+                    'items',
+                    new Filter(FilterFieldOperator.EQUAL, 'id', 1),
+                ),
+            ]));
         });
 
         it('should throw on the ITSELF marker outside an elemMatch interior', () => {

--- a/packages/sql/src/adapter/filters/base.ts
+++ b/packages/sql/src/adapter/filters/base.ts
@@ -197,7 +197,17 @@ export abstract class FiltersBaseAdapter<
                 sql = `(${sql})`;
             }
 
-            this.conditions.push(`${isInverted ? 'not ' : ''}${sql}`);
+            if (isInverted) {
+                // group negation is the exact complement of the group
+                // verdict (null-inclusive complement law). A bare
+                // `not (…)` follows three-valued logic and drops rows
+                // where the interior is UNKNOWN (null comparisons); the
+                // CASE wrapper collapses UNKNOWN to false first and is
+                // portable across all shipped dialects.
+                sql = `case when ${sql} then 1 else 0 end = 0`;
+            }
+
+            this.conditions.push(sql);
             this.params.push(...query.params);
         }
 

--- a/packages/sql/test/unit/interpreters/compound.spec.ts
+++ b/packages/sql/test/unit/interpreters/compound.spec.ts
@@ -41,8 +41,35 @@ describe('compound operators', () => {
 
         const [sql, params] = adapter.getQueryAndParameters();
 
-        expect(sql).toEqual('not ("age" = $1 or "age" = $2)');
+        // exact complement: the CASE wrapper collapses UNKNOWN to
+        // false, so null-bearing rows match the negation.
+        expect(sql).toEqual('case when ("age" = $1 or "age" = $2) then 1 else 0 end = 0');
         expect([12, 13]).toStrictEqual(params);
+    });
+
+    it('generates a null-inclusive complement for a negated ordering condition', () => {
+        const condition = new Filters('not', [
+            new Filter('gt', 'age', 50),
+        ]);
+        condition.accept(visitor);
+
+        const [sql, params] = adapter.getQueryAndParameters();
+
+        expect(sql).toEqual('case when "age" > $1 then 1 else 0 end = 0');
+        expect(params).toStrictEqual([50]);
+    });
+
+    it('renders a single-child negated equality via its complement twin', () => {
+        const condition = new Filters('not', [
+            new Filter('eq', 'age', 18),
+        ]);
+        condition.accept(visitor);
+
+        const [sql, params] = adapter.getQueryAndParameters();
+
+        // not(eq) normalizes onto the ne plan — identical rendering.
+        expect(sql).toEqual('("age" <> $1 or "age" is null)');
+        expect(params).toStrictEqual([18]);
     });
 
     it('generates query combined by logical `and` for "and"', () => {
@@ -83,7 +110,7 @@ describe('compound operators', () => {
 
         const [sql, params] = adapter.getQueryAndParameters();
 
-        expect(sql).toEqual('not ("age" = $1 or "active" = $2)');
+        expect(sql).toEqual('case when ("age" = $1 or "active" = $2) then 1 else 0 end = 0');
         expect(params).toStrictEqual([1, true]);
     });
 
@@ -113,8 +140,8 @@ describe('compound operators', () => {
         expect(sql).toEqual(`(${[
             '("age" = $1 or "age" = $2)',
             'or ("qty" > $3 and "qty" < $4)',
-            'or not ("qty" > $5 or "qty" < $6)',
-            'or not ("active" = $7 and "age" > $8)',
+            'or case when ("qty" > $5 or "qty" < $6) then 1 else 0 end = 0',
+            'or case when ("active" = $7 and "age" > $8) then 1 else 0 end = 0',
         ].join(' ')})`);
         expect(params).toStrictEqual([1, 2, 1, 20, 10, 20, false, 18]);
     });

--- a/packages/typeorm/test/unit/complement.spec.ts
+++ b/packages/typeorm/test/unit/complement.spec.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Filter } from '@rapiq/core';
+import type { Condition, Filter } from '@rapiq/core';
 import {
     FilterCompoundOperator,
     Filters,
@@ -17,6 +17,7 @@ import {
     inArray,
     ne,
     nin,
+    not,
     notContains,
     notEndsWith,
     notStartsWith,
@@ -69,7 +70,7 @@ describe('cross-adapter complement law (memory vs typeorm)', () => {
         await dataSource.destroy();
     });
 
-    const fetchIds = async (condition: Filter) : Promise<number[]> => {
+    const fetchIds = async (condition: Condition) : Promise<number[]> => {
         const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
 
         const adapter = new TypeormAdapter({ queryBuilder });
@@ -79,8 +80,8 @@ describe('cross-adapter complement law (memory vs typeorm)', () => {
         return data.map((user) => user.id).sort((a, b) => a - b);
     };
 
-    const evaluateIds = (condition: Filter) : number[] => {
-        const predicate = compileFilters(condition);
+    const evaluateIds = (condition: Condition) : number[] => {
+        const predicate = compileFilters(condition as Filter | Filters);
 
         return records
             .filter((record) => predicate(record))
@@ -113,6 +114,12 @@ describe('cross-adapter complement law (memory vs typeorm)', () => {
             // the negation selects exactly the remaining records.
             const allIds = records.map((user) => user.id).sort((a, b) => a - b);
             expect([...positiveIds, ...negativeIds].sort((a, b) => a - b)).toEqual(allIds);
+
+            // the first-class NOT node is the same complement: not(c)
+            // selects exactly the rows c does not — on both backends.
+            const symbolicIds = await fetchIds(not(positive));
+            expect(symbolicIds).toEqual(negativeIds);
+            expect(evaluateIds(not(positive))).toEqual(negativeIds);
         });
     });
 });

--- a/packages/typeorm/test/unit/parity.spec.ts
+++ b/packages/typeorm/test/unit/parity.spec.ts
@@ -262,7 +262,7 @@ const CASES : ParityCase[] = [
     },
     {
         operator: 'nor',
-        label: 'compound nor (plain boolean not)',
+        label: 'compound nor (exact complement)',
         condition: new Filters('nor', [
             new Filter(FilterFieldOperator.EQUAL, 'age', 18),
             new Filter(FilterFieldOperator.GREATER_THAN, 'age', 50),
@@ -271,11 +271,43 @@ const CASES : ParityCase[] = [
     },
     {
         operator: 'not',
-        label: 'compound not (plain boolean not)',
+        label: 'compound not (exact complement)',
         condition: new Filters('not', [
             new Filter(FilterFieldOperator.GREATER_THAN, 'age', 50),
         ]),
         expected: [1],
+    },
+    {
+        operator: 'not',
+        label: 'not matches null-bearing rows (complement law)',
+        // address is 'Hogwarts' (1) and NULL (2) — the negation must
+        // select the null row on every backend, where a bare SQL
+        // `not (…)` would drop it (three-valued logic).
+        condition: new Filters(FilterCompoundOperator.NOT, [
+            new Filter(FilterFieldOperator.CONTAINS, 'address', 'warts'),
+        ]),
+        expected: [2],
+    },
+    {
+        operator: 'not',
+        label: 'not over a group with null participants',
+        condition: new Filters(FilterCompoundOperator.NOT, [
+            new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'first_name', 'Caleb'),
+                new Filter(FilterFieldOperator.CONTAINS, 'address', 'warts'),
+            ]),
+        ]),
+        expected: [2],
+    },
+    {
+        operator: 'not',
+        label: 'double negation cancels',
+        condition: new Filters(FilterCompoundOperator.NOT, [
+            new Filters(FilterCompoundOperator.NOT, [
+                new Filter(FilterFieldOperator.GREATER_THAN, 'age', 50),
+            ]),
+        ]),
+        expected: [2],
     },
 ];
 


### PR DESCRIPTION
Closes #811.

## What

A first-class negation node in the public condition IR, per the issue's four asks:

- **Builder**: `FilterCompoundOperator.NOT` (`'not'`) + a `not(...conditions)` condition helper. Multiple arguments negate their conjunction (`not(a, b)` ≡ `not(and(a, b))`).
- **Lowering**: `planCondition` already accepted `not`/`nor` compounds; it now additionally normalizes a **single-child** negation onto the child plan's own negated form — `not(eq(…))` lowers to the *identical* plan as `ne(…)` (constants flip their verdict, double negation cancels structurally). Only interiors without a negated leaf form (ordering comparisons, `mod`, `size`, `elemMatch`, multi-child groups) remain a `CompoundPlan` with `negated: true`.
- **Backends**: memory needed no change; sql/typeorm change the negated-group rendering (below).
- **Codec round-trip**: the expression dialect parses and serializes `not(…)` first-class; the legacy simple dialect throws typed (`FEATURE_UNSUPPORTED`) instead of silently serializing the children positively.

## The pinned semantic

The issue's core subtlety: `CompoundPlan.negated` was documented as *not* null-inclusive (SQL three-valued), while memory's `!combined` was a plain boolean complement — the same policy tree could authorize different rows depending on whether it ran as a post-check or was pushed down.

**Pinned: `not(c)` is the exact null-inclusive complement — it matches exactly the rows/bindings `c` does not.** Rationale:

- It is the leaf complement law (#752, plan 019 "settled semantics") extended uniformly to trees; anything else would make `not(eq(…))` and `ne(…)` disagree.
- It is what `invert: true` policy lowering means: the boolean complement of the policy verdict. With three-valued SQL semantics, an inverted policy pushdown would silently deny null-bearing rows the memory post-check allows — the exact bug class the issue warns about.
- Memory produces it naturally; SQL can render it portably.

SQL/typeorm therefore render a negated group as `case when (…) then 1 else 0 end = 0` — the `CASE` collapses `UNKNOWN` to false before the complement, is portable across all shipped dialect presets (pg/mysql/sqlite/mssql/oracle), and single-child negations avoid it entirely via the plan normalization (they reuse the existing null-inclusive twin renderings, e.g. `("age" <> $1 or "age" is null)`).

For dotted to-many paths and `elemMatch` interiors, negation applies per join-row/element binding (existentially quantified outside), consistent with how `ne` over dotted paths already behaves on both backends.

Cross-backend agreement is pinned by the typeorm suites against live sqlite: new null-bearing `not` cases in `parity.spec.ts`, and `complement.spec.ts` now additionally asserts `not(positive)` selects exactly the negative twin's rows on both backends for the whole complement matrix.

## Expression dialect change

`not(…)` previously desugared eagerly (De Morgan + twin flips) and threw for `size`/`elemMatch`; negated ordering flipped to the classical opposite (`not(gt)` → `lte`), which is **not** the complement on null rows. Now:

- a single leaf with a complement twin still normalizes (`not(eq(name,'x'))` → `ne` — wire compatibility for the twins is unchanged, `ne` still encodes as `not(eq(…))`),
- a double `not` cancels,
- everything else — groups, ordering comparisons, `size`, `elemMatch` — stays a first-class NOT node with complement semantics.

The `negation` flag threading through the whole grammar is gone.

## Also

- `Filters.flatten()` no longer hoists same-operator children through a NOT group (negation is not associative; hoisting would turn `not(not(x))` into `not(x)`).
- The expression encoder rejects unknown compound operators typed (previously an unregistered operator like `nor` was emitted verbatim and produced an undecodable token); `nor` stays an internal lowering alias with no public builder or wire form.
- Docs: filters guide (new *Negation* section + complement-law note), building-queries, wire matrix, query-ast, parser-expression and codec-url pages.

## Follow-up candidate (not in scope)

`@rapiq/parser-mongo` still eagerly De Morgans `$not`/`$nor` and throws for the non-twin families (regex/`$size`/`$all`/`$elemMatch`); with the NOT node in place those could become symbolic instead of errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-class `not(...)` filter support with exact, null-inclusive complement behavior.
  * Added negation support for expression-based query URLs, including nested conditions.
  * Added automatic normalization for common negated operators and double negation.

* **Bug Fixes**
  * Improved SQL negation handling for null values and complex filter groups.
  * Prevented unsupported legacy URL filters from being silently misinterpreted.

* **Documentation**
  * Expanded filter, query, URL, and expression-language documentation with negation semantics and dialect support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->