### PR TITLE
feat(memory): accept ICondition in compileFilters

### DIFF
--- a/packages/docs/packages/memory.md
+++ b/packages/docs/packages/memory.md
@@ -56,6 +56,8 @@ const slicer = compilePagination(query.pagination); // (data) => page
 
 Under the hood each `compile*` helper wraps a visitor class (`FiltersVisitor`, `SortsVisitor`, `FieldsVisitor`, `PaginationVisitor`, `QueryVisitor`) — subclass those for custom behavior. Compilation validates the AST (unknown operators throw); the compiled functions themselves never throw.
 
+`compileFilters` accepts any condition node — a leaf `IFilter`, a compound `IFilters`, or the `ICondition` interface both implement. Conditions held abstractly (builder output, a schema's `filters.default`, a lowered authorization residual) pass straight through, no narrowing cast required.
+
 ## Filter semantics
 
 The package aims for **SQL parity**: the same query should select the same records in memory as `@rapiq/sql`/`@rapiq/typeorm` select from the database.

--- a/packages/memory/src/module.ts
+++ b/packages/memory/src/module.ts
@@ -6,9 +6,8 @@
  */
 
 import type {
+    ICondition,
     IFields,
-    IFilter,
-    IFilters,
     IPagination,
     IQuery,
     IQueryVisitor,
@@ -90,10 +89,10 @@ export function applyQuery<T = Record<string, any>>(
 }
 
 export function compileFilters(
-    input: IFilter | IFilters,
+    input: ICondition,
     options: FiltersVisitorOptions = {},
 ) : Predicate {
-    return input.accept<Predicate>(new FiltersVisitor(options));
+    return new FiltersVisitor(options).compile(input);
 }
 
 export function compileSorts<T = Record<string, any>>(input: ISorts) : Comparator<T> {

--- a/packages/memory/src/parameter/filters/module.ts
+++ b/packages/memory/src/parameter/filters/module.ts
@@ -6,6 +6,7 @@
  */
 
 import type {
+    ICondition,
     IFilter,
     IFilterVisitor,
     IFilters,
@@ -37,7 +38,14 @@ export class FiltersVisitor implements IFiltersVisitor<Predicate>, IFilterVisito
 
     // -----------------------------------------------------------
 
-    protected compile(expr: IFilter | IFilters) : Predicate {
+    /**
+     * Compile any condition node — a leaf `IFilter`, a compound `IFilters`,
+     * or the `ICondition` interface both implement — into a {@link Predicate}.
+     * Dispatch happens in `planCondition` (by node kind), so the concrete
+     * union is unnecessary here; callers holding a condition abstractly
+     * (schema `default`, builder output, lowered residuals) need no cast.
+     */
+    compile(expr: ICondition) : Predicate {
         const plan = planCondition(expr, { caseSensitive: this.options.caseSensitive });
         if (!plan) {
             return () => true;

--- a/packages/memory/test/unit/module.spec.ts
+++ b/packages/memory/test/unit/module.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { ICondition } from '@rapiq/core';
 import {
     Field,
     Fields,
@@ -19,7 +20,7 @@ import {
     eq,
     gte,
 } from '@rapiq/core';
-import { applyQuery, compileQuery } from '../../src';
+import { applyQuery, compileFilters, compileQuery } from '../../src';
 
 type User = {
     id: number,
@@ -135,5 +136,18 @@ describe('module', () => {
         expect(output.total).toEqual(users.length);
         expect(output.data[0]).toBe(users[0]);
         expect(output.pagination).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('should compile a condition held abstractly as ICondition without a cast', () => {
+        // Consumers (schema `default`, builder output, lowered policy residuals)
+        // traffic in the `ICondition` interface, not the concrete union.
+        const leaf : ICondition = eq('age', 18);
+        const compound : ICondition = and(gte('age', 18), eq('realm.name', 'master'));
+
+        expect(compileFilters(leaf)(users[0])).toBeTruthy();
+        expect(compileFilters(leaf)(users[2])).toBeFalsy();
+
+        expect(compileFilters(compound)(users[0])).toBeTruthy();
+        expect(compileFilters(compound)(users[3])).toBeFalsy();
     });
 });


### PR DESCRIPTION
Closes #814.

## Problem

`@rapiq/memory`'s `compileFilters` was typed over the concrete union:

```ts
declare function compileFilters(input: IFilter | IFilters, options?: FiltersVisitorOptions): Predicate;
```

Consumers that hold conditions *abstractly* as `ICondition` — the interface both `IFilter` and `IFilters` implement, and the type the `@rapiq/core` builders (`and`/`or`/`not`/`eq`/…) and `FiltersSchema.default` traffic in — had to cast (`condition as IFilter | IFilters`) at every call site. This bit authup's policy lowering (authup#3286 phase 2), which stores the pending residual as `ICondition`.

## Change

- **`compileFilters(input: ICondition, …)`** — widened to the interface. The body no longer calls `input.accept(...)` (which requires the concrete node type); it routes through the visitor's `compile`, which dispatches via `planCondition` by node kind.
- **`FiltersVisitor.compile`** is now public and typed over `ICondition` (it already forwarded to `planCondition`, which has always accepted `ICondition`). `visitFilter`/`visitFilters` still delegate to it unchanged.
- Test pinning the widening: values declared as `ICondition` (leaf `eq(...)` and compound `and(...)`) compile without a cast and evaluate correctly.
- Docs note in `packages/docs/packages/memory.md`.

Out of scope: `Query.filters` stays `IFilters` (root must be a compound node so `.flatten()`/`.merge()`/`.and()`/`.or()` work), and the vestigial `visitFilterElemMatch` value type — neither is the `IFilter | IFilters` union #814 targets, and no real consumer is blocked there.

## Verification

- `@rapiq/memory` builds clean (`build:types` + `build:js`).
- 144 tests pass.
- Changed files lint clean.
- Memory is a leaf package — no downstream impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `compileFilters` now accepts any condition type, including individual and compound conditions.
  * Conditions held through the shared `ICondition` interface can be compiled without casting.

* **Documentation**
  * Clarified supported condition types and abstract condition handling in the API documentation.

* **Tests**
  * Added coverage for compiling and evaluating leaf and compound conditions through `ICondition`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->