### PR TITLE
feat(typeorm): id-only relation hydration for grouped pagination (#828)

### DIFF
--- a/packages/docs/packages/typeorm.md
+++ b/packages/docs/packages/typeorm.md
@@ -49,6 +49,7 @@ adapter.execute(query, { clear: false });
 new TypeormAdapter({
     relations: {
         joinAndSelect: true,
+        hydrationMode: 'full',
         joinType: 'left',
         onJoin: (path, alias, queryBuilder) => {
             queryBuilder.addGroupBy(`${alias}.id`);
@@ -60,6 +61,7 @@ new TypeormAdapter({
 | Option | Description |
 |---|---|
 | `relations.joinAndSelect` | Hydrate **every** joined relation, including those joined only for a filter or sort. Off by default — an `include`d relation is always hydrated as a complete subtree (a sparse `fields` entry such as `child.name` never narrows it), while a relation joined purely for filtering/sorting stays unselected (its columns are hydrated only when a `fields` path references them). |
+| `relations.hydrationMode` | `'full'` (default) or `'key'`. Select granularity for the relations the adapter hydrates. `'full'` selects the whole subtree (`leftJoinAndSelect`); `'key'` selects only the relation's primary key (plain `leftJoin` + `addSelect(<alias>.<pk>)`), so the relation object is hydrated **id-only**. Use `'key'` to keep an `include`d relation defined under `GROUP BY <root>.id` on strict dialects — see the warning below. |
 | `relations.joinType` | `'left'` (default) or `'inner'`. Left joins keep records whose relation is absent. |
 | `relations.onJoin` | Invoked as `(path, alias, queryBuilder)` for every join the adapter applies — e.g. to `addGroupBy` per join when the root query is grouped. Skipped (pre-existing) joins don't trigger it. |
 | `relations.relationAlias` | Derive the join alias for a relation path (default: collision-free length-prefixed segments, e.g. `role.realm` → `r4_role_5_realm`). Filter/sort/field references resolve against the same derivation. |
@@ -68,6 +70,18 @@ Relations are validated against the entity metadata of the attached query builde
 
 ::: warning Alias convention
 The exported `buildRelationAlias(path)` helper length-prefixes every segment: `realm` becomes `r5_realm`, and `role.realm` becomes `r4_role_5_realm`. This remains distinct even from a relation literally named `role_realm`. Fields, filters, sorts and joins all use the same derivation. Pre-existing joins are matched by that alias; use the helper for joins you apply yourself, or inject one convention via `relations.relationAlias`. Keep a custom derivation collision-free and within your database's identifier length limit.
+:::
+
+::: warning `include` + `GROUP BY <root>.id`
+An `include`d relation is join-and-**selected as a complete subtree**, which adds *all* of the child's columns to the `SELECT` (this matches the [`@rapiq/memory`](/packages/memory) projection contract). Strict SQL dialects (postgres) reject those columns under a `GROUP BY <root>.id` pagination pattern — a `relations.onJoin` hook that adds `addGroupBy(alias + '.id')` per join — because each joined column is neither grouped nor aggregated. Hydrating an arbitrary subtree and collapsing to distinct roots are fundamentally incompatible there, regardless of how the columns are selected (the same applies to `relations.joinAndSelect: true`).
+
+Pick one:
+
+- **Sparse selection via a field path** — `fields=<relation>.<column>` joins the relation with a plain `leftJoin` and selects only the referenced (groupable) column, no `leftJoinAndSelect`. Use this when you only need a few columns of the relation under a grouped root.
+- **Id-only hydration** — set `relations.hydrationMode: 'key'` to select only the relation's primary key, so the relation object is at least *defined* (id-only) and every selected join column is groupable. The subtree is not materialized — reach for this when a caller relies on the relation being present but does not need its columns.
+- **A non-grouping pagination strategy** — a distinct-root subquery or a two-phase *ids-then-load* when you genuinely need the full include alongside pagination.
+
+`include` remains the right tool when you are **not** grouping the root — the full subtree hydrates without conflict.
 :::
 
 ## Dialect detection

--- a/packages/typeorm/src/adapter/relations.ts
+++ b/packages/typeorm/src/adapter/relations.ts
@@ -6,8 +6,10 @@
  */
 
 import { RelationsBaseAdapter, splitFirst } from '@rapiq/sql';
-import type { SelectQueryBuilder } from 'typeorm';
+import type { EntityMetadata, SelectQueryBuilder } from 'typeorm';
 import type { RelationsAdapterOptions } from './types';
+
+type RelationSelectMode = 'none' | 'full' | 'key';
 
 export class RelationsAdapter extends RelationsBaseAdapter {
     protected queryBuilder : SelectQueryBuilder<any>;
@@ -98,7 +100,8 @@ export class RelationsAdapter extends RelationsBaseAdapter {
                 this.applyJoin(
                     `${parentAlias}.${relationName}`,
                     alias,
-                    this.shouldSelect(path),
+                    this.selectMode(path),
+                    relation.inverseEntityMetadata,
                 );
 
                 if (this.options.onJoin) {
@@ -131,19 +134,64 @@ export class RelationsAdapter extends RelationsBaseAdapter {
         return !!entry && !!entry.include;
     }
 
-    protected applyJoin(property: string, alias: string, andSelect: boolean) : void {
+    /**
+     * Resolve how a joined relation is materialized: `'none'` (plain join,
+     * unselected), `'full'` (whole subtree) or `'key'` (id-only). The
+     * `hydrationMode` option narrows every *hydrated* relation to its primary
+     * key so it survives `GROUP BY <root>.id` on strict dialects.
+     */
+    protected selectMode(path: string): RelationSelectMode {
+        if (!this.shouldSelect(path)) {
+            return 'none';
+        }
+
+        return this.options.hydrationMode === 'key' ? 'key' : 'full';
+    }
+
+    protected applyJoin(
+        property: string,
+        alias: string,
+        mode: RelationSelectMode,
+        target: EntityMetadata,
+    ) : void {
         const inner = this.options.joinType === 'inner';
 
-        if (andSelect) {
+        if (mode === 'full') {
             if (inner) {
                 this.queryBuilder.innerJoinAndSelect(property, alias);
             } else {
                 this.queryBuilder.leftJoinAndSelect(property, alias);
             }
-        } else if (inner) {
+
+            return;
+        }
+
+        // 'none' (filter/sort-only) or 'key' (id-only hydration): a plain join.
+        if (inner) {
             this.queryBuilder.innerJoin(property, alias);
         } else {
             this.queryBuilder.leftJoin(property, alias);
+        }
+
+        if (mode === 'key') {
+            // Selecting the primary key alone hydrates the relation object
+            // id-only (TypeORM's JoinAttribute.isSelected matches any selected
+            // `<alias>.<column>`), which strict dialects accept under GROUP BY.
+            // Guarded because relations run after fields: a `<relation>.<pk>`
+            // field path (or a full `<alias>` select) already covers the key,
+            // and re-adding it multiplies duplicate SELECT columns.
+            const { selects } = this.queryBuilder.expressionMap;
+
+            for (const column of target.primaryColumns) {
+                const selection = `${alias}.${column.propertyPath}`;
+                const selected = selects.some(
+                    (select) => select.selection === selection || select.selection === alias,
+                );
+
+                if (!selected) {
+                    this.queryBuilder.addSelect(selection);
+                }
+            }
         }
     }
 }

--- a/packages/typeorm/src/adapter/types.ts
+++ b/packages/typeorm/src/adapter/types.ts
@@ -10,6 +10,20 @@ import type { SelectQueryBuilder } from 'typeorm';
 
 export type RelationsAdapterJoinType = 'left' | 'inner';
 
+/**
+ * How much of a hydrated relation is selected.
+ *
+ * - `'full'` (default): the whole subtree — every column of the joined
+ *   relation is selected (`leftJoinAndSelect`), matching the
+ *   `@rapiq/memory` projection contract.
+ * - `'key'`: only the relation's primary key column(s) — a plain
+ *   `leftJoin` plus `addSelect(<alias>.<pk>)`, so the relation object is
+ *   hydrated **id-only**. Use this to keep an `include`d relation defined
+ *   under `GROUP BY <root>.id` on strict dialects (postgres), where the
+ *   full subtree's non-grouped columns are rejected.
+ */
+export type RelationsAdapterHydrationMode = 'full' | 'key';
+
 export type RelationsAdapterOptions = RelationsAdapterBaseOptions & {
     /**
      * Join strategy for relations.
@@ -17,6 +31,15 @@ export type RelationsAdapterOptions = RelationsAdapterBaseOptions & {
      * (matches typeorm-extension's leftJoinAndSelect behavior).
      */
     joinType?: RelationsAdapterJoinType,
+
+    /**
+     * Select granularity for relations the adapter hydrates (both
+     * `include`d relations and, with `joinAndSelect`, every joined one).
+     * Defaults to `'full'` (whole subtree). Set to `'key'` to select only
+     * the primary key so a hydrated relation survives `GROUP BY <root>.id`
+     * on strict dialects — see {@link RelationsAdapterHydrationMode}.
+     */
+    hydrationMode?: RelationsAdapterHydrationMode,
 
     /**
      * Invoked for every join this adapter applies (skipped joins,

--- a/packages/typeorm/test/unit/hydration.spec.ts
+++ b/packages/typeorm/test/unit/hydration.spec.ts
@@ -228,6 +228,104 @@ describe('src/adapter/relations (hydration)', () => {
         expect(schema.fields.default).toEqual(['id', 'name', 'data']);
     });
 
+    it('should hydrate an included relation id-only with hydrationMode: key', async () => {
+        // #828 escape: the relation is defined, but only its primary key is
+        // selected — the whole-subtree columns (name/args) stay unhydrated so
+        // the relation survives GROUP BY <root>.id on strict dialects.
+        const parent = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('name')]),
+            relations: new Relations([new Relation('child')]),
+        }), { hydrationMode: 'key' });
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.id).toBeDefined();
+        expect(parent.child.name).toBeUndefined();
+        expect(parent.child.args).toBeUndefined();
+    });
+
+    it('should emit a plain leftJoin selecting only the key under hydrationMode: key', () => {
+        const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
+        new TypeormAdapter({ queryBuilder, relations: { hydrationMode: 'key' } })
+            .execute(new Query({ relations: new Relations([new Relation('child')]) }));
+
+        const sql = queryBuilder.getQuery();
+        const alias = queryBuilder.expressionMap.joinAttributes[0].alias.name;
+
+        // the child's key is selected, but its other columns are not
+        expect(sql).toContain(`"${alias}"."id"`);
+        expect(sql).not.toContain(`"${alias}"."name"`);
+        expect(sql).not.toContain(`"${alias}"."args"`);
+    });
+
+    it('should not re-select the key when a field already names it under hydrationMode: key', async () => {
+        // relations run after fields, so a `child.id` field path already selects
+        // the key the id-only mode would add. The guard must not add it a second
+        // time (otherwise the adapter multiplies duplicate SELECT columns).
+        const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
+        new TypeormAdapter({ queryBuilder, relations: { hydrationMode: 'key' } })
+            .execute(new Query({
+                fields: new Fields([new Field('id'), new Field('child.id')]),
+                relations: new Relations([new Relation('child')]),
+            }));
+
+        const alias = queryBuilder.expressionMap.joinAttributes[0].alias.name;
+        const keySelects = queryBuilder.expressionMap.selects
+            .filter((select) => select.selection === `${alias}.id`);
+
+        // the adapter contributes exactly one key selection — the field's — and
+        // does not stack another on top
+        expect(keySelects).toHaveLength(1);
+
+        const parent = await queryBuilder.getOneOrFail();
+        expect(parent.child.id).toBeDefined();
+    });
+
+    it('should hydrate a nested include id-only with hydrationMode: key', async () => {
+        const parent = await run(
+            new Query({ relations: new Relations([new Relation('child.pet')]) }),
+            { hydrationMode: 'key' },
+        );
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.id).toBeDefined();
+        expect(parent.child.name).toBeUndefined();
+        expect(parent.child.pet).toBeDefined();
+        expect(parent.child.pet.id).toBeDefined();
+        expect(parent.child.pet.name).toBeUndefined();
+    });
+
+    it('should keep an id-only include defined under GROUP BY <root>.id', async () => {
+        // the motivating case (#828): grouped-root pagination + include. With the
+        // full subtree, postgres rejects the joined columns; id-only keeps the
+        // relation defined and every selected join column groupable.
+        const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
+        new TypeormAdapter({
+            queryBuilder,
+            relations: {
+                hydrationMode: 'key',
+                onJoin: (_path, alias, qb) => qb.addGroupBy(`${alias}.id`),
+            },
+        }).execute(new Query({ relations: new Relations([new Relation('child')]) }));
+        queryBuilder.addGroupBy('parent.id');
+
+        const parent = await queryBuilder.getOneOrFail();
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.id).toBeDefined();
+        expect(parent.child.name).toBeUndefined();
+    });
+
+    it('should hydrate the whole subtree with hydrationMode: full (default)', async () => {
+        const parent = await run(
+            new Query({ relations: new Relations([new Relation('child')]) }),
+            { hydrationMode: 'full' },
+        );
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');
+        expect(parent.child.args).toEqual([{ k: 'a' }]);
+    });
+
     it('should hydrate an include end-to-end when the target schema has no fields block', async () => {
         // mirrors the downstream crash (authup #3313 / FLAME Hub): a schema used
         // purely as an `include` target with no `fields` declaration, consumed


### PR DESCRIPTION
Closes #828.

## Context

After #825, an explicitly `include`d relation is `leftJoinAndSelect`ed as a **complete subtree** (matching the `@rapiq/memory` projection contract). That is the intended semantics, but it cannot coexist with the `GROUP BY <root>.id` pagination pattern on strict dialects (postgres): the join selects *every* child column, and postgres rejects non-grouped selected columns under `GROUP BY`. The same already applies to `relations.joinAndSelect: true`.

This PR does both parts of #828: **documents the interaction** (the minimum) and adds a **first-class escape**.

## The escape — `relations.hydrationMode: 'full' | 'key'`

New adapter option controlling the select granularity of the relations the adapter hydrates (parallels the existing `joinType`):

- `'full'` (default) — the whole subtree (`leftJoinAndSelect`); unchanged behavior.
- `'key'` — a plain `leftJoin` + `addSelect(<alias>.<pk>)` per primary column, so the relation object is hydrated **id-only** and every selected join column is groupable under `GROUP BY <root>.id`.

```ts
new TypeormAdapter({
    queryBuilder,
    relations: {
        hydrationMode: 'key',
        onJoin: (_p, alias, qb) => qb.addGroupBy(`${alias}.id`),
    },
});
```

### Why id-only actually hydrates

Verified against the TypeORM 1.1.0 transformer: `JoinAttribute.isSelected` returns true when any selected column matches `<alias>.<propertyPath>`, so selecting only the primary key is enough for the result transformer to build the nested `{ id }` object. A plain `leftJoin` with no select would leave the relation `undefined`.

### Duplicate-select guard

`relations.execute()` runs after `fields.execute()`, so a `<relation>.<pk>` field path — or a manual caller `.select()`/`.addSelect()` on the relation alias — may already cover the key. The key-mode add reads the live `expressionMap.selects` and skips a primary key that is already selected (by rapiq or externally), so the adapter never stacks duplicate SELECT columns. (Note: TypeORM itself emits a manually-selected relation PK twice via its two select-generation passes — a pre-existing quirk the guard does not amplify.)

## Docs

`packages/docs/packages/typeorm.md`:
- New `relations.hydrationMode` options-table row + example.
- A warning block explaining the `include` + `GROUP BY <root>.id` conflict and the three escapes: sparse `fields=<relation>.<column>`, `hydrationMode: 'key'`, or a non-grouping pagination strategy (distinct-root subquery / ids-then-load).

## Limitation (documented, by design)

`'key'` hydrates the relation object id-only — the subtree is not materialized. It is the right tool when a caller relies on the relation being *present* but does not need its columns; when full columns are needed under a grouped root, use a non-grouping pagination strategy instead.

## Tests

`packages/typeorm/test/unit/hydration.spec.ts` (against a real in-memory sqlite builder):
- id-only hydration (child defined, only `id` populated);
- SQL shape: plain `LEFT JOIN` selecting only the key;
- nested id-only include;
- id-only include staying defined under `GROUP BY <root>.id` + `onJoin`;
- `hydrationMode: 'full'` matching the default;
- duplicate-select guard (key not re-added when a field already names it).

All 155 `@rapiq/typeorm` tests pass; build + lint clean.