### PR TITLE
docs: give sub-package READMEs a consistent, richer layout

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -25,6 +25,7 @@
 - **Indentation**: 4 spaces.
 - **Linting**: `@tada5hi/eslint-config` (flat); locally disabled rules: `class-methods-use-this`, `no-continue`, `no-shadow`, `no-use-before-define`, `no-useless-constructor` (see root `eslint.config.mjs`).
 - Every source file starts with the copyright header block (copy it from a neighboring file).
+- **Prose & Markdown**: do not use em dashes (`—`) or en dashes (`–`) in written text (`README.md`, docs pages, code comments, commit/PR bodies). Reach for a colon when a clause explains or introduces, a semicolon or a full stop between independent clauses, or commas/parentheses for an aside. This keeps the READMEs especially consistent.
 
 ## Naming Conventions
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 <h1 align="center">rapiq</h1>
 
 <p align="center">
-  <b>Typed REST queries — build, transport, validate, execute.</b><br>
-  Rapiq (<b>R</b>est <b>Api</b> <b>Q</b>uery) builds an efficient interface between applications —<br>
+  <b>Typed REST queries: build, transport, validate, execute.</b><br>
+  Rapiq (<b>R</b>est <b>Api</b> <b>Q</b>uery) builds an efficient interface between applications:<br>
   browser&nbsp;↔&nbsp;API just as well as service&nbsp;↔&nbsp;service. It defines a scheme for the request, but <b>not</b> for the response.
 </p>
 
@@ -41,34 +41,34 @@ Every REST list endpoint answers the same five questions: which **fields**, whic
 
 | Stage | What happens |
 |---|---|
-| **Build** <sub>calling application</sub> | `defineQuery<User>({ filters: { age: gte(18) }, sort: '-name' })` — typed input in, query AST out |
+| **Build** <sub>calling application</sub> | `defineQuery<User>({ filters: { age: gte(18) }, sort: '-name' })`: typed input in, query AST out |
 | **Transport** <sub>wire</sub> | encoded as a self-described URL query string: `?codec=url-expression&filter=gte(age,'18')&sort=-name` |
-| **Validate** <sub>receiving application</sub> | decoded back into the same AST, checked against a `Schema` — allow-lists, defaults, mappings |
+| **Validate** <sub>receiving application</sub> | decoded back into the same AST, checked against a `Schema`: allow-lists, defaults, mappings |
 | **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/sql`) or to a TypeORM `SelectQueryBuilder` (`@rapiq/typeorm`) |
 
-The two ends are just applications. A browser querying an API is the common case, but services compose the same way —
+The two ends are just applications. A browser querying an API is the common case, but services compose the same way:
 an API gateway, for instance, validates an incoming query against its own schema, scopes it
 (`query.filters.and(...)`) and re-encodes it for the upstream service.
 
-- 🧭 **Typed end to end** — every field path in `defineQuery<User>` is checked against the record type; condition helpers (`eq`, `gte`, `and`, `or`, …) replace magic value strings.
-- 🛡️ **The receiving side has the last word** — a `Schema` declares what a caller may request per parameter (allow-lists, defaults, mappings). Invalid input is dropped or rejected according to the parser dialect and schema policy, and injected conditions (`query.filters.and(...)`) can't be displaced by caller input.
-- 🔁 **Loss-free transport** — within each codec dialect, `decode(encode(query))` restores the same query; outside its subset, encoding fails loudly with a typed error instead of silently changing semantics.
-- 🔌 **Any backend** — the AST is consumed through visitors: parameterized SQL fragments with presets for Postgres, MySQL, SQLite, MSSQL & Oracle, or applied straight to a TypeORM `SelectQueryBuilder`.
-- 📦 **Composable packages** — no monolith: install only what each side needs; `@rapiq/core` is the single shared foundation.
+- 🧭 **Typed end to end**: every field path in `defineQuery<User>` is checked against the record type; condition helpers (`eq`, `gte`, `and`, `or`, …) replace magic value strings.
+- 🛡️ **The receiving side has the last word**: a `Schema` declares what a caller may request per parameter (allow-lists, defaults, mappings). Invalid input is dropped or rejected according to the parser dialect and schema policy, and injected conditions (`query.filters.and(...)`) can't be displaced by caller input.
+- 🔁 **Loss-free transport**: within each codec dialect, `decode(encode(query))` restores the same query; outside its subset, encoding fails loudly with a typed error instead of silently changing semantics.
+- 🔌 **Any backend**: the AST is consumed through visitors: parameterized SQL fragments with presets for Postgres, MySQL, SQLite, MSSQL & Oracle, or applied straight to a TypeORM `SelectQueryBuilder`.
+- 📦 **Composable packages**: no monolith, install only what each side needs; `@rapiq/core` is the single shared foundation.
 
 ## Installation
 
-Version 2 splits the former single `rapiq` package into focused, composable `@rapiq/*` packages —
+Version 2 splits the former single `rapiq` package into focused, composable `@rapiq/*` packages:
 there is **no** `rapiq` umbrella package for v2, install only what you need
 (see [Packages](#packages) below; `@rapiq/core` is a peer dependency of every other package).
 
-Querying application — build queries and encode them as URL query strings:
+Querying application, build queries and encode them as URL query strings:
 
 ```bash
 npm install @rapiq/core @rapiq/codec-url
 ```
 
-Queried application — decode & validate incoming query input and apply it to the database:
+Queried application, decode & validate incoming query input and apply it to the database:
 
 ```bash
 npm install @rapiq/core @rapiq/codec-url @rapiq/sql @rapiq/typeorm
@@ -82,7 +82,7 @@ read the [docs](https://rapiq.tada5hi.net).
 ### Build 🔧
 
 The first step is to build a [Query](https://rapiq.tada5hi.net/guide/query-ast) for a generic Record `<T>` with
-[defineQuery](https://rapiq.tada5hi.net/guide/building-queries) — typed input in, AST out, no magic value strings.
+[defineQuery](https://rapiq.tada5hi.net/guide/building-queries): typed input in, AST out, no magic value strings.
 Filters accept scalars, arrays (`null` is a legal element), `$`-operator objects and
 [condition helpers](https://rapiq.tada5hi.net/guide/building-queries#condition-helpers) (`eq`, `gte`, `and`, `or`, …);
 queries compose with [mergeQueries](https://rapiq.tada5hi.net/guide/merging-queries).

--- a/packages/codec-url/README.md
+++ b/packages/codec-url/README.md
@@ -1,8 +1,40 @@
-# @rapiq/codec-url
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/codec-url</h1>
 
-Moves a `Query` over a URL boundary. New payloads use expression filters and carry an in-band codec identifier; the decoder also accepts legacy JSON:API-style bracket filters so applications can migrate without a flag day.
+<p align="center">
+  <b>Move a rapiq <code>Query</code> across a URL boundary, and back, losslessly.</b><br>
+  Writes self-described expression filters; reads expression <i>and</i> legacy<br>
+  JSON:API bracket filters, so applications migrate without a flag day.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/codec-url"><img src="https://img.shields.io/npm/v/@rapiq/codec-url/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/codec-url"><img src="https://img.shields.io/npm/types/@rapiq/codec-url?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/codec-url?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/codec-url"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/codec-url">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+This is the **transport** layer: one façade encodes a `Query` into a query string on the calling side and decodes it back into the same AST on the receiving side.
+
+- 🔁 **Lossless within a dialect**: `decode(encode(query))` restores the same query (modulo scalar type normalization); outside a dialect's subset, `encode` throws a typed error instead of silently changing semantics.
+- 🏷️ **In-band codec identity**: encoded payloads carry a reserved `codec` stamp, so decoding dispatches deterministically; unstamped input is probed via registered `detect` hooks.
+- 🧭 **Read-both, write-expression**: new payloads use expression filters; the decoder still accepts legacy `filter[name]=…` bracket filters for a gradual v2 migration.
+- 🔌 **Express-ready**: feed it a raw query string or a pre-parsed `req.query`; it maps the JSON:API wire names (`filter`, `page`, `include`, …) and validates against your schema.
 
 ## Installation
 
@@ -37,10 +69,23 @@ Decoding dispatches on a stamped codec identifier first. For unstamped input, a 
 
 Use `encodeAsync()` and `decodeAsync()` when schema filter validators are asynchronous. Advanced callers can register a custom `URLCodecDefinition` on a `URLCodec` instance.
 
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| **[@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url)** | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
+
 ## Documentation
 
 Full guide: [rapiq.tada5hi.net/packages/codec-url](https://rapiq.tada5hi.net/packages/codec-url)
 
 ## License
 
-Published under the [MIT License](https://github.com/Tada5hi/rapiq/blob/master/LICENSE).
+Published under the [MIT License](https://github.com/tada5hi/rapiq/blob/master/LICENSE).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,39 @@
-# @rapiq/core
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-The foundation of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/core</h1>
 
-This package owns the query AST (`Query` with fields, filters, pagination, relations & sorts), the typed build layer, the schema system and the visitor interfaces every other `@rapiq/*` package builds on.
+<p align="center">
+  <b>The foundation of rapiq: the query AST, the typed build layer & the schema system.</b><br>
+  Every other <code>@rapiq/*</code> package builds on the interfaces defined here.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/core"><img src="https://img.shields.io/npm/v/@rapiq/core/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/core"><img src="https://img.shields.io/npm/types/@rapiq/core?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/core?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/core"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/core">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+`@rapiq/core` owns the **intermediate representation** the whole pipeline revolves around: a typed `Query` AST (fields, filters, pagination, relations, sorts), the `defineQuery` build layer, the `Schema` allow-list system, and the visitor interfaces parsers, codecs and backend adapters implement.
+
+- 🧭 **Typed end to end**: every field path in `defineQuery<User>` is checked against the record type; condition helpers (`eq`, `gte`, `and`, `or`, …) replace magic value strings.
+- 🌳 **One AST, many consumers**: the same `Query` node graph is walked into SQL, a TypeORM builder or in-memory predicates through the visitor pattern; core never changes when a backend is added.
+- 🛡️ **Schema = the receiving side's allow-list**: declare per-parameter `allowed` / `default` / `mapping`; parsers and codecs validate against it and drop or throw per policy.
+- 🧩 **Composable & immutable**: `mergeQueries` (left priority) and the `Filters` combinators (`merge`, `and`, `or`) let a gateway scope a query without a client being able to displace injected conditions.
 
 ## Installation
 
@@ -14,7 +45,7 @@ npm install @rapiq/core
 
 ### Build a query
 
-`defineQuery` builds the AST directly from typed input — every field path is checked against the record generic:
+`defineQuery` builds the AST directly from typed input; every field path is checked against the record generic:
 
 ```typescript
 import { defineQuery, gte, or, eq } from '@rapiq/core';
@@ -32,7 +63,7 @@ Filters accept scalars (`{ name: 'John' }`), bare arrays (`in`, `null` is a lega
 
 ### Declare what a caller may request
 
-A `Schema` is the receiving side's allow-list — parsers and decoders validate incoming input against it:
+A `Schema` is the receiving side's allow-list: parsers and decoders validate incoming input against it:
 
 ```typescript
 import { SchemaRegistry, defineSchema } from '@rapiq/core';
@@ -52,11 +83,24 @@ registry.add(defineSchema<User>({
 
 ### Consume the AST
 
-Every node implements `accept(visitor)` — backends implement the visitor interfaces (`IQueryVisitor`, `IFiltersVisitor`, …) to walk a query into whatever they target. Ready-made adapters exist for [SQL](https://www.npmjs.com/package/@rapiq/sql) and [TypeORM](https://www.npmjs.com/package/@rapiq/typeorm); parsers and URL codecs live in their own packages as well.
+Every node implements `accept(visitor)`. Backends implement the visitor interfaces (`IQueryVisitor`, `IFiltersVisitor`, …) to walk a query into whatever they target. Ready-made adapters exist for [SQL](https://www.npmjs.com/package/@rapiq/sql), [TypeORM](https://www.npmjs.com/package/@rapiq/typeorm) and [in-memory data](https://www.npmjs.com/package/@rapiq/memory); parsers and URL codecs live in their own packages as well.
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| **[@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core)** | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation
 
-Full guide: [rapiq.tada5hi.net](https://rapiq.tada5hi.net) — see [Building Queries](https://rapiq.tada5hi.net/guide/building-queries), [Schemas](https://rapiq.tada5hi.net/guide/schemas) and [Merging Queries](https://rapiq.tada5hi.net/guide/merging-queries).
+Full guide: [rapiq.tada5hi.net](https://rapiq.tada5hi.net). See [Building Queries](https://rapiq.tada5hi.net/guide/building-queries), [Schemas](https://rapiq.tada5hi.net/guide/schemas) and [Merging Queries](https://rapiq.tada5hi.net/guide/merging-queries).
 
 ## License
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/core",
     "version": "2.0.0-beta.9",
-    "description": "A tiny library which provides utility types/functions for request and response query handling.",
+    "description": "The rapiq foundation: typed query AST, defineQuery build layer, schema allow-list system & visitor interfaces.",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -1,6 +1,17 @@
-# @rapiq/docs
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-The [VitePress](https://vitepress.dev) documentation site for [rapiq](https://github.com/tada5hi/rapiq), published at [rapiq.tada5hi.net](https://rapiq.tada5hi.net). Private — not published to npm.
+<h1 align="center">@rapiq/docs</h1>
+
+<p align="center">
+  <b>The <a href="https://vitepress.dev">VitePress</a> documentation site for <a href="https://github.com/tada5hi/rapiq">rapiq</a>.</b><br>
+  Published at <a href="https://rapiq.tada5hi.net">rapiq.tada5hi.net</a> · private, not published to npm.
+</p>
+
+---
 
 ## Development
 
@@ -10,4 +21,4 @@ npm run dev --workspace=packages/docs     # local dev server
 npm run build --workspace=packages/docs   # production build (runs in CI)
 ```
 
-Content lives in `getting-started/`, `guide/` and `integrations/`; navigation and sidebar are configured in `.vitepress/config.mjs`.
+Content lives in `getting-started/`, `guide/`, `packages/` and `integrations/`; navigation and sidebar are configured in `.vitepress/config.mjs`.

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -1,12 +1,40 @@
-# @rapiq/memory
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/memory</h1>
 
-This package evaluates a parsed `Query` against **in-memory data** — plain JavaScript
-objects and arrays. It is the in-memory sibling of `@rapiq/sql` and `@rapiq/typeorm`:
-the same visitor-pattern adapter surface, but instead of SQL fragments or a query
-builder, the visitors compile the query AST into plain functions (predicate,
-comparator, projector, slicer).
+<p align="center">
+  <b>Evaluate a rapiq <code>Query</code> against plain JavaScript objects & arrays.</b><br>
+  The in-memory sibling of <code>@rapiq/sql</code> and <code>@rapiq/typeorm</code>: same AST,<br>
+  compiled into plain functions instead of SQL.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/memory"><img src="https://img.shields.io/npm/v/@rapiq/memory/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/memory"><img src="https://img.shields.io/npm/types/@rapiq/memory?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/memory?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/memory"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/memory">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+Same visitor-pattern surface as the SQL/TypeORM adapters, but the visitors compile the AST into plain functions (predicate, comparator, projector, slicer), so the same query filters a database **and** an array.
+
+- ⚡ **Compile once, run many**: the AST is turned into closures up front; apply them across large collections without re-walking the tree.
+- 🧪 **No database required**: perfect for tests, mock servers, edge/serverless caches, or filtering data you already hold in memory.
+- 🤝 **Backend-parity semantics**: matches `@rapiq/sql` for positive operators and the complement law for negations (`ne` / `nin` / `not*` match null & missing), same-element binding for dotted paths over arrays.
+- 🧱 **Whole-query or à la carte**: `applyQuery` runs everything, or compile just the filters / sort / fields / pagination on their own.
 
 ```typescript
 import { and, eq, gte } from '@rapiq/core';
@@ -52,11 +80,24 @@ import {
     compileSorts,
 } from '@rapiq/memory';
 
-const predicate = compileFilters(query.filters);   // (input) => boolean
-const comparator = compileSorts(query.sorts);      // (a, b) => number
-const projector = compileFields(query.fields);     // (input) => projected
+const predicate = compileFilters(query.filters);    // (input) => boolean
+const comparator = compileSorts(query.sorts);       // (a, b) => number
+const projector = compileFields(query.fields);      // (input) => projected
 const slicer = compilePagination(query.pagination); // (data) => data page
 ```
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| **[@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory)** | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation
 

--- a/packages/memory/package.json
+++ b/packages/memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/memory",
     "version": "2.0.0-beta.9",
-    "description": "A package to evaluate queries against in-memory objects and arrays.",
+    "description": "Evaluate a rapiq query against in-memory objects & arrays by compiling the AST into plain functions.",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",

--- a/packages/parser-expression/README.md
+++ b/packages/parser-expression/README.md
@@ -1,14 +1,46 @@
-# @rapiq/parser-expression
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/parser-expression</h1>
 
-Parses a function-call expression language for filters — useful when a single string must carry a complex condition tree (search boxes, saved filters, CLI flags):
+<p align="center">
+  <b>Parse a function-call filter language into a rapiq <code>Query</code>.</b><br>
+  For when a single string must carry a whole condition tree:<br>
+  search boxes, saved filters, CLI flags.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/parser-expression"><img src="https://img.shields.io/npm/v/@rapiq/parser-expression/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/parser-expression"><img src="https://img.shields.io/npm/types/@rapiq/parser-expression?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/parser-expression?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/parser-expression"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/parser-expression">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+A tokenizer + recursive-descent parser for a compact, human-readable filter language: the default filter format the [URL codec](https://www.npmjs.com/package/@rapiq/codec-url) writes.
 
 ```txt
 and(eq(name, 'John'), gte(age, '18'))
 or(in(status, 'active', 'pending'), gt(age, '65'))
 not(contains(user.name, 'Bob'))
 ```
+
+- 🧵 **One string, whole tree**: arbitrary `and` / `or` / `not` nesting fits in a single value; ideal for URLs, saved filters and CLI flags.
+- 🎯 **Explicit operators**: `eq`, `ne`, `lt(e)`, `gt(e)`, `in`, `nin`, `contains`, `startsWith`, `endsWith`, and their negations, with no operator guessing.
+- 🛡️ **Fails loud**: syntax errors and schema violations throw `FiltersParseError` immediately; there is no silent-drop mode for malformed expressions.
+- 🔗 **Same AST as every dialect**: only `filters` is expression-flavoured; fields, relations, pagination and sort reuse `@rapiq/parser-simple`.
 
 ## Installation
 
@@ -30,11 +62,24 @@ const query = parser.parse({
 }, { schema: 'user' });
 ```
 
-Only the `filters` parameter uses the expression language — fields, relations, pagination and sort accept the same input as [@rapiq/parser-simple](https://www.npmjs.com/package/@rapiq/parser-simple), and the whole thing returns the same [`Query`](https://rapiq.tada5hi.net/guide/query-ast) AST. A standalone `parseFilters(input, options)` returns just the `Filters` node.
+Only the `filters` parameter uses the expression language; fields, relations, pagination and sort accept the same input as [@rapiq/parser-simple](https://www.npmjs.com/package/@rapiq/parser-simple), and the whole thing returns the same [`Query`](https://rapiq.tada5hi.net/guide/query-ast) AST. A standalone `parseFilters(input, options)` returns just the `Filters` node.
 
-The grammar: `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `in`, `nin`, `contains`, `startsWith`, `endsWith` (and negations) as leaf conditions, composed with `and(…)` / `or(…)` / `not(…)`. Values are always single-quoted (`gte(age, '18')`); quoted numerals coerce to numbers, `'true'`/`'false'` to booleans, `'null'` to `null`.
+**The grammar**: `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `in`, `nin`, `contains`, `startsWith`, `endsWith` (and negations) as leaf conditions, composed with `and(…)` / `or(…)` / `not(…)`. Values are always single-quoted (`gte(age, '18')`); quoted numerals coerce to numbers, `'true'` / `'false'` to booleans, `'null'` to `null`.
 
-Syntax errors and schema violations throw `FiltersParseError` immediately — the expression parser has no silent-drop mode for malformed expressions.
+Syntax errors and schema violations throw `FiltersParseError` immediately; the expression parser has no silent-drop mode for malformed expressions.
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| **[@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression)** | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation
 

--- a/packages/parser-expression/package.json
+++ b/packages/parser-expression/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/parser-expression",
     "version": "2.0.0-beta.9",
-    "description": "A package containing an expression parser",
+    "description": "Parse a function-call filter language (e.g. and(eq(name,'John'), gte(age,'18'))) into a rapiq query AST.",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",

--- a/packages/parser-mongo/README.md
+++ b/packages/parser-mongo/README.md
@@ -1,8 +1,35 @@
-# @rapiq/parser-mongo
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/parser-mongo</h1>
 
-Parses MongoDB-style filter objects — `$and`/`$or`/`$nor` compounds, field operators like `$eq`, `$gte`, `$in`, `$not`, `$regex` and `$elemMatch` — into the rapiq `Query` AST. Useful when clients submit filters as JSON documents (request bodies, saved queries):
+<p align="center">
+  <b>Parse MongoDB-style filter documents into a rapiq <code>Query</code>.</b><br>
+  <code>$and</code> / <code>$or</code> / <code>$nor</code>, <code>$gte</code> / <code>$in</code> / <code>$not</code> / <code>$regex</code>, <code>$elemMatch</code><br>
+  for clients that submit filters as JSON.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/parser-mongo"><img src="https://img.shields.io/npm/v/@rapiq/parser-mongo/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/parser-mongo"><img src="https://img.shields.io/npm/types/@rapiq/parser-mongo?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/parser-mongo?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/parser-mongo"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/parser-mongo">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+Bring a familiar MongoDB-style query document to any rapiq backend. Useful when clients submit filters as typed JSON in request bodies or saved queries.
 
 ```typescript
 {
@@ -12,6 +39,11 @@ Parses MongoDB-style filter objects — `$and`/`$or`/`$nor` compounds, field ope
     ],
 }
 ```
+
+- 🍃 **Familiar syntax**: `$and` / `$or` / `$nor` compounds, De Morgan `$not` / `$nor` negation, field operators (`$eq`, `$gte`, `$in`, `$regex`, `$elemMatch`, …) and six `$contains`-family rapiq extensions.
+- 🔢 **Typed values**: JSON keeps its types (`{ $gte: 18 }` stays a number), no wire-string coercion.
+- 🛡️ **Two-class failure model**: grammar errors always throw `FiltersParseError`; field-key/allow-list failures follow the schema drop-vs-throw policy.
+- 🔗 **Same AST as every dialect**: only `filters` is mongo-flavoured; fields, relations, pagination and sort reuse `@rapiq/parser-simple`.
 
 ## Installation
 
@@ -33,9 +65,22 @@ const query = parser.parse({
 }, { schema: 'user' });
 ```
 
-Only the `filters` parameter uses the mongo dialect — fields, relations, pagination and sort accept the same input as [@rapiq/parser-simple](https://www.npmjs.com/package/@rapiq/parser-simple), and the whole thing returns the same [`Query`](https://rapiq.tada5hi.net/guide/query-ast) AST.
+Only the `filters` parameter uses the mongo dialect; fields, relations, pagination and sort accept the same input as [@rapiq/parser-simple](https://www.npmjs.com/package/@rapiq/parser-simple), and the whole thing returns the same [`Query`](https://rapiq.tada5hi.net/guide/query-ast) AST.
 
 Grammar errors (unknown `$`-operators, misplaced operators, malformed operator arguments) always throw `FiltersParseError`; field keys that fail the schema allow-list are dropped by default and throw when `throwOnFailure` is set.
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| **[@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo)** | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation
 

--- a/packages/parser-mongo/package.json
+++ b/packages/parser-mongo/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/parser-mongo",
     "version": "2.0.0-beta.9",
-    "description": "A package containing a mongodb style parser",
+    "description": "Parse MongoDB-style filter documents (e.g. { age: { $gte: 18 } }) into a rapiq query AST.",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",

--- a/packages/parser-simple/README.md
+++ b/packages/parser-simple/README.md
@@ -1,8 +1,39 @@
-# @rapiq/parser-simple
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/parser-simple</h1>
 
-Parses plain object/array input — the URL-query-like "simple" dialect — into a [`Query`](https://rapiq.tada5hi.net/guide/query-ast) AST, validated against a schema. It is the workhorse parser the [URL codec](https://www.npmjs.com/package/@rapiq/codec-url) builds on.
+<p align="center">
+  <b>Parse plain object/array input (the URL-query-like "simple" dialect) into a rapiq <code>Query</code>.</b><br>
+  The workhorse parser the <a href="https://www.npmjs.com/package/@rapiq/codec-url">URL codec</a> builds on.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/parser-simple"><img src="https://img.shields.io/npm/v/@rapiq/parser-simple/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/parser-simple"><img src="https://img.shields.io/npm/types/@rapiq/parser-simple?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/parser-simple?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/parser-simple"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/parser-simple">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+This is the **validate** end for URL-query-shaped input: plain objects and arrays go in, a schema-checked `Query` AST comes out.
+
+- 📥 **URL-query shaped**: the exact structure you get from a query string, e.g. `{ fields: [...], filters: {...}, sort: '-age', … }`.
+- 🛡️ **Schema-validated**: anything outside the allow-list is dropped by default, or throws with `throwOnFailure`; absent parameters still receive schema defaults.
+- 🔣 **Compact operators**: filter values carry inline operators like `'>=18'`, `'~jo~'`, `'!5'`, `null`.
+- 🧱 **Per-parameter parsers**: `SimpleFieldsParser`, `SimpleFiltersParser`, … are exported for parsing a single parameter.
 
 ## Installation
 
@@ -39,13 +70,26 @@ const query = parser.parse({
 
 Anything outside the schema's allow-lists is silently dropped; set `throwOnFailure: true` on the schema to get a `ParseError` instead. Parameters absent from the input still receive schema defaults.
 
-The parser is transport-agnostic: it reads the canonical parameter keys (`fields`, `filters`, `pagination`, `relations`, `sort`) only. To consume a raw URL query string or an express-style `req.query` object (JSON:API wire names like `filter`, `page`, `include`), use the [URL codec](https://www.npmjs.com/package/@rapiq/codec-url) — its decoder maps the wire names and delegates to this parser.
+The parser is transport-agnostic: it reads the canonical parameter keys (`fields`, `filters`, `pagination`, `relations`, `sort`) only. To consume a raw URL query string or an express-style `req.query` object (JSON:API wire names like `filter`, `page`, `include`), use the [URL codec](https://www.npmjs.com/package/@rapiq/codec-url): its decoder maps the wire names and delegates to this parser.
 
 Per-parameter parser classes (`SimpleFieldsParser`, `SimpleFiltersParser`, `SimplePaginationParser`, `SimpleRelationsParser`, `SimpleSortParser`) are exported for parsing a single parameter.
 
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| **[@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple)** | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
+
 ## Documentation
 
-Full guide: [rapiq.tada5hi.net/packages/parser-simple](https://rapiq.tada5hi.net/packages/parser-simple) — per-parameter input shapes and operator syntax are on the [parameter pages](https://rapiq.tada5hi.net/guide/filters).
+Full guide: [rapiq.tada5hi.net/packages/parser-simple](https://rapiq.tada5hi.net/packages/parser-simple). Per-parameter input shapes and operator syntax are on the [parameter pages](https://rapiq.tada5hi.net/guide/filters).
 
 ## License
 

--- a/packages/parser-simple/package.json
+++ b/packages/parser-simple/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/parser-simple",
     "version": "2.0.0-beta.9",
-    "description": "A package containing a simple parser",
+    "description": "Parse plain object/array input (the URL-query-like \"simple\" dialect) into a rapiq query AST.",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -1,8 +1,40 @@
-# @rapiq/sql
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/sql</h1>
 
-Turns query AST nodes into **parameterized SQL fragments**. Database-agnostic: per-database behavior is injected as a small dialect option object (presets for `pg`, `mysql`, `sqlite`, `mssql`, `oracle`), and values are always bound as parameters — never interpolated. It is also the foundation the [TypeORM adapter](https://www.npmjs.com/package/@rapiq/typeorm) builds on.
+<p align="center">
+  <b>Turn a rapiq <code>Query</code> into parameterized SQL fragments, for any dialect.</b><br>
+  Database-agnostic core, five ready-made presets (<code>pg</code>, <code>mysql</code>, <code>sqlite</code>, <code>mssql</code>, <code>oracle</code>),<br>
+  values always <b>bound</b>, never interpolated.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/sql"><img src="https://img.shields.io/npm/v/@rapiq/sql/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/sql"><img src="https://img.shields.io/npm/types/@rapiq/sql?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/sql?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/sql"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/sql">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+This is the dialect-agnostic **execute** layer: it renders a validated `Query` into clause fragments you compose into a `SELECT`. It is also the foundation the [TypeORM adapter](https://www.npmjs.com/package/@rapiq/typeorm) builds on.
+
+- 🔒 **Parameterized always**: filter values are bound, never string-interpolated. No SQL injection surface.
+- 🐘 **Five dialects, one adapter**: `pg`, `mysql`, `sqlite`, `mssql`, `oracle` presets; per-database behaviour is a tiny `DialectOptions` object you can also supply yourself.
+- 🧮 **Sensible SQL**: `null` → `IS NULL` / `IS NOT NULL`, empty `IN` → `1 = 0` (never invalid SQL), case-insensitive string matching folded consistently across dialects.
+- 🔧 **Fragment-level control**: render a whole query, or just the filters, or just the sort; each parameter has a standalone adapter/visitor pair.
 
 ## Installation
 
@@ -31,9 +63,9 @@ const fragments = adapter.execute(query);
 // }
 ```
 
-Construct the `Adapter` **per request** — it accumulates per-call state, so the shareable, long-lived part is the options object, not the adapter instance.
+Construct the `Adapter` **per request**: it accumulates per-call state, so the shareable, long-lived part is the options object, not the adapter instance.
 
-Per-parameter adapter/visitor pairs work standalone — e.g. rendering just the filters:
+Per-parameter adapter/visitor pairs work standalone, e.g. rendering just the filters:
 
 ```typescript
 import { FiltersAdapter, FiltersVisitor, RelationsAdapter, pg } from '@rapiq/sql';
@@ -46,9 +78,22 @@ const [sql, params] = filters.getQueryAndParameters();
 // params: ['jo', 18]
 ```
 
-The package deliberately stops at fragments: composing the final `SELECT` — in particular `FROM`/`JOIN` conditions — is the caller's job, or a backend adapter's (that's exactly what [@rapiq/typeorm](https://www.npmjs.com/package/@rapiq/typeorm) does).
+The package deliberately stops at fragments: composing the final `SELECT`, in particular `FROM` / `JOIN` conditions, is the caller's job, or a backend adapter's (that's exactly what [@rapiq/typeorm](https://www.npmjs.com/package/@rapiq/typeorm) does).
 
-Notable semantics: `null` filter values render as `IS NULL` / `IS NOT NULL` predicates, empty `IN` lists render as `1 = 0` (never invalid SQL), string-matching operators match literally on every dialect, and `resolveDialect(name)` maps driver/connection type names (`postgres`, `mariadb`, `better-sqlite3`, …) to the matching preset. On dialects without a regexp operator (SQL Server, stock SQLite), `contains`/`startsWith`/`endsWith` fall back to escaped `LIKE`; only the `regex` operator throws a typed `AdapterError`.
+**Notable semantics**: `null` filter values render as `IS NULL` / `IS NOT NULL`; empty `IN` lists render as `1 = 0` (never invalid SQL); string-matching operators match literally on every dialect; and `resolveDialect(name)` maps driver/connection type names (`postgres`, `mariadb`, `better-sqlite3`, …) to the matching preset. On dialects without a regexp operator (SQL Server, stock SQLite), `contains` / `startsWith` / `endsWith` fall back to escaped `LIKE`; only the `regex` operator throws a typed `AdapterError`.
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| **[@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql)** | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation
 

--- a/packages/sql/package.json
+++ b/packages/sql/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/sql",
     "version": "2.0.0-beta.9",
-    "description": "A SQL extension for rapiq.",
+    "description": "Render a rapiq query into parameterized SQL fragments (pg, mysql, sqlite, mssql & oracle presets).",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",

--- a/packages/typeorm/README.md
+++ b/packages/typeorm/README.md
@@ -1,8 +1,58 @@
-# @rapiq/typeorm
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
 
-Part of [rapiq](https://github.com/tada5hi/rapiq) — typed REST queries: build, transport, validate, execute.
+<h1 align="center">@rapiq/typeorm</h1>
 
-Applies a parsed [`Query`](https://rapiq.tada5hi.net/guide/query-ast) directly to a TypeORM `SelectQueryBuilder` — filters become parameterized `WHERE` conditions, relations become joins, fields/sort/pagination map to `select`/`orderBy`/`take`+`skip`.
+<p align="center">
+  <b>Apply a rapiq <code>Query</code> straight to a TypeORM <code>SelectQueryBuilder</code>.</b><br>
+  Filters become parameterized <code>WHERE</code> conditions, relations become joins,<br>
+  <code>fields</code> / <code>sort</code> / <code>pagination</code> map to <code>select</code> / <code>orderBy</code> / <code>take</code>&nbsp;+&nbsp;<code>skip</code>.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/typeorm"><img src="https://img.shields.io/npm/v/@rapiq/typeorm/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/typeorm"><img src="https://img.shields.io/npm/types/@rapiq/typeorm?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/typeorm?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/typeorm"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/typeorm">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+This is the **execute** end for [TypeORM](https://typeorm.io): hand it a validated `Query` and a builder, get back a fully-shaped query.
+
+## Why
+
+You decoded and validated a request query; now it has to become a real database query **without** losing your own tenant/auth scoping and **without** hand-writing `andWhere` glue for every parameter. That is all this package does, in one `execute(query)` call.
+
+- 🧩 **Drop-in**: bind your `SelectQueryBuilder`, call `execute(query)`, run it. Nothing else to wire.
+- 🔒 **Injection-safe**: every filter value is bound as a parameter, never string-interpolated.
+- 🤝 **Keeps your predicates**: filters are applied with `andWhere`, so tenant/auth `WHERE`s already on the builder survive untouched.
+- 🔗 **Relations → joins**: `leftJoinAndSelect` (or `inner`), applied idempotently, validated against the entity metadata, with deterministic aliases shared with `@rapiq/sql`.
+- 🎛️ **Dialect-aware**: the SQL dialect is inferred from the builder's connection; case-folding is applied only to string columns (no `lower(int)` errors on Postgres).
+- ↩️ **Familiar defaults**: mirrors typeorm-extension's `applyQuery` contract (`leftJoinAndSelect`, returned pagination) for a painless migration.
+
+## What a query becomes
+
+A single `adapter.execute(query)` walks the parsed AST and applies it to your builder:
+
+| Query parameter | Applied to the `SelectQueryBuilder` |
+|---|---|
+| `filters: { age: gte(18) }` | `.andWhere('"user"."age" >= :p0', { p0: 18 })` |
+| `relations: ['realm']` | `.leftJoinAndSelect('user.realm', 'realm')` |
+| `fields: ['id', 'name']` | `.select(['user.id', 'user.name'])` |
+| `sort: '-createdAt'` | `.orderBy('user.createdAt', 'DESC')` |
+| `pagination: { limit, offset }` | `.take(limit).skip(offset)` |
 
 ## Installation
 
@@ -11,6 +61,8 @@ npm install @rapiq/core @rapiq/sql @rapiq/typeorm
 ```
 
 ## Usage
+
+### Quick start
 
 ```typescript
 import { TypeormAdapter } from '@rapiq/typeorm';
@@ -27,15 +79,104 @@ const { pagination } = adapter.execute(query);
 const [entities, total] = await queryBuilder.getManyAndCount();
 ```
 
-The `queryBuilder` (the builder to write into) is bound at construction; `adapter.execute(query)` then walks the parsed `Query`, collects the state into its sub-adapters, and applies it to that builder — returning the applied pagination (e.g. for the response `meta` block). State is cleared before each call by default (pass `{ clear: false }` as the second argument to apply several queries onto the same builder).
+The `queryBuilder` is bound at construction; `adapter.execute(query)` walks the parsed `Query`, collects the state into its sub-adapters, applies it to that builder, and returns the pagination it applied (handy for the response `meta` block).
 
-Construct the adapter **per request**, like the `SelectQueryBuilder` you hand it — it holds per-call state. The shareable, long-lived part is your config (`relations`, …), spread into the per-request options with the request's builder as `queryBuilder`.
+Construct the adapter **per request**, like the `SelectQueryBuilder` you hand it: it holds per-call state. The shareable, long-lived part is your config (`relations`, …), spread into the per-request options with the request's builder as `queryBuilder`.
 
-The SQL dialect is resolved from the attached builder's connection type; joins are applied idempotently and validated against the entity metadata. Options: `relations.joinAndSelect` (hydrate related entities), `relations.joinType` (`'left'` default / `'inner'`), and an `onJoin(path, alias, queryBuilder)` hook per applied join. Per-parameter visitors from [@rapiq/sql](https://www.npmjs.com/package/@rapiq/sql) work against the adapter's sub-adapters (`adapter.filters`, `adapter.sort`, …) when only part of a query applies.
+### In a request handler
 
-Typically the query comes from a [URL decoder](https://www.npmjs.com/package/@rapiq/codec-url) validating `req.query` against a schema — see the [end-to-end example](https://rapiq.tada5hi.net/guide/recipes/express-typeorm) in the docs.
+The query usually arrives from a [URL decoder](https://www.npmjs.com/package/@rapiq/codec-url) that validated `req.query` against a schema. Filters are applied with `andWhere`, so any application-owned scoping already on the builder (tenant, auth, soft-delete) survives untouched:
 
-Migrating from typeorm-extension's `applyQuery`? The defaults mirror its contract (`leftJoinAndSelect`, returned pagination) — see the [migration guide](https://rapiq.tada5hi.net/guide/migration-typeorm-extension).
+```typescript
+import { createURLCodec } from '@rapiq/codec-url';
+import { TypeormAdapter } from '@rapiq/typeorm';
+
+const codec = createURLCodec(registry); // registry: your SchemaRegistry
+
+app.get('/users', async (req, res) => {
+    const query = codec.decode(req.query, { schema: 'user' });
+    if (!query) {
+        return res.status(400).end();
+    }
+
+    const queryBuilder = dataSource
+        .getRepository(User)
+        .createQueryBuilder('user')
+        // application-owned scoping: preserved, never overwritten
+        .where('user.realm_id = :realmId', { realmId: req.realmId });
+
+    const { pagination } = new TypeormAdapter({
+        queryBuilder,
+        relations: { joinAndSelect: true },
+    }).execute(query);
+
+    const [data, total] = await queryBuilder.getManyAndCount();
+
+    res.json({ data, meta: { total, ...pagination } });
+});
+```
+
+### Relation join strategies
+
+A relation referenced only by a filter or sort is joined **without** being selected; an `include`d relation is hydrated according to your options:
+
+```typescript
+// hydrate included relations: leftJoinAndSelect (records with no relation are kept)
+new TypeormAdapter({
+    queryBuilder,
+    relations: { joinAndSelect: true },
+}).execute(query);
+
+// inner join + id-only hydration that survives GROUP BY user.id on strict dialects
+new TypeormAdapter({
+    queryBuilder,
+    relations: {
+        joinAndSelect: true,
+        joinType: 'inner',
+        hydrationMode: 'key',
+        onJoin: (path, alias, qb) => qb.addGroupBy(`${alias}.id`),
+    },
+}).execute(query);
+```
+
+| `relations` option | Effect |
+|---|---|
+| `joinAndSelect` | Hydrate related entities (`leftJoinAndSelect`) instead of joining for filtering only. |
+| `joinType` | `'left'` (default, keeps records with an absent relation) or `'inner'`. |
+| `hydrationMode` | `'full'` (default) selects the whole related subtree; `'key'` selects only the related primary key, so a hydrated relation survives `GROUP BY <root>.id`. |
+| `onJoin(path, alias, queryBuilder)` | Invoked per applied join (pre-existing/skipped joins don't trigger it): extend the query, e.g. add a group-by or an extra condition. |
+
+The SQL dialect is resolved from the attached builder's connection type; joins are applied idempotently and validated against the entity metadata.
+
+### Applying part of a query
+
+`adapter.execute()` runs everything, but the per-parameter sub-adapters (`adapter.filters`, `adapter.sort`, `adapter.fields`, …) are public: pair one with its matching [@rapiq/sql](https://www.npmjs.com/package/@rapiq/sql) visitor to apply a single parameter:
+
+```typescript
+import { FiltersVisitor } from '@rapiq/sql';
+
+const adapter = new TypeormAdapter({ queryBuilder });
+
+query.filters.accept(new FiltersVisitor(adapter.filters)); // collect
+adapter.filters.execute();                                 // flush to the builder
+```
+
+`execute()` also takes per-call options: `{ clear: false }` accumulates several queries onto the same builder, and `{ visitor: { caseSensitive: ['token'] } }` opts specific fields out of the case-insensitive equality default.
+
+Migrating from typeorm-extension's `applyQuery`? The defaults mirror its contract (`leftJoinAndSelect`, returned pagination). See the [migration guide](https://rapiq.tada5hi.net/guide/migration-typeorm-extension). For the complete walkthrough, follow the [end-to-end Express + TypeORM recipe](https://rapiq.tada5hi.net/guide/recipes/express-typeorm).
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| **[@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm)** | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation
 

--- a/packages/typeorm/package.json
+++ b/packages/typeorm/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@rapiq/typeorm",
     "version": "2.0.0-beta.9",
-    "description": "A typeorm adapter for rapiq.",
+    "description": "Apply a rapiq query directly to a TypeORM SelectQueryBuilder (filters, relations, fields, sort & pagination).",
     "type": "module",
     "main": "dist/index.mjs",
     "types": "dist/index.d.mts",


### PR DESCRIPTION
## Summary

Brings every `packages/*/README.md` up to the standard already set by the root `README.md`. The sub-package READMEs were previously plain (`# @rapiq/x`, one-liner, install, usage), which undersold what each package does; the `@rapiq/typeorm` one in particular read as a bare stub.

Each README now has a consistent, richer layout:

- **Header**: centered logo (absolute raw-GitHub URL so it renders on GitHub and npm), title, bold tagline
- **Badges**: npm version (`/beta` dist-tag, since these publish under `beta`, not `latest`), a TypeScript "types" badge, and MIT license; colors match the logo gradient
- **Nav row**: Documentation, Monorepo, npm
- **Highlights**: emoji bullets explaining what the package does and why you'd reach for it
- **"The rapiq family" table**: the full package list in every README (current one bolded) for cross-package discovery

### @rapiq/typeorm (expanded)

The flagship package now has a substantial Usage section: a **Quick start**, a realistic **request-handler** example (showing that application-owned `WHERE` scoping survives because filters use `andWhere`), **relation join strategies** (`joinAndSelect` / `joinType` / `hydrationMode` / `onJoin`, verified against `packages/typeorm/src`), and **applying part of a query** via the public sub-adapters. It also keeps the **"what a query becomes"** mapping table (`filters -> andWhere`, `relations -> leftJoinAndSelect`, `fields -> select`, `sort -> orderBy`, `pagination -> take/skip`). `@rapiq/sql` shows the fragment-output shape.

### npm descriptions

Refreshed the stale `description` fields (e.g. `@rapiq/core` no longer reads *"A tiny library which provides utility types/functions…"*). Package **versions are untouched** (each `package.json` change is the description line only).

### Prose convention

Recorded a style rule in `.agents/conventions.md`: no em or en dashes in written text (READMEs, docs, comments, commit/PR bodies), with the preferred substitutes. The READMEs follow it.

## Notes

- Docs-only change; no source or public API touched. All referenced doc pages (`packages/*`, guide pages, typeorm recipe/migration) were verified to exist, and every `package.json` still parses.
- **SVG-on-npm caveat:** shields badges (also SVG) render on npm and the logo uses an absolute raw URL, but npm's `<img>`-SVG support has historically been spotty. Guaranteed on GitHub; if the logo does not show on npm package pages, converting it to a PNG is the fallback.
