### PR TITLE
fix(core): allow concrete-typed json columns in the fields build input (#826)

### DIFF
--- a/packages/core/src/build/parameter/fields/types.ts
+++ b/packages/core/src/build/parameter/fields/types.ts
@@ -12,18 +12,25 @@ import type {
     ObjectLiteral,
     PrevIndex,
     SimpleKeys,
+    SimpleResourceKeys,
 } from '../../../types';
 
 type FieldWithOperator<T extends string> = KeyWithOptionalPrefix<T, FieldOperator>;
 
+// `SimpleResourceKeys` admits record/array-shaped keys — concrete-typed json
+// columns (e.g. `{ k: string }[]`), which are single columns at the database
+// level but which `SimpleKeys`/`NestedKeys` treat as recursable resources.
+// Listing the bare key selects the whole column, mirroring `defineSchema`
+// `fields` (FieldKeys). Relation keys are admitted too (structurally identical
+// at the type level) — list only column-backed keys; relations use `include`.
 export type FieldsBuildSimpleKeyInput<
     T extends ObjectLiteral = ObjectLiteral,
-> = FieldWithOperator<SimpleKeys<T>>;
+> = FieldWithOperator<SimpleKeys<T> | SimpleResourceKeys<T>>;
 
 export type FieldsBuildNestedKeyInput<
     T extends ObjectLiteral = ObjectLiteral,
     DEPTH extends number = 5,
-> = FieldWithOperator<NestedKeys<T, DEPTH>>;
+> = FieldWithOperator<NestedKeys<T, DEPTH> | SimpleResourceKeys<T>>;
 
 export type FieldsBuildRecordInput<
     T extends Record<PropertyKey, any>,

--- a/packages/core/test/unit/build/module.spec.ts
+++ b/packages/core/test/unit/build/module.spec.ts
@@ -317,6 +317,23 @@ describe('src/build/parameter/{fields,sorts,relations,pagination}/*.ts', () => {
         expect(tuple.value.map((el) => el.name)).toEqual(['id', 'realm.name']);
     });
 
+    it('should select a concrete-typed json column as a whole field (#826)', () => {
+        type Row = {
+            id: string, 
+            name: string, 
+            args: { k: string }[] | null 
+        };
+
+        // the json column is a single DB column: listing the bare key selects it
+        // whole (previously rejected because it is not a SimpleKey / NestedKeys
+        // recurses into it as `args.k`).
+        const array = defineFields<Row>(['id', 'args']);
+        expect(array.value.map((el) => el.name)).toEqual(['id', 'args']);
+
+        const tuple = defineFields<Row>([['id', 'args'], {}]);
+        expect(tuple.value.map((el) => el.name)).toEqual(['id', 'args']);
+    });
+
     it('should desugar sort strings, arrays and records', () => {
         const single = defineSorts<User>('-age');
         expect(single.value.map((el) => [el.name, el.operator])).toEqual([


### PR DESCRIPTION
Fixes #826.

Companion to #825, which widened the **server-side** `fields` schema key type so concrete-typed json columns (`{ k: string }[]`) can be listed in `defineSchema`. This brings the same to the **client-side build path** (`defineFields`/`defineQuery`).

## Problem

`FieldsBuildInput<T>` typed field keys via `SimpleKeys`/`NestedKeys`, so a concrete json column fell through every arm (it is structurally identical to a to-many relation):

- `FieldsBuildSimpleKeyInput` (`SimpleKeys`) rejected the bare key.
- `FieldsBuildNestedKeyInput` (`NestedKeys`) recursed into the shape → `args.k`, not bare `args` (and `args.k` is not a real column).

## Fix

Widen the two bare-key arms to also admit `SimpleResourceKeys`, so listing the bare key selects the whole column:

```ts
FieldsBuildSimpleKeyInput = FieldWithOperator<SimpleKeys<T> | SimpleResourceKeys<T>>
FieldsBuildNestedKeyInput = FieldWithOperator<NestedKeys<T, DEPTH> | SimpleResourceKeys<T>>
```

```ts
type Row = { id: string; name: string; args: { k: string }[] | null };
defineFields<Row>(['id', 'args']); // ✅ now compiles -> Field('args')
```

Relation keys are admitted too (same structural ambiguity, same contract as the schema side — `fields` is for columns; use `include`/`relations` for relations). The record-descent form is unchanged, and the `@ts-expect-error` DEPTH guards still hold.

## Notes

- Independent of #825 — uses the pre-existing `SimpleResourceKeys`, so it branches cleanly off `master`. Once #825 lands, `FieldsBuildSimpleKeyInput` could reuse the `FieldKeys` alias it introduces (cosmetic).
- Additive type widening: full build + all 8 test projects pass.

## Tests

`packages/core/test/unit/build/module.spec.ts`: a concrete json column is selectable as a whole field through both the array and tuple build forms.
