### PR TITLE
fix(typeorm): hydrate included relations & allow json columns in fields (#824)

### DIFF
--- a/packages/core/src/schema/parameter/fields/schema.ts
+++ b/packages/core/src/schema/parameter/fields/schema.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { MaybeAsync, ObjectLiteral, SimpleKeys } from '../../../types';
+import type { FieldKeys, MaybeAsync, ObjectLiteral } from '../../../types';
 import {
     isPropertyNameValid,
 } from '../../../utils';
@@ -63,7 +63,7 @@ export class FieldsSchema<
 
     // ---------------------------------------------------------
 
-    setDefault(input?: SimpleKeys<RECORD>[]) {
+    setDefault(input?: FieldKeys<RECORD>[]) {
         if (typeof input === 'undefined') {
             this.default = [];
             this.defaultIsUndefined = true;
@@ -74,7 +74,7 @@ export class FieldsSchema<
         this.defaultIsUndefined = false;
     }
 
-    setAllowed(input?: SimpleKeys<RECORD>[]) {
+    setAllowed(input?: FieldKeys<RECORD>[]) {
         if (typeof input === 'undefined') {
             this.allowed = [];
             this.allowedIsUndefined = true;

--- a/packages/core/src/schema/parameter/fields/types.ts
+++ b/packages/core/src/schema/parameter/fields/types.ts
@@ -6,15 +6,15 @@
  */
 
 import type { BaseSchemaOptions, KeyValidator } from '../../types';
-import type { SimpleKeys } from '../../../types';
+import type { FieldKeys } from '../../../types';
 
 export type FieldsOptions<
     T extends Record<string, any> = Record<string, any>,
     CONTEXT = any,
 > = BaseSchemaOptions & {
     mapping?: Record<string, string>,
-    allowed?: SimpleKeys<T>[],
-    default?: SimpleKeys<T>[],
+    allowed?: FieldKeys<T>[],
+    default?: FieldKeys<T>[],
     /**
      * Dynamic per-field gate, e.g. an actor permission check.
      * Runs once per client-requested field against the schema that

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -118,6 +118,22 @@ export type SimpleResourceKeys<
             never
 }[keyof T & string];
 
+/**
+ * Keys a `fields` projection may list: scalar/leaf columns ({@link SimpleKeys})
+ * plus record/array-shaped keys ({@link SimpleResourceKeys}). The latter covers
+ * concrete-typed json columns (e.g. `{ k: string }[]`) — single columns at the
+ * database level that {@link SimpleKeys} would otherwise reject. Index-signature
+ * json (`Record<string, any>`) is already a {@link SimpleKeys}.
+ *
+ * A json column and a relation are structurally identical at the type level, so
+ * relation keys are admitted here too. List only column-backed keys in `fields`;
+ * relations belong in the `relations` allow-list (`include`). A relation key that
+ * reaches a backend's `fields` is caller error — it is not a selectable column.
+ */
+export type FieldKeys<
+    T extends Record<PropertyKey, any>,
+> = SimpleKeys<T> | SimpleResourceKeys<T>;
+
 export type NestedResourceKeys<
     T extends Record<PropertyKey, any>,
     DEPTH extends number = 4,

--- a/packages/core/test/unit/types.spec.ts
+++ b/packages/core/test/unit/types.spec.ts
@@ -8,6 +8,7 @@
 import { expectTypeOf } from 'vitest';
 import { defineSchema } from '../../src';
 import type {
+    FieldKeys,
     NestedKeys,
     NestedResourceKeys,
     SimpleKeys,
@@ -62,6 +63,30 @@ describe('src/types.ts', () => {
 
             expect(keys).toBeDefined();
             expect(invalid).toBeDefined();
+        });
+    });
+
+    describe('FieldKeys', () => {
+        it('should admit a concrete-typed json column that SimpleKeys rejects (#824)', () => {
+            type Row = {
+                id: string,
+                name: string,
+                args: { k: string }[] | null,
+            };
+
+            const keys: FieldKeys<Row>[] = ['id', 'name', 'args'];
+
+            // @ts-expect-error a concrete-shaped json column is not a SimpleKey
+            const rejected: SimpleKeys<Row>[] = ['args'];
+
+            expect(keys).toBeDefined();
+            expect(rejected).toBeDefined();
+        });
+
+        it('should union leaf columns and resource-shaped keys', () => {
+            const keys: FieldKeys<Event>[] = ['id', 'data', 'meta', 'created_at', 'realm', 'user', 'items'];
+
+            expect(keys).toBeDefined();
         });
     });
 

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -59,7 +59,7 @@ new TypeormAdapter({
 
 | Option | Description |
 |---|---|
-| `relations.joinAndSelect` | Hydrate **every** joined relation, including those joined only for a filter or sort. Off by default — an `include`d relation is still hydrated on its own (join-and-selected, or via its columns when a `fields` projection already covers it), while a relation joined purely for filtering/sorting stays unselected. |
+| `relations.joinAndSelect` | Hydrate **every** joined relation, including those joined only for a filter or sort. Off by default — an `include`d relation is always hydrated as a complete subtree (a sparse `fields` entry such as `child.name` never narrows it), while a relation joined purely for filtering/sorting stays unselected (its columns are hydrated only when a `fields` path references them). |
 | `relations.joinType` | `'left'` (default) or `'inner'`. Left joins keep records whose relation is absent. |
 | `relations.onJoin` | Invoked as `(path, alias, queryBuilder)` for every join the adapter applies — e.g. to `addGroupBy` per join when the root query is grouped. Skipped (pre-existing) joins don't trigger it. |
 | `relations.relationAlias` | Derive the join alias for a relation path (default: collision-free length-prefixed segments, e.g. `role.realm` → `r4_role_5_realm`). Filter/sort/field references resolve against the same derivation. |

--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -59,7 +59,7 @@ new TypeormAdapter({
 
 | Option | Description |
 |---|---|
-| `relations.joinAndSelect` | Join **and select** (hydrate the related entities) instead of joining for filtering/sorting only. |
+| `relations.joinAndSelect` | Hydrate **every** joined relation, including those joined only for a filter or sort. Off by default — an `include`d relation is still hydrated on its own (join-and-selected, or via its columns when a `fields` projection already covers it), while a relation joined purely for filtering/sorting stays unselected. |
 | `relations.joinType` | `'left'` (default) or `'inner'`. Left joins keep records whose relation is absent. |
 | `relations.onJoin` | Invoked as `(path, alias, queryBuilder)` for every join the adapter applies — e.g. to `addGroupBy` per join when the root query is grouped. Skipped (pre-existing) joins don't trigger it. |
 | `relations.relationAlias` | Derive the join alias for a relation path (default: collision-free length-prefixed segments, e.g. `role.realm` → `r4_role_5_realm`). Filter/sort/field references resolve against the same derivation. |

--- a/packages/sql/src/adapter/relations/base.ts
+++ b/packages/sql/src/adapter/relations/base.ts
@@ -7,7 +7,7 @@
 
 import type { RelationAliasFn } from '../../helpers';
 import { buildRelationAlias, splitFirst } from '../../helpers';
-import type { IRelationsAdapter, RelationsAdapterBaseOptions } from './types';
+import type { IRelationsAdapter, RelationAddOptions, RelationsAdapterBaseOptions } from './types';
 
 export abstract class RelationsBaseAdapter implements IRelationsAdapter {
     /**
@@ -23,7 +23,12 @@ export abstract class RelationsBaseAdapter implements IRelationsAdapter {
     protected value : {
         path: string,
         name: string,
-        executed?: boolean
+        executed?: boolean,
+        /**
+         * Explicitly requested via `include`/`relations` (vs. only
+         * traversed by a field/filter/sort path). See {@link RelationAddOptions}.
+         */
+        include?: boolean,
     }[];
 
     protected relationAlias : RelationAliasFn;
@@ -75,10 +80,8 @@ export abstract class RelationsBaseAdapter implements IRelationsAdapter {
 
     // -----------------------------------------------------------
 
-    add(relation: string) {
-        if (this.has(relation)) {
-            return true;
-        }
+    add(relation: string, options: RelationAddOptions = {}) {
+        const include = options.include ?? false;
 
         let path : string | undefined;
         let last : string | undefined = relation;
@@ -91,13 +94,22 @@ export abstract class RelationsBaseAdapter implements IRelationsAdapter {
                 `${path}.${relationName}` :
                 relationName;
 
-            if (this.has(path)) {
+            const existing = this.value.find((join) => join.path === path);
+            if (existing) {
+                // A path already registered by a field/filter/sort traversal
+                // is upgraded to an explicit include when re-added as one;
+                // never downgrade an existing include.
+                if (include) {
+                    existing.include = true;
+                }
+
                 continue;
             }
 
             this.value.push({
                 path,
                 name: relationName,
+                include,
             });
         }
 

--- a/packages/sql/src/adapter/relations/types.ts
+++ b/packages/sql/src/adapter/relations/types.ts
@@ -8,8 +8,18 @@
 import type { RelationAliasFn } from '../../helpers';
 import type { ISubAdapter } from '../types';
 
+export type RelationAddOptions = {
+    /**
+     * Whether the relation was explicitly requested (`include`/`relations`)
+     * rather than only traversed by a field/filter/sort path. Explicit
+     * includes are hydrated by backends that materialize an object graph
+     * (e.g. `@rapiq/typeorm`), a join-for-filter is not.
+     */
+    include?: boolean,
+};
+
 export interface IRelationsAdapter extends ISubAdapter {
-    add(input: string): void;
+    add(input: string, options?: RelationAddOptions): void;
 
     buildAlias(path: string): string;
 

--- a/packages/sql/src/visitor/relations.ts
+++ b/packages/sql/src/visitor/relations.ts
@@ -31,7 +31,7 @@ IRelationVisitor<IRelationsAdapter> {
     }
 
     visitRelation(expr: Relation): IRelationsAdapter {
-        this.adapter.add(expr.name);
+        this.adapter.add(expr.name, { include: true });
 
         return this.adapter;
     }

--- a/packages/typeorm/src/adapter/module.ts
+++ b/packages/typeorm/src/adapter/module.ts
@@ -56,6 +56,9 @@ export class TypeormAdapter implements IRootAdapter<TypeormAdapterOutput> {
 
         query.accept(new QueryVisitor(this, options.visitor));
 
+        // ordering is load-bearing: fields.execute() calls queryBuilder.select()
+        // (which resets the select list), while relations.execute() *appends*
+        // join-and-selected relation columns — so fields must run first.
         this.fields.execute();
         this.filters.execute();
         this.pagination.execute();

--- a/packages/typeorm/src/adapter/relations.ts
+++ b/packages/typeorm/src/adapter/relations.ts
@@ -95,7 +95,11 @@ export class RelationsAdapter extends RelationsBaseAdapter {
             );
 
             if (!joined) {
-                this.applyJoin(`${parentAlias}.${relationName}`, alias);
+                this.applyJoin(
+                    `${parentAlias}.${relationName}`,
+                    alias,
+                    this.shouldSelect(path),
+                );
 
                 if (this.options.onJoin) {
                     this.options.onJoin(path, alias, this.queryBuilder);
@@ -109,10 +113,28 @@ export class RelationsAdapter extends RelationsBaseAdapter {
         return true;
     }
 
-    protected applyJoin(property: string, alias: string) : void {
+    /**
+     * Whether the joined relation's columns should be selected (hydrated).
+     * An explicitly `include`d relation is always join-and-selected as a whole
+     * subtree — a sparse `relation.column` field never narrows it, matching the
+     * `@rapiq/memory` projection contract (#824). A relation joined purely for a
+     * filter/sort (not `include`d) stays a plain `leftJoin`, so its columns are
+     * selected only when a field references them.
+     */
+    protected shouldSelect(path: string): boolean {
+        if (this.options.joinAndSelect) {
+            return true;
+        }
+
+        const entry = this.value.find((join) => join.path === path);
+
+        return !!entry && !!entry.include;
+    }
+
+    protected applyJoin(property: string, alias: string, andSelect: boolean) : void {
         const inner = this.options.joinType === 'inner';
 
-        if (this.options.joinAndSelect) {
+        if (andSelect) {
             if (inner) {
                 this.queryBuilder.innerJoinAndSelect(property, alias);
             } else {

--- a/packages/typeorm/test/unit/hydration.spec.ts
+++ b/packages/typeorm/test/unit/hydration.spec.ts
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+/* eslint-disable max-classes-per-file */
+import type { DataSource } from 'typeorm';
+import {
+    Column, 
+    DataSource as DataSourceCtor, 
+    Entity, 
+    JoinColumn, 
+    ManyToOne, 
+    PrimaryGeneratedColumn,
+} from 'typeorm';
+import {
+    Field,
+    Fields,
+    Filter,
+    FilterCompoundOperator,
+    FilterFieldOperator,
+    Filters,
+    Query,
+    Relation,
+    Relations,
+    SchemaRegistry,
+    defineSchema,
+} from '@rapiq/core';
+import { SimpleParser } from '@rapiq/parser-simple';
+import { TypeormAdapter } from '../../src';
+
+@Entity()
+class HPet {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}
+
+@Entity()
+class HChild {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column({ type: 'simple-json', nullable: true })
+    args: { k: string }[] | null;
+
+    @Column({ nullable: true })
+    pet_id: number | null;
+
+    @ManyToOne(() => HPet, { nullable: true })
+    @JoinColumn({ name: 'pet_id' })
+    pet: HPet;
+}
+
+@Entity()
+class HParent {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column({ type: 'simple-json', nullable: true })
+    data: { k: string }[] | null;
+
+    @Column({ nullable: true })
+    child_id: number | null;
+
+    @ManyToOne(() => HChild, { nullable: true })
+    @JoinColumn({ name: 'child_id' })
+    child: HChild;
+}
+
+/**
+ * Regression coverage for #824: a relation `include`d without `joinAndSelect`
+ * and without projected child fields must still hydrate, and json/array
+ * columns must project through the Fields IR.
+ */
+describe('src/adapter/relations (hydration)', () => {
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        dataSource = new DataSourceCtor({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            entities: [HParent, HChild, HPet],
+        });
+        await dataSource.initialize();
+        await dataSource.synchronize();
+
+        const pet = await dataSource.getRepository(HPet).save({ name: 'rex' });
+        const child = await dataSource.getRepository(HChild).save({
+            name: 'c',
+            args: [{ k: 'a' }],
+            pet_id: (pet as any).id,
+        });
+        await dataSource.getRepository(HParent).save({
+            name: 'p',
+            data: [{ k: 'b' }],
+            child_id: (child as any).id,
+        });
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    const run = (query: Query, relationOpts: any = {}) => {
+        const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
+        new TypeormAdapter({ queryBuilder, relations: relationOpts }).execute(query);
+
+        return queryBuilder.getOneOrFail();
+    };
+
+    it('should hydrate an included relation without joinAndSelect and without child fields', async () => {
+        const parent = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('name')]),
+            relations: new Relations([new Relation('child')]),
+        }));
+
+        expect(parent.child).toBeDefined();
+        // full hydration -> json column comes through too
+        expect(parent.child.args).toEqual([{ k: 'a' }]);
+    });
+
+    it('should hydrate an included relation without any root projection', async () => {
+        const parent = await run(new Query({ relations: new Relations([new Relation('child')]) }));
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');
+        // the root stays fully selected
+        expect(parent.data).toEqual([{ k: 'b' }]);
+    });
+
+    it('should widen an included relation to the whole subtree even with a projected child field', async () => {
+        // @rapiq/memory contract: an included relation contributes ALL its
+        // columns; a sparse `child.name` never narrows an included relation.
+        const parent = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('child.name')]),
+            relations: new Relations([new Relation('child')]),
+        }));
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');
+        expect(parent.child.args).toEqual([{ k: 'a' }]);
+    });
+
+    it('should keep a relation sparse when a field traverses it WITHOUT an include', async () => {
+        // no `relations` include: `child.name` only joins-for-projection, so the
+        // relation is materialized sparsely (just the referenced column).
+        const parent = await run(new Query({ fields: new Fields([new Field('id'), new Field('child.name')]) }));
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');
+        expect(parent.child.args).toBeUndefined();
+    });
+
+    it('should hydrate a nested include without joinAndSelect', async () => {
+        const parent = await run(new Query({ relations: new Relations([new Relation('child.pet')]) }));
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.pet).toBeDefined();
+        expect(parent.child.pet.name).toEqual('rex');
+    });
+
+    it('should hydrate a nested include while a filter joins another branch', async () => {
+        const parent = await run(new Query({
+            relations: new Relations([new Relation('child.pet')]),
+            filters: new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'child.name', 'c'),
+            ]),
+        }));
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.pet.name).toEqual('rex');
+    });
+
+    it('should hydrate with joinAndSelect (regression guard)', async () => {
+        const parent = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('name')]),
+            relations: new Relations([new Relation('child')]),
+        }), { joinAndSelect: true });
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.args).toEqual([{ k: 'a' }]);
+    });
+
+    it('should NOT hydrate a relation joined only for a filter', async () => {
+        const parent = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('name')]),
+            filters: new Filters(FilterCompoundOperator.AND, [
+                new Filter(FilterFieldOperator.EQUAL, 'child.name', 'c'),
+            ]),
+        }));
+
+        // the relation is joined for the WHERE clause but never requested,
+        // so it must not appear in the result
+        expect(parent.child).toBeUndefined();
+    });
+
+    it('should project a json/array column placed in the Fields IR', async () => {
+        const parent = await run(new Query({ fields: new Fields([new Field('id'), new Field('data')]) }));
+
+        expect(parent.data).toEqual([{ k: 'b' }]);
+    });
+
+    it('should drop a json/array column omitted from an explicit projection', async () => {
+        const parent = await run(new Query({ fields: new Fields([new Field('id'), new Field('name')]) }));
+
+        expect(parent.data).toBeUndefined();
+    });
+
+    it('should allow listing a concrete-typed json column in a schema fields block', () => {
+        // #824 G2: a json column typed as a concrete array/object shape is now
+        // a valid `fields` key (widened from SimpleKeys to FieldKeys).
+        const schema = defineSchema<HParent>({
+            name: 'parent',
+            fields: { default: ['id', 'name', 'data'] },
+        });
+
+        expect(schema.fields.default).toEqual(['id', 'name', 'data']);
+    });
+
+    it('should hydrate an include end-to-end when the target schema has no fields block', async () => {
+        // mirrors the downstream crash (authup #3313 / FLAME Hub): a schema used
+        // purely as an `include` target with no `fields` declaration, consumed
+        // without `joinAndSelect` — the relation used to come back undefined.
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema<HChild>({ name: 'child' }));
+        registry.add(defineSchema<HParent>({
+            name: 'parent',
+            relations: { allowed: ['child'] },
+            schemaMapping: { child: 'child' },
+        }));
+
+        const query = new SimpleParser(registry).parse(
+            { relations: ['child'] },
+            { schema: 'parent' },
+        );
+
+        const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
+        new TypeormAdapter({ queryBuilder }).execute(query);
+        const parent = await queryBuilder.getOneOrFail();
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');
+        expect(parent.child.args).toEqual([{ k: 'a' }]);
+    });
+});


### PR DESCRIPTION
Fixes #824.

Two related projection issues in `@rapiq/core` + `@rapiq/typeorm` that together made it impossible to have an entity be both an `include=` target and return its json columns.

## Gotcha 1 — an included relation without `joinAndSelect` + child fields was silently dropped

`TypeormAdapter` joined an `include`d relation with a plain `leftJoin` unless `relations.joinAndSelect` was set. Without a child-field projection, TypeORM never hydrated it, so the relation came back `undefined` — an authorization/data bug that was hard to trace (crashed downstream node creation on `clientPermission.permission.name`).

An included relation is now **join-and-selected as a whole subtree**, so it hydrates on its own. This deliberately matches the settled `@rapiq/memory` projection contract (`should widen refined relations to the whole subtree`):

- `include=child` → child fully hydrated, **even alongside** a sparse `fields=[…, child.name]` (a sparse child field never narrows an included relation).
- `fields=child.name` **without** an include → child materialized sparsely (join-for-projection only).
- a relation joined only for a **filter/sort** → plain `leftJoin`, never selected.
- `relations.joinAndSelect: true` → unchanged (selects every joined relation).

Relations now carry an `include` flag (set by the relations visitor, upgraded — never downgraded — when a field/filter/sort traversal also names them), and `shouldSelect = joinAndSelect || include`.

## Gotcha 2 — json/array columns could not be listed in a `fields` schema block

A concrete-typed json column (`@Column({ type: 'simple-json' }) args: { k: string }[]`) selects fine through the `Fields` IR but was rejected by `SimpleKeys<T>` at the `defineSchema` type level, so it could never appear in `fields.allowed`/`default` and was unavoidably dropped.

The `fields` key type is widened to `FieldKeys<T> = SimpleKeys<T> | SimpleResourceKeys<T>`, which admits concrete json shapes (index-signature json like `Record<string, any>` was already a `SimpleKeys`).

A json column and a relation are structurally identical to the type system, so relation keys are admitted here too. Rather than add a backend-specific guard, this follows the maintainer's steer: **`fields` is for columns, `relations` is for relations.** Correct schema-driven input never produces a relation key in `fields` (a client's `fields=child` is dropped by the `fields.allowed` allow-list at decode time, since `child` lives in `relations.allowed`); a hand-built `new Field('child')` is caller responsibility, not something a backend silently papers over.

## Notes / design

- No new cross-backend behavior: the change makes `@rapiq/typeorm` match `@rapiq/memory`, and `@rapiq/sql` is untouched (it never joins/hydrates).
- The `fields.execute()` → `relations.execute()` ordering is now documented as load-bearing (`select()` resets, join-and-select appends).
- Two independent adversarial reviews drove this design; both flagged an earlier `hasProjection`-based approach as over-hydrating on deeper projections and diverging from the memory contract — that machinery was removed in favor of the simpler `joinAndSelect || include` rule.

## Follow-up (out of scope)

The client-side build layer (`defineFields`/`defineQuery`, `FieldsBuildInput`) still types field keys via `SimpleKeys`/`NestedKeys`, so it rejects concrete json columns — an asymmetry with the (now widened) server schema. Worth a separate change.

## Tests

- `packages/typeorm/test/unit/hydration.spec.ts` (new): include-without-joinAndSelect, whole-subtree widening, sparse traversal, nested `child.pet` includes (incl. alongside a filter), filter-only-not-hydrated, json projection, and an end-to-end `SchemaRegistry` + `SimpleParser` → `TypeormAdapter` case mirroring the downstream crash.
- `packages/core/test/unit/types.spec.ts`: `FieldKeys` admits a concrete json column that `SimpleKeys` rejects.
- Docs: `packages/docs/packages/typeorm.md` `relations.joinAndSelect` description updated.

All 8 test projects pass; full build + lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting typed JSON and resource-shaped fields in field projections.
  * Included relations are now fully hydrated, including nested relations and JSON/array columns.
  * Relations used only for filtering or sorting remain unselected unless explicitly included.

* **Bug Fixes**
  * Improved relation hydration when `joinAndSelect` is disabled.

* **Documentation**
  * Clarified relation join and hydration behavior for the TypeORM adapter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->