### PR TITLE
refactor(sql): make FieldsBaseAdapter generic over its relations adapter

### DIFF
--- a/packages/sql/src/adapter/fields/base.ts
+++ b/packages/sql/src/adapter/fields/base.ts
@@ -10,8 +10,10 @@ import { parseField } from '../../helpers';
 import type { RelationsBaseAdapter } from '../relations';
 import type { IFieldsAdapter } from './types';
 
-export abstract class FieldsBaseAdapter implements IFieldsAdapter {
-    protected relations: RelationsBaseAdapter;
+export abstract class FieldsBaseAdapter<
+    RELATIONS extends RelationsBaseAdapter = RelationsBaseAdapter,
+> implements IFieldsAdapter {
+    protected relations: RELATIONS;
 
     /**
      * selection fields.
@@ -23,7 +25,7 @@ export abstract class FieldsBaseAdapter implements IFieldsAdapter {
     // -----------------------------------------------------------
 
     protected constructor(
-        relations: RelationsBaseAdapter,
+        relations: RELATIONS,
     ) {
         this.relations = relations;
         this.value = [];

--- a/packages/typeorm/src/adapter/fields.ts
+++ b/packages/typeorm/src/adapter/fields.ts
@@ -9,16 +9,13 @@ import { FieldsBaseAdapter } from '@rapiq/sql';
 import type { SelectQueryBuilder } from 'typeorm';
 import type { RelationsAdapter } from './relations';
 
-export class FieldsAdapter extends FieldsBaseAdapter {
+export class FieldsAdapter extends FieldsBaseAdapter<RelationsAdapter> {
     protected queryBuilder : SelectQueryBuilder<any>;
-
-    protected relationsAdapter : RelationsAdapter;
 
     constructor(queryBuilder: SelectQueryBuilder<any>, relations: RelationsAdapter) {
         super(relations);
 
         this.queryBuilder = queryBuilder;
-        this.relationsAdapter = relations;
     }
 
     rootAlias(): string | undefined {
@@ -39,7 +36,7 @@ export class FieldsAdapter extends FieldsBaseAdapter {
         // the output alias (MySQL rejects it, #831). A relation joined only for a
         // filter/sort, or hydrated id-only ('key' mode), is NOT auto-selected, so
         // a field that references it stays and is projected sparsely.
-        const selected = this.relationsAdapter.fullySelectedRelationAliases();
+        const selected = this.relations.fullySelectedRelationAliases();
 
         const columns = this.getColumns().filter((column) => {
             // The join alias is always the FIRST dotted segment: relation aliases


### PR DESCRIPTION
Follow-up polish for #834 (stacked on `fix/831-typeorm-double-projection`; retarget to `master` once #834 merges).

## Why

#834 gave `@rapiq/typeorm`'s `FieldsAdapter` a `RelationsAdapter`-specific need (`fullySelectedRelationAliases()`), but `FieldsBaseAdapter` types `relations` as the abstract `RelationsBaseAdapter`. To reach the concrete method without a cast, `FieldsAdapter` kept a second, narrowly-typed `relationsAdapter` field pointing at the same instance — a minor smell flagged in the #834 review.

## What

Parameterize the base over its relations type:

```ts
export abstract class FieldsBaseAdapter<
    RELATIONS extends RelationsBaseAdapter = RelationsBaseAdapter,
> implements IFieldsAdapter {
    protected relations: RELATIONS;
}
```

The **defaulted** type param keeps every existing `extends FieldsBaseAdapter` compiling unchanged (including `@rapiq/sql`'s own `FieldsAdapter`). `@rapiq/typeorm` opts in with `FieldsBaseAdapter<RelationsAdapter>`, so `this.relations` is already the concrete type — the duplicate `relationsAdapter` field and its assignment are gone.

Type-level only: generics erase, so there is **no runtime change**.

## Verification

- `@rapiq/sql` and `@rapiq/typeorm` both `tsc` clean (typeorm type-checked against the rebuilt `sql` types).
- Full `@rapiq/typeorm` suite green (160).
- eslint clean.