### PR TITLE
fix(typeorm): stop double-projecting included relations (#831)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,6 +87,75 @@ jobs:
                 run: |
                     npm run test:coverage
 
+    tests-db:
+        # Runs the @rapiq/typeorm live-database specs (`*.db.spec.ts`, executed
+        # via `getMany()` against a real engine) so an engine-specific regression
+        # like MySQL rejecting a duplicate output alias (#831) can no longer hide
+        # behind the sqlite-only `tests` job. Scoped to the `.db.spec` files on
+        # purpose: the rest of the suite asserts dialect-specific SQL strings
+        # (escaping, placeholders, collation) that only hold on sqlite. The
+        # default `tests` job keeps sqlite + coverage on the Docker-free path.
+        name: Test Package (Database)
+        needs: [build]
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -   db: mysql
+                        port: 3306
+                        username: root
+                    -   db: postgres
+                        port: 5432
+                        username: postgres
+        services:
+            mysql:
+                image: mysql:9
+                env:
+                    MYSQL_ROOT_PASSWORD: start123
+                    MYSQL_DATABASE: test
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="mysqladmin ping -h 127.0.0.1 -pstart123"
+                    --health-interval=5s
+                    --health-timeout=5s
+                    --health-retries=10
+            postgres:
+                image: postgres:18
+                env:
+                    POSTGRES_PASSWORD: start123
+                    POSTGRES_DB: test
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U postgres"
+                    --health-interval=5s
+                    --health-timeout=5s
+                    --health-retries=10
+        env:
+            DB_TYPE: ${{ matrix.db }}
+            DB_HOST: 127.0.0.1
+            DB_PORT: ${{ matrix.port }}
+            DB_USERNAME: ${{ matrix.username }}
+            DB_PASSWORD: start123
+            DB_DATABASE: test
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v7
+
+            -   name: Install
+                uses: ./.github/actions/install
+                with:
+                    node-version: ${{ env.PRIMARY_NODE_VERSION }}
+
+            -   name: Build
+                uses: ./.github/actions/build
+
+            -   name: Run tests
+                run: |
+                    npm run test:db --workspace=packages/typeorm
+
 #    preview:
 #        name: Preview Package
 #        needs: [build]

--- a/package-lock.json
+++ b/package-lock.json
@@ -7398,6 +7398,103 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/pg": {
+            "version": "8.22.0",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+            "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pg-connection-string": "^2.14.0",
+                "pg-pool": "^3.14.0",
+                "pg-protocol": "^1.15.0",
+                "pg-types": "2.2.0",
+                "pgpass": "1.0.5"
+            },
+            "engines": {
+                "node": ">= 16.0.0"
+            },
+            "optionalDependencies": {
+                "pg-cloudflare": "^1.4.0"
+            },
+            "peerDependencies": {
+                "pg-native": ">=3.0.1"
+            },
+            "peerDependenciesMeta": {
+                "pg-native": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/pg-cloudflare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+            "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/pg-connection-string": {
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+            "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pg-int8": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+            "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/pg-pool": {
+            "version": "3.14.0",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+            "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "pg": ">=8.0"
+            }
+        },
+        "node_modules/pg-protocol": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+            "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pg-types": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+            "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pg-int8": "1.0.1",
+                "postgres-array": "~2.0.0",
+                "postgres-bytea": "~1.0.0",
+                "postgres-date": "~1.0.4",
+                "postgres-interval": "^1.1.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/pgpass": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+            "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "split2": "^4.1.0"
+            }
+        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7479,6 +7576,49 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/postgres-array": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+            "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postgres-bytea": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
+            "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-date": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+            "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/postgres-interval": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+            "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xtend": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/preact": {
@@ -8167,6 +8307,16 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/split2": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+            "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10.x"
             }
         },
         "node_modules/sql-escaper": {
@@ -9678,6 +9828,16 @@
                 "node": ">=12"
             }
         },
+        "node_modules/xtend": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.4"
+            }
+        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -9936,6 +10096,7 @@
                 "ansis": "^4.2.0",
                 "better-sqlite3": "^12.6.0",
                 "mysql2": "^3.22.6",
+                "pg": "^8.13.0",
                 "reflect-metadata": "^0.2.2",
                 "typeorm": "^1.1.0",
                 "unplugin-swc": "^1.5.9"

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -26,6 +26,7 @@
         "ansis": "^4.2.0",
         "better-sqlite3": "^12.6.0",
         "mysql2": "^3.22.6",
+        "pg": "^8.13.0",
         "reflect-metadata": "^0.2.2",
         "typeorm": "^1.1.0",
         "unplugin-swc": "^1.5.9"
@@ -41,6 +42,7 @@
         "build": "npm run build:types && npm run build:js",
         "test": "vitest --config test/vitest.config.ts --run",
         "test:coverage": "vitest --config test/vitest.config.ts --run --coverage",
+        "test:db": "vitest --config test/vitest.config.ts --run .db.spec",
         "prepublishOnly": "npm run build"
     },
     "author": {

--- a/packages/typeorm/src/adapter/fields.ts
+++ b/packages/typeorm/src/adapter/fields.ts
@@ -12,10 +12,13 @@ import type { RelationsAdapter } from './relations';
 export class FieldsAdapter extends FieldsBaseAdapter {
     protected queryBuilder : SelectQueryBuilder<any>;
 
+    protected relationsAdapter : RelationsAdapter;
+
     constructor(queryBuilder: SelectQueryBuilder<any>, relations: RelationsAdapter) {
         super(relations);
 
         this.queryBuilder = queryBuilder;
+        this.relationsAdapter = relations;
     }
 
     rootAlias(): string | undefined {
@@ -30,7 +33,27 @@ export class FieldsAdapter extends FieldsBaseAdapter {
     }
 
     override execute() {
-        const columns = this.getColumns();
+        // A relation join-and-selected as a whole subtree (an `include` in the
+        // default 'full' hydration mode) is hydrated by the join itself, so its
+        // columns must not also appear in the explicit select — that duplicates
+        // the output alias (MySQL rejects it, #831). A relation joined only for a
+        // filter/sort, or hydrated id-only ('key' mode), is NOT auto-selected, so
+        // a field that references it stays and is projected sparsely.
+        const selected = this.relationsAdapter.fullySelectedRelationAliases();
+
+        const columns = this.getColumns().filter((column) => {
+            // The join alias is always the FIRST dotted segment: relation aliases
+            // never contain '.', and a column behind a relation may carry a dotted
+            // embedded path (e.g. `r4_role.profile.firstName`). Splitting on the
+            // last dot would miss those and re-project the embedded column (#831).
+            const index = column.indexOf('.');
+            if (index === -1) {
+                return true;
+            }
+
+            return !selected.has(column.substring(0, index));
+        });
+
         if (columns.length > 0) {
             this.queryBuilder.select(columns);
         }

--- a/packages/typeorm/src/adapter/relations.ts
+++ b/packages/typeorm/src/adapter/relations.ts
@@ -69,6 +69,29 @@ export class RelationsAdapter extends RelationsBaseAdapter {
         }
     }
 
+    /**
+     * Aliases of the relations `execute()` will join-*and-select* as a whole
+     * subtree — i.e. `selectMode(path) === 'full'`. Such a relation contributes
+     * every one of its columns through the join, so a field that also projects
+     * into it is redundant, and re-selecting the column duplicates its output
+     * alias, which MySQL rejects (#831). The fields adapter drops those columns.
+     *
+     * Deliberately keyed on `'full'`, not `shouldSelect`: an id-only `'key'`
+     * relation is a plain `leftJoin` that does NOT auto-select its columns, so a
+     * `<relation>.<column>` field there must stay in the explicit select.
+     */
+    fullySelectedRelationAliases() : Set<string> {
+        const output = new Set<string>();
+
+        for (const relation of this.value) {
+            if (this.selectMode(relation.path) === 'full') {
+                output.add(this.buildAlias(relation.path));
+            }
+        }
+
+        return output;
+    }
+
     protected join(input: string): boolean {
         let relationFullName : string | undefined = input;
         let path : string | undefined;

--- a/packages/typeorm/test/data/factory.ts
+++ b/packages/typeorm/test/data/factory.ts
@@ -12,10 +12,36 @@ import { Role } from './entity/role';
 import { RoleDetail } from './entity/role-detail';
 import { User } from './entity/user';
 
+const entities = [Role, RoleDetail, User, Realm];
+
+/**
+ * DataSource options for the live-database specs. Defaults to an in-memory
+ * `better-sqlite3` database so `npm test` needs no external infrastructure.
+ * The CI matrix opts into a real engine via `DB_TYPE` (`mysql` | `postgres`)
+ * plus the `DB_HOST`/`DB_PORT`/`DB_USERNAME`/`DB_PASSWORD`/`DB_DATABASE`
+ * connection env vars — the same contract authup uses. `dropSchema` is set for
+ * the persistent engines so each suite's `synchronize()` starts from a clean
+ * schema (unlike sqlite `:memory:`, a real DB survives across spec files).
+ */
 export function createDataSourceOptions() : DataSourceOptions {
+    const type = process.env.DB_TYPE;
+
+    if (type === 'mysql' || type === 'postgres') {
+        return {
+            type,
+            host: process.env.DB_HOST || '127.0.0.1',
+            port: Number(process.env.DB_PORT) || (type === 'mysql' ? 3306 : 5432),
+            username: process.env.DB_USERNAME || (type === 'mysql' ? 'root' : 'postgres'),
+            password: process.env.DB_PASSWORD || 'start123',
+            database: process.env.DB_DATABASE || 'test',
+            entities,
+            dropSchema: true,
+        };
+    }
+
     return {
         type: 'better-sqlite3',
-        entities: [Role, RoleDetail, User, Realm],
+        entities,
         database: ':memory:',
         extra: { charset: 'UTF8_GENERAL_CI' },
     };

--- a/packages/typeorm/test/unit/embedded.spec.ts
+++ b/packages/typeorm/test/unit/embedded.spec.ts
@@ -12,6 +12,8 @@ import {
     FilterFieldOperator,
     Filters,
     Query,
+    Relation,
+    Relations,
     Sort,
     Sorts,
 } from '@rapiq/core';
@@ -172,5 +174,28 @@ describe('src/adapter (embedded columns)', () => {
             buildRelationAlias('role'),
             buildRelationAlias('role.realm'),
         ]);
+    });
+
+    it('should project an included relation once when a dotted embedded column behind it is selected (#831)', async () => {
+        // `role.profile.firstName` behind an included `role` builds the column
+        // string `<roleAlias>.profile.firstName` — a dotted embedded path. The
+        // join alias is the FIRST segment; the fields adapter must recognize it
+        // and drop the column, because `role` is join-and-selected as a whole
+        // subtree. Splitting on the last dot would keep it and re-project the
+        // embedded column, duplicating its output alias (MySQL rejects it).
+        const queryBuilder = createQueryBuilder(new Query({
+            fields: new Fields([new Field('id'), new Field('role.profile.firstName')]),
+            relations: new Relations([new Relation('role')]),
+        }));
+
+        const aliases = [...queryBuilder.getSql().matchAll(/AS\s+"([^"]+)"/g)].map((m) => m[1]);
+        const duplicates = aliases.filter((alias, index) => aliases.indexOf(alias) !== index);
+        expect(duplicates).toEqual([]);
+
+        // the included relation still hydrates as a whole subtree
+        const data = await queryBuilder.getMany();
+        const aston = data.find((user) => !!user.role);
+        expect(aston).toBeDefined();
+        expect(aston!.role.profile.firstName).toEqual('Ada');
     });
 });

--- a/packages/typeorm/test/unit/hydration.spec.ts
+++ b/packages/typeorm/test/unit/hydration.spec.ts
@@ -243,6 +243,23 @@ describe('src/adapter/relations (hydration)', () => {
         expect(parent.child.args).toBeUndefined();
     });
 
+    it('should keep a projected relation column under hydrationMode: key', async () => {
+        // reconciliation guard between #831 and #828/#832: a 'key'-mode relation
+        // is a plain leftJoin that does NOT auto-select its columns, so a sparse
+        // `child.name` field must STAY projected. The #831 drop applies only to
+        // 'full' mode, where leftJoinAndSelect already emits every column — if it
+        // keyed on `shouldSelect` (true for both modes) it would wrongly strip
+        // this column and hydrate the relation without its requested field.
+        const parent = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('child.name')]),
+            relations: new Relations([new Relation('child')]),
+        }), { hydrationMode: 'key' });
+
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');    // sparse column kept
+        expect(parent.child.args).toBeUndefined(); // otherwise still id-only
+    });
+
     it('should emit a plain leftJoin selecting only the key under hydrationMode: key', () => {
         const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
         new TypeormAdapter({ queryBuilder, relations: { hydrationMode: 'key' } })
@@ -321,6 +338,41 @@ describe('src/adapter/relations (hydration)', () => {
             { hydrationMode: 'full' },
         );
 
+        expect(parent.child).toBeDefined();
+        expect(parent.child.name).toEqual('c');
+        expect(parent.child.args).toEqual([{ k: 'a' }]);
+    });
+
+    it('should project an included relation exactly once (no duplicate output alias)', async () => {
+        // Regression for #831: a schema with an explicit root `fields.default`
+        // (authup junction pattern) + an `include` used to project the joined
+        // relation TWICE — once via the schema-projected child fields in the
+        // explicit `select()`, once via `leftJoinAndSelect`'s full-entity
+        // expansion. MySQL rejects the duplicate output alias; sqlite/pg tolerate
+        // it, so this asserts on the generated SQL directly.
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema<HChild>({ name: 'child', fields: { default: ['id', 'name'] } }));
+        registry.add(defineSchema<HParent>({
+            name: 'parent',
+            fields: { default: ['id', 'name'] },
+            relations: { allowed: ['child'] },
+            schemaMapping: { child: 'child' },
+        }));
+
+        const query = new SimpleParser(registry).parse(
+            { relations: ['child'] },
+            { schema: 'parent' },
+        );
+
+        const queryBuilder = dataSource.getRepository(HParent).createQueryBuilder('parent');
+        new TypeormAdapter({ queryBuilder }).execute(query);
+
+        const aliases = [...queryBuilder.getSql().matchAll(/AS\s+"([^"]+)"/g)].map((m) => m[1]);
+        const duplicates = aliases.filter((alias, index) => aliases.indexOf(alias) !== index);
+        expect(duplicates).toEqual([]);
+
+        // the include still hydrates as a whole subtree (the json column comes through)
+        const parent = await queryBuilder.getOneOrFail();
         expect(parent.child).toBeDefined();
         expect(parent.child.name).toEqual('c');
         expect(parent.child.args).toEqual([{ k: 'a' }]);

--- a/packages/typeorm/test/unit/issue-831.db.spec.ts
+++ b/packages/typeorm/test/unit/issue-831.db.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2025.
+ *  Author Peter Placzek (tada5hi)
+ *  For the full copyright and license information,
+ *  view the LICENSE file that was distributed with this source code.
+ */
+
+import type { DataSource } from 'typeorm';
+import {
+    Field, 
+    Fields, 
+    Query, 
+    Relation, 
+    Relations,
+} from '@rapiq/core';
+import { TypeormAdapter } from '../../src';
+import { Role } from '../data/entity/role';
+import { User } from '../data/entity/user';
+import { createDataSource } from '../data/factory';
+import { createRealmSeed } from '../data/seeder/realm';
+import { createRoleSeed } from '../data/seeder/role';
+import { createUserSeed } from '../data/seeder/user';
+
+/**
+ * Executing regression for #831 against a live database (the CI `tests-db`
+ * matrix runs this suite on MySQL and postgres; locally it runs on sqlite).
+ *
+ * The junction/authup pattern groups the root by its id and includes a
+ * relation. Before the fix, the relation's columns were projected twice (once
+ * via the explicit `select()`, once via `leftJoinAndSelect`), which MySQL
+ * rejects with `Duplicate column name` once GROUP BY materializes a temporary
+ * table. sqlite and postgres tolerate the duplicate output alias, so this only
+ * goes red on the MySQL leg — exactly why the beta.7 -> beta.8 regression
+ * slipped a sqlite-only suite.
+ */
+describe('issue #831', () => {
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        dataSource = createDataSource();
+        await dataSource.initialize();
+        await dataSource.synchronize();
+
+        const [master] = await createRealmSeed(dataSource);
+
+        const [admin] = await createRoleSeed(dataSource);
+        const roleRepository = dataSource.getRepository(Role);
+        admin.realm = master;
+        await roleRepository.save(admin);
+
+        const [, aston] = await createUserSeed(dataSource);
+        const userRepository = dataSource.getRepository(User);
+        aston.role = admin;
+        aston.realm = master;
+        await userRepository.save(aston);
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    it('projects an included relation exactly once under GROUP BY <root>.id', async () => {
+        const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
+        queryBuilder.groupBy('user.id');
+
+        new TypeormAdapter({
+            queryBuilder,
+            relations: {
+                // mirror the authup junction adapter: keep every joined relation
+                // groupable so postgres' functional-dependency check is satisfied
+                // and the query isolates the #831 duplicate-alias failure to MySQL.
+                onJoin: (_path, alias, builder) => {
+                    if (builder.expressionMap.groupBys.length > 0) {
+                        builder.addGroupBy(`${alias}.id`);
+                    }
+                },
+            },
+        }).execute(new Query({
+            fields: new Fields([new Field('id'), new Field('role.id')]),
+            relations: new Relations([new Relation('role')]),
+        }));
+
+        // getMany() (not getSql()) is required: the duplicate only errors when
+        // the live engine materializes the grouped result.
+        const users = await queryBuilder.getMany();
+
+        expect(users.length).toBeGreaterThan(0);
+        expect(users.some((user) => !!user.role)).toBe(true);
+    });
+
+    it('emits no duplicate output alias for an included relation', () => {
+        const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
+
+        new TypeormAdapter({ queryBuilder }).execute(new Query({
+            fields: new Fields([new Field('id'), new Field('role.id')]),
+            relations: new Relations([new Relation('role')]),
+        }));
+
+        const aliases = [...queryBuilder.getSql().matchAll(/AS\s+"([^"]+)"/g)].map((m) => m[1]);
+        const duplicates = aliases.filter((alias, index) => aliases.indexOf(alias) !== index);
+        expect(duplicates).toEqual([]);
+    });
+});

--- a/packages/typeorm/test/vitest.config.ts
+++ b/packages/typeorm/test/vitest.config.ts
@@ -20,6 +20,12 @@ export default defineConfig({
         environment: 'node',
         setupFiles: ['reflect-metadata'],
         include: ['test/unit/**/*.{spec,test}.{ts,js}'],
+        // Against a real DB (DB_TYPE set) the specs share one persistent
+        // database, so run files serially to avoid workers racing each other's
+        // dropSchema/synchronize, and allow more time for container round-trips.
+        // sqlite (:memory:, per-worker) keeps the default parallel fast path.
+        fileParallelism: !process.env.DB_TYPE,
+        testTimeout: process.env.DB_TYPE ? 30000 : 5000,
         coverage: {
             provider: 'v8',
             include: ['src/**/*.{ts,tsx,js,jsx}'],


### PR DESCRIPTION
Closes #831.

## Problem

Since `2.0.0-beta.8` (#824/#825), `TypeormAdapter` projects a joined relation's columns **twice** when the schema declares a root `fields.default` and the request carries an `include=`. MySQL rejects the duplicate output-column alias (`Duplicate column name`); postgres/sqlite tolerate it, so every junction `include=` endpoint (authup `user-role`, `role-permission`, …) 500s on MySQL after the beta.8 bump.

## Root cause

For an `include`d relation, the fields parser materializes the related schema's default fields (`user.id`, `user.name`, …) into the `Fields` IR. `FieldsAdapter.execute()` emits them via `queryBuilder.select(...)`, while `RelationsAdapter.execute()` **also** `leftJoinAndSelect`s the full entity — two projections of the same alias.

## Fix

Drop from the explicit `select()` any column that belongs to a relation the adapter will join-and-**select** as a whole subtree (`selectMode(path) === 'full'`). That relation is hydrated entirely by the join, so re-selecting its columns is redundant and produces the duplicate alias. A relation joined only for a filter/sort — or hydrated id-only via `hydrationMode: 'key'` (#832) — is a plain `leftJoin` and keeps its projected columns. This aligns the implementation with the already-documented contract (`docs/packages/typeorm.md`): *an `include`d relation is always hydrated as a complete subtree; a sparse `fields` entry never narrows it.*

Rebased on top of #832; the drop is keyed on `'full'` (not `shouldSelect`) precisely so it does not strip `'key'`-mode field columns.

Two subtleties handled:
- **Embedded columns behind an include** (`role.profile.firstName`) build the dotted string `<relAlias>.profile.firstName`; the join alias is the **first** dotted segment, so the alias is extracted with `indexOf('.')`, not `lastIndexOf`.
- The `'key'`/`'full'` distinction: a `'key'`-mode relation must keep a projected `relation.column` field (it is not auto-selected).

## Tests

- Unit regression guards (sqlite): no duplicate output alias for an included relation, incl. the embedded-column-behind-include case and the `hydrationMode: 'key'` reconciliation.
- **CI database matrix** (`tests-db`): the live-DB specs are now engine-selectable via `DB_TYPE` (default in-memory sqlite, so `npm test` needs no Docker). A new job runs **only** the `@rapiq/typeorm` workspace against `mysql:9` and `postgres:18` service containers. A new executing spec reproduces the junction `GROUP BY` + `include` pattern so `getMany()` throws `Duplicate column name` on the MySQL leg whenever this regresses — the class of bug a sqlite-only suite can't catch.

All 160 typeorm specs pass locally on sqlite; type-check, lint and bundle are clean.