### PR TITLE
feat(prisma): add prisma adapter

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -167,6 +167,56 @@ type DialectOptions = {
 
 `@rapiq/typeorm`: `TypeormAdapter` mirrors the SQL adapter but mutates a TypeORM query builder. The builder is bound at construction (`new TypeormAdapter({ queryBuilder: qb })`); `adapter.execute(query)` then walks the query and applies the accumulated state to that builder in a single call. Filters use `andWhere`, preserving application-owned tenant/auth predicates already present on the builder. Relation aliases come from @rapiq/sql's shared, injective length-prefixed `buildRelationAlias` derivation; fields, filters, sorts and joins must all use that same function.
 
+`@rapiq/prisma`: pure IR **serializer**. `PrismaAdapter.execute(query)` is stateless (one
+instance per app, not per request; composition happens BEFORE serialization via
+`mergeQueries`/`filters.and()`, so there is no accumulation API) and returns a plain
+`findMany` args object (`{ where, select | include, orderBy, take, skip }`) plus the applied
+pagination; `@prisma/client` is not a dependency (model facts come through the local
+`IMetadata` interface, fed by `defineMetadata(Prisma.dmmf.datamodel, ...)`). The `where` is
+produced by a pipeline of pure passes: `planCondition` then core's `distributeNegation`
+then quantifier factoring then a leaf-literal table (`adapter/where.ts`). Settled during
+plan 024, do not re-litigate:
+
+- **Negation is eliminated before rendering.** Prisma's `not`/`NOT` are three-valued and
+  drop null rows, so the renderer consumes `distributeNegation` (in CORE, next to the
+  semantics table, because complement selection is operator semantics, not rendering) and
+  only ever sees leaves in final form. The settled contract behind the transform: group
+  negation is the two-valued complement PER BINDING with the quantifier outermost (sql
+  wraps CASE per join row, memory negates per binding context), so De Morgan applies and
+  negation commutes through `elemMatch`: `not(elemMatch(c))` selects records with an
+  element FAILING c, not records without a matching element. The null arm of a complement
+  is dropped only when metadata proves the column non-nullable; a null check on a
+  *relation* renders as a presence test (`{ rel: { is: {} } }` and its `NOT`, both
+  two-valued), and `exists()` on a to-many is constantly true (a collection is never
+  absent).
+- **Same-element binding holds.** Conditions sharing a to-many path inside a conjunction
+  are factored into ONE `some` scope, reproducing the per-join-row semantics of sql/typeorm
+  and memory's shared binding; `∃` distributes over OR so disjunctions need none; mixed
+  root/relation trees are expanded distributively first (capped at 64 conjuncts, typed
+  error beyond: loud beats a silent semantic downgrade). Every quantifier (and to-one hop)
+  gains a `{ none: {} }`/absence arm exactly when its interior evaluates true at the
+  all-null binding an empty collection contributes: ONE rule replaces all previous ad-hoc
+  null-arm cases.
+- **`metadata` and `provider` are required options.** The four metadata questions
+  (`isRelation` / `isToMany` / `isNullable` / `isString`) each change what a *valid* prisma
+  filter looks like, so a wrong guess is a runtime validation error, never graceful
+  degradation. Do not re-add fallbacks: an earlier cut had them and every one was an
+  unverified assumption sold as a "documented limitation".
+- **The parity gate is a real engine**, not a model: `@prisma/client` is a devDependency and
+  `npm run test:db` (CI's `tests-db` job, where ALL engine specs live so the default job
+  stays codegen-free) replays the matrix through a query engine: SQLite by default,
+  PostgreSQL under `DB_TYPE=postgres`: cross-checked against `@rapiq/memory`. Findings that
+  came from measurement, not reasoning: `exists()` on a to-many relation is constantly true
+  (a collection is never *absent*), and the `%`/`_` case-fold veto belongs on the equality
+  family ONLY: `equals` lowers to ILIKE and wildcards, `in`/`notIn` never do.
+- **Case folding** is `mode: 'insensitive'`, gated on a per-connector preset
+  (`provider/`: postgres/cockroach/mongo only; mysql/sqlserver are already collation-CI,
+  the same reasoning as `@rapiq/sql`'s identity `caseFold`), on string-typedness, and on the
+  value carrying no `%`/`_` (an insensitive `equals` lowers to `ILIKE`, where those would
+  widen an exact comparison).
+- **Unsupported by construction**: `regex`, `mod`, `size`, ITSELF, and `elemMatch` on a
+  to-one relation raise a typed `AdapterError`, never approximated.
+
 `@rapiq/memory`: compile-once functional visitors — the core visitor interfaces implemented with `R = compiled function` (`IFiltersVisitor<Predicate>`, `ISortsVisitor<Comparator>`, `IFieldsVisitor<Projector>`, `IPaginationVisitor<Slicer>`, `IQueryVisitor<CompiledQuery>`): `compileFilters(condition)` → `(input) => boolean`, `applyQuery(query, data)` → `{ data, total, pagination }`. The semantics contract (SQL parity for positive operators, complement law for negations — `ne`/`nin`/`not*` match null/missing —, same-element join-row binding for dotted paths over arrays, keep-tree projection where relations widen a sparse field selection) is settled in `.agents/plans/014-memory.md`; do not re-litigate decisions recorded there.
 
 **Case semantics (settled 2026-07-14)**: string matching is case-insensitive by default and uniform across backends — the anchored operators (`contains`/`startsWith`/`endsWith`, `i`-flag regex) *and* the equality family (`eq`/`ne`/`in`/`nin`). `@rapiq/sql` folds both comparison sides through the `caseFold` dialect callback (default `lower(...)`; the mysql/mssql presets use identity because their default `*_ci` collations already compare case-insensitively and skipping `lower()` keeps plain indexes usable). Per-field opt-out: `filters.caseSensitive` on the schema, forwarded as `{ visitor: { caseSensitive } }` (sql/typeorm) or `{ filters: { caseSensitive } }` (memory). Folding is further gated on the value being a string and on `IFiltersAdapter.isCaseFoldable(field)` (default true) — `@rapiq/typeorm` overrides it via entity metadata so only string-typed columns fold (an int column filtered with a wire string `'18'` renders plain `=`, avoiding `lower(integer)` errors on pg). Range comparisons and sort ordering stay collation-governed. Do not re-litigate: `eq` stays typed/exact for non-strings, and no `ilike`-style extra operators.

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -13,6 +13,7 @@ npm-workspaces monorepo (`packages/*`) orchestrated by Nx. Every publishable pac
 | [@rapiq/codec-url](../packages/codec-url)                 | Library  | URL transport façade: expression-default encoding, expression + legacy simple decoding, in-band dialect dispatch; uses `qs` |
 | [@rapiq/sql](../packages/sql)                             | Library  | Dialect-agnostic SQL adapter + visitor; ships dialect presets (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](../packages/typeorm)                     | Library  | Adapter applying a parsed `Query` to a TypeORM `SelectQueryBuilder`         |
+| [@rapiq/prisma](../packages/prisma)                       | Library  | Adapter serializing a parsed `Query` into a Prisma `findMany` args object (pure value, no prisma dependency) |
 | [@rapiq/memory](../packages/memory)                       | Library  | Evaluates a parsed `Query` against in-memory objects/arrays: visitors compile the AST into plain functions (predicate/comparator/projector/slicer) |
 | [@rapiq/docs](../packages/docs)                           | Docs app | VitePress documentation site (rapiq.tada5hi.net); private, not published    |
 
@@ -28,6 +29,7 @@ Layer 1 (depend on core):
   @rapiq/parser-simple
   @rapiq/sql
   @rapiq/memory
+  @rapiq/prisma
 
 Layer 2:
   @rapiq/parser-expression   (core + parser-simple)
@@ -86,6 +88,11 @@ packages/sql/src/
 packages/typeorm/src/
 └── adapter/              # TypeormAdapter + sub-adapters targeting SelectQueryBuilder
 
+packages/prisma/src/
+├── adapter/              # PrismaAdapter + per-parameter sub-adapters building the args object
+├── metadata/             # IMetadata + Metadata/defineMetadata over a prisma datamodel (DMMF-shaped)
+└── provider/             # per-connector capability presets (mode: 'insensitive' support)
+
 packages/memory/src/
 ├── parameter/{fields,filters,pagination,relations,sorts}/  # visitors compiling AST nodes into functions
 ├── query/                # CompiledQuery (matches/apply, pagination echo)
@@ -127,5 +134,5 @@ Public API is controlled via the barrel `src/index.ts` of each package; anything
 - **What a client may request (allow-lists, defaults, mappings)** → `@rapiq/core` (`schema/`)
 - **Turning raw URL input into the AST** → `@rapiq/codec-url` (dispatch + decode through parser-simple/parser-expression)
 - **Turning the AST into URL transport format** → `@rapiq/codec-url` (expression-default encode; deprecated explicit simple encode)
-- **Turning the AST into backend queries** → `@rapiq/sql`, `@rapiq/typeorm`
+- **Turning the AST into backend queries** → `@rapiq/sql`, `@rapiq/typeorm`, `@rapiq/prisma`
 - **Evaluating the AST against in-memory data** → `@rapiq/memory` (predicates/comparators/projectors compiled from the AST)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,6 +156,17 @@ jobs:
                 run: |
                     npm run test:db --workspace=packages/typeorm
 
+            # @rapiq/prisma keeps ALL engine-backed specs here: they need a
+            # generated client (`prisma generate`), so the default `tests` job
+            # stays codegen-free. The postgres matrix entry is the only place
+            # `mode: 'insensitive'` exists at all, so the case contract and the
+            # ILIKE-wildcard veto can only be measured there. Under mysql the
+            # suite falls back to its own sqlite file, which still exercises
+            # the full parity matrix.
+            -   name: Run tests (prisma)
+                run: |
+                    npm run test:db --workspace=packages/prisma
+
 #    preview:
 #        name: Preview Package
 #        needs: [build]

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -6,5 +6,6 @@
     "packages/codec-url": "2.0.0-beta.9",
     "packages/sql": "2.0.0-beta.9",
     "packages/typeorm": "2.0.0-beta.9",
+    "packages/prisma": "2.0.0-beta.9",
     "packages/memory": "2.0.0-beta.9"
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Every REST list endpoint answers the same five questions: which **fields**, whic
 | **Build** <sub>calling application</sub> | `defineQuery<User>({ filters: { age: gte(18) }, sort: '-name' })`: typed input in, query AST out |
 | **Transport** <sub>wire</sub> | encoded as a self-described URL query string: `?codec=url-expression&filter=gte(age,'18')&sort=-name` |
 | **Validate** <sub>receiving application</sub> | decoded back into the same AST, checked against a `Schema`: allow-lists, defaults, mappings |
-| **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/sql`) or to a TypeORM `SelectQueryBuilder` (`@rapiq/typeorm`) |
+| **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/sql`), to a TypeORM `SelectQueryBuilder` (`@rapiq/typeorm`) or as Prisma arguments (`@rapiq/prisma`) |
 
 The two ends are just applications. A browser querying an API is the common case, but services compose the same way:
 an API gateway, for instance, validates an incoming query against its own schema, scopes it
@@ -228,6 +228,7 @@ export async function getUsers(req: Request, res: Response) {
 | [@rapiq/codec-url](packages/codec-url) | URL query-string codec; writes expression filters and reads expression plus legacy simple filters |
 | [@rapiq/sql](packages/sql) | Dialect-agnostic SQL adapter (pg, mysql, sqlite, mssql & oracle presets) |
 | [@rapiq/typeorm](packages/typeorm) | Applies a parsed `Query` to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](packages/prisma) | Serializes a parsed `Query` into a Prisma argument object |
 | [@rapiq/memory](packages/memory) | Evaluates a parsed `Query` against in-memory objects & arrays |
 
 ## Parameters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,6 +1206,144 @@
                 "url": "https://github.com/sponsors/Boshen"
             }
         },
+        "node_modules/@prisma/client": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+            "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.18"
+            },
+            "peerDependencies": {
+                "prisma": "*",
+                "typescript": ">=5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "prisma": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@prisma/config": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+            "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "c12": "3.1.0",
+                "deepmerge-ts": "7.1.5",
+                "effect": "3.21.0",
+                "empathic": "2.0.0"
+            }
+        },
+        "node_modules/@prisma/config/node_modules/c12": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/c12/-/c12-3.1.0.tgz",
+            "integrity": "sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "chokidar": "^4.0.3",
+                "confbox": "^0.2.2",
+                "defu": "^6.1.4",
+                "dotenv": "^16.6.1",
+                "exsolve": "^1.0.7",
+                "giget": "^2.0.0",
+                "jiti": "^2.4.2",
+                "ohash": "^2.0.11",
+                "pathe": "^2.0.3",
+                "perfect-debounce": "^1.0.0",
+                "pkg-types": "^2.2.0",
+                "rc9": "^2.1.2"
+            },
+            "peerDependencies": {
+                "magicast": "^0.3.5"
+            },
+            "peerDependenciesMeta": {
+                "magicast": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@prisma/config/node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "node_modules/@prisma/config/node_modules/empathic": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
+            "integrity": "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/@prisma/debug": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+            "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@prisma/engines": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+            "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@prisma/debug": "6.19.3",
+                "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+                "@prisma/fetch-engine": "6.19.3",
+                "@prisma/get-platform": "6.19.3"
+            }
+        },
+        "node_modules/@prisma/engines-version": {
+            "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+            "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
+            "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@prisma/fetch-engine": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+            "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@prisma/debug": "6.19.3",
+                "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+                "@prisma/get-platform": "6.19.3"
+            }
+        },
+        "node_modules/@prisma/get-platform": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+            "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@prisma/debug": "6.19.3"
+            }
+        },
         "node_modules/@quansync/fs": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/@quansync/fs/-/fs-1.0.0.tgz",
@@ -1245,6 +1383,10 @@
         },
         "node_modules/@rapiq/parser-simple": {
             "resolved": "packages/parser-simple",
+            "link": true
+        },
+        "node_modules/@rapiq/prisma": {
+            "resolved": "packages/prisma",
             "link": true
         },
         "node_modules/@rapiq/sql": {
@@ -4161,6 +4303,22 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
         "node_modules/ci-info": {
             "version": "4.4.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
@@ -4175,6 +4333,16 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/citty": {
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
+            "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "consola": "^3.2.3"
             }
         },
         "node_modules/clean-regexp": {
@@ -4304,6 +4472,23 @@
             "dependencies": {
                 "array-ify": "^1.0.0",
                 "dot-prop": "^5.1.0"
+            }
+        },
+        "node_modules/confbox": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+            "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/consola": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+            "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.18.0 || >=16.10.0"
             }
         },
         "node_modules/conventional-changelog-angular": {
@@ -4542,6 +4727,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/deepmerge-ts": {
+            "version": "7.1.5",
+            "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+            "integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
         "node_modules/defaults": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -4601,6 +4796,13 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/destr": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
+            "integrity": "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -4701,6 +4903,17 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/effect": {
+            "version": "3.21.0",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+            "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.0.0",
+                "fast-check": "^3.23.1"
             }
         },
         "node_modules/ejs": {
@@ -5212,6 +5425,36 @@
                 "node": ">=12.0.0"
             }
         },
+        "node_modules/exsolve": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+            "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/fast-check": {
+            "version": "3.23.2",
+            "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+            "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "pure-rand": "^6.1.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5539,6 +5782,24 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
+        "node_modules/giget": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
+            "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.1.6",
+                "consola": "^3.4.0",
+                "defu": "^6.1.4",
+                "node-fetch-native": "^1.6.6",
+                "nypm": "^0.6.0",
+                "pathe": "^2.0.3"
+            },
+            "bin": {
+                "giget": "dist/cli.mjs"
             }
         },
         "node_modules/git-raw-commits": {
@@ -6098,7 +6359,6 @@
             "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "lib/jiti-cli.mjs"
             }
@@ -6905,6 +7165,13 @@
                 "node": ">=10"
             }
         },
+        "node_modules/node-fetch-native": {
+            "version": "1.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
+            "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/node-releases": {
             "version": "2.0.48",
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.48.tgz",
@@ -7151,6 +7418,31 @@
                 "node": ">=12"
             }
         },
+        "node_modules/nypm": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.8.tgz",
+            "integrity": "sha512-Q9K4Diu6l5u6xJQogeFSs/zKtyMSgFKFtRQV+tHP4kL7KPm2grpBU0dFIwFaXwNxN0MtfKWc43VpCugAa+LPsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "citty": "^0.2.2",
+                "pathe": "^2.0.3",
+                "tinyexec": "^1.2.4"
+            },
+            "bin": {
+                "nypm": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/nypm/node_modules/citty": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7176,6 +7468,13 @@
             "engines": {
                 "node": ">=12.20.0"
             }
+        },
+        "node_modules/ohash": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
+            "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/once": {
             "version": "1.4.0",
@@ -7525,6 +7824,18 @@
                 "pkg-pr-new": "bin/cli.js"
             }
         },
+        "node_modules/pkg-types": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+            "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.2.4",
+                "exsolve": "^1.0.8",
+                "pathe": "^2.0.3"
+            }
+        },
         "node_modules/pluralize": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -7670,6 +7981,32 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/prisma": {
+            "version": "6.19.3",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+            "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@prisma/config": "6.19.3",
+                "@prisma/engines": "6.19.3"
+            },
+            "bin": {
+                "prisma": "build/index.js"
+            },
+            "engines": {
+                "node": ">=18.18"
+            },
+            "peerDependencies": {
+                "typescript": ">=5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/property-information": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
@@ -7711,6 +8048,23 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/pure-rand": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+            "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/dubzzz"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fast-check"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/qs": {
             "version": "6.15.3",
@@ -7768,6 +8122,17 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/rc9": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
+            "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "defu": "^6.1.4",
+                "destr": "^2.0.3"
+            }
+        },
         "node_modules/readable-stream": {
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
@@ -7781,6 +8146,20 @@
             },
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/readdirp": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+            "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/reflect-metadata": {
@@ -10065,6 +10444,19 @@
             "license": "MIT",
             "devDependencies": {
                 "@rapiq/core": "^2.0.0-beta.9"
+            },
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.9"
+            }
+        },
+        "packages/prisma": {
+            "name": "@rapiq/prisma",
+            "version": "2.0.0-beta.9",
+            "license": "MIT",
+            "devDependencies": {
+                "@prisma/client": "^6.19.3",
+                "@rapiq/core": "^2.0.0-beta.9",
+                "prisma": "^6.19.3"
             },
             "peerDependencies": {
                 "@rapiq/core": "^2.0.0-beta.9"

--- a/packages/codec-url/README.md
+++ b/packages/codec-url/README.md
@@ -80,6 +80,7 @@ Use `encodeAsync()` and `decodeAsync()` when schema filter validators are asynch
 | **[@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url)** | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -96,6 +96,7 @@ Every node implements `accept(visitor)`. Backends implement the visitor interfac
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/core/src/parameter/filters/plan/distribute.ts
+++ b/packages/core/src/parameter/filters/plan/distribute.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError } from '../../../errors';
+import { FILTER_OPERATOR_SEMANTICS } from './constants';
+import type {
+    ComparePlan,
+    ConditionPlan,
+    PlanCompareOperator,
+} from './types';
+
+/**
+ * The ordering complement, derived from the semantics table: the
+ * operator accepting exactly the complementary three-way comparison
+ * range (lt {-1..-1} complements gte {0..1}, and so on). Derived
+ * rather than hardcoded, so the table stays the single authority.
+ */
+const ORDERING_COMPLEMENTS : Partial<Record<PlanCompareOperator, PlanCompareOperator>> = {};
+
+{
+    const entries = Object.entries(FILTER_OPERATOR_SEMANTICS)
+        .filter((entry) => entry[1].family === 'ordering') as [
+        PlanCompareOperator,
+        { compare: { min: number, max: number } },
+    ][];
+
+    for (const [name, semantics] of entries) {
+        const match = entries.find(([, other]) => (
+            other.compare.min === (semantics.compare.max === 1 ? -1 : semantics.compare.max + 1) &&
+            other.compare.max === (semantics.compare.min === -1 ? 1 : semantics.compare.min - 1)
+        ));
+
+        if (match) {
+            ORDERING_COMPLEMENTS[name] = match[0];
+        }
+    }
+}
+
+/**
+ * Push group negation down to the leaves, eliminating
+ * `CompoundPlan.negated` from the tree.
+ *
+ * `planCondition` keeps group negation because SQL and the in-memory
+ * backend render it two-valued cheaply (a CASE wrapper, a `!`).
+ * Backends without a two-valued NOT of their own (prisma, and the
+ * other structured-args ORMs of plan 023) instead consume this
+ * transform. It is semantics-preserving under the settled negation
+ * contract:
+ *
+ * - group negation is the two-valued complement PER BINDING, with the
+ *   binding quantifier outermost (SQL applies its CASE wrapper per
+ *   join row; the in-memory backend negates per binding context):
+ *   so De Morgan applies, negation commutes through `elemMatch`
+ *   (`not(elemMatch(c))` selects bindings where an element fails `c`,
+ *   NOT records without a matching element), and leaves flip to their
+ *   null-inclusive complement twins.
+ * - the complement of an ordering comparison has no leaf twin; it
+ *   becomes the complementary operator OR a null check: expressible
+ *   in the existing plan vocabulary, so backends need no new node
+ *   kinds and their usual constant folding (e.g. a non-nullable
+ *   column) applies unchanged.
+ * - `mod` and `size` have no complement form and stay wrapped in a
+ *   residual negated single-child compound; a backend that cannot
+ *   render that keeps failing typed, exactly as before.
+ */
+export function distributeNegation(plan: ConditionPlan) : ConditionPlan {
+    return distribute(plan, false);
+}
+
+function distribute(plan: ConditionPlan, negated: boolean) : ConditionPlan {
+    switch (plan.kind) {
+        case 'compound': {
+            const effective = negated !== plan.negated;
+
+            const children = plan.children.map((child) => distribute(child, effective));
+
+            // a single-child group carries no operator of its own;
+            // unwrapping keeps the tree in the shape the lowering
+            // produces for positive input.
+            if (children.length === 1) {
+                return children[0] as ConditionPlan;
+            }
+
+            let { operator } = plan;
+            if (effective) {
+                operator = plan.operator === 'and' ? 'or' : 'and';
+            }
+
+            return {
+                kind: 'compound',
+                operator,
+                negated: false,
+                children,
+            };
+        }
+        case 'constant': {
+            return negated ? { ...plan, verdict: !plan.verdict } : plan;
+        }
+        case 'null-check':
+        case 'one-of':
+        case 'match': {
+            return negated ? { ...plan, negated: !plan.negated } : plan;
+        }
+        case 'compare': {
+            return distributeCompare(plan, negated);
+        }
+        case 'elem-match': {
+            // negation commutes through the element quantifier: it
+            // applies per binding, the ∃ stays outside.
+            return {
+                ...plan,
+                condition: distribute(plan.condition, negated),
+            };
+        }
+        case 'mod':
+        case 'size': {
+            if (!negated) {
+                return plan;
+            }
+
+            // no complement form exists; the residual wrapper keeps
+            // the negation explicit for backends that can render it.
+            return {
+                kind: 'compound',
+                operator: 'and',
+                negated: true,
+                children: [plan],
+            };
+        }
+        default: {
+            throw AdapterError.featureUnsupported(
+                `filters:${(plan as { kind: string }).kind}`,
+            );
+        }
+    }
+}
+
+function distributeCompare(plan: ComparePlan, negated: boolean) : ConditionPlan {
+    if (!negated) {
+        return plan;
+    }
+
+    if (plan.op === 'eq') {
+        return { ...plan, negated: !plan.negated };
+    }
+
+    const complement = ORDERING_COMPLEMENTS[plan.op];
+    if (!complement) {
+        throw AdapterError.operatorUnsupported(plan.op);
+    }
+
+    // the null-inclusive complement of an ordering comparison: the
+    // complementary operator, or no value at all.
+    return {
+        kind: 'compound',
+        operator: 'or',
+        negated: false,
+        children: [
+            { ...plan, op: complement },
+            {
+                kind: 'null-check',
+                field: plan.field,
+                negated: false,
+                elementwise: true,
+            },
+        ],
+    };
+}

--- a/packages/core/src/parameter/filters/plan/index.ts
+++ b/packages/core/src/parameter/filters/plan/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './constants';
+export * from './distribute';
 export * from './module';
 export * from './types';

--- a/packages/core/test/unit/parameter/filters-plan-distribute.spec.ts
+++ b/packages/core/test/unit/parameter/filters-plan-distribute.spec.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition, ConditionPlan } from '../../../src';
+import {
+    and,
+    distributeNegation,
+    elemMatch,
+    eq,
+    exists,
+    gte,
+    inArray,
+    lt,
+    mod,
+    ne,
+    not,
+    or,
+    planCondition,
+} from '../../../src';
+
+function distributed(condition: Condition) : ConditionPlan {
+    const plan = planCondition(condition);
+    expect(plan).not.toBeNull();
+
+    return distributeNegation(plan as ConditionPlan);
+}
+
+/**
+ * No compound in the tree carries group negation, except the residual
+ * wrappers around kinds without a complement form.
+ */
+function assertDistributed(plan: ConditionPlan) {
+    if (plan.kind === 'compound') {
+        if (plan.negated) {
+            expect(plan.children).toHaveLength(1);
+            expect(['mod', 'size']).toContain((plan.children[0] as ConditionPlan).kind);
+
+            return;
+        }
+
+        for (const child of plan.children) {
+            assertDistributed(child);
+        }
+    }
+
+    if (plan.kind === 'elem-match') {
+        assertDistributed(plan.condition);
+    }
+}
+
+describe('src/parameter/filters/plan/distribute.ts', () => {
+    it('should leave a positive tree untouched', () => {
+        const plan = distributed(and(eq('a', 1), or(gte('b', 2), exists('c'))));
+
+        assertDistributed(plan);
+        expect(plan).toEqual(planCondition(and(eq('a', 1), or(gte('b', 2), exists('c')))));
+    });
+
+    it('should apply De Morgan to a negated group', () => {
+        const plan = distributed(not(and(eq('a', 1), eq('b', 2))));
+
+        expect(plan).toMatchObject({
+            kind: 'compound',
+            operator: 'or',
+            negated: false,
+            children: [
+                {
+                    kind: 'compare', 
+                    op: 'eq', 
+                    field: 'a', 
+                    negated: true,
+                },
+                {
+                    kind: 'compare', 
+                    op: 'eq', 
+                    field: 'b', 
+                    negated: true,
+                },
+            ],
+        });
+    });
+
+    it('should toggle the negated flag of leaf twins', () => {
+        // ¬(¬a ∨ b) = a ∧ ¬b
+        const plan = distributed(not(or(ne('a', 1), inArray('b', [1, 2]))));
+
+        expect(plan).toMatchObject({
+            operator: 'and',
+            children: [
+                { kind: 'compare', negated: false },
+                { kind: 'one-of', negated: true },
+            ],
+        });
+    });
+
+    it('should complement an ordering comparison with the dual operator or null', () => {
+        const plan = distributed(not(lt('age', 18)));
+
+        expect(plan).toMatchObject({
+            kind: 'compound',
+            operator: 'or',
+            children: [
+                {
+                    kind: 'compare', 
+                    op: 'gte', 
+                    value: 18, 
+                    negated: false,
+                },
+                {
+                    kind: 'null-check', 
+                    field: 'age', 
+                    negated: false, 
+                },
+            ],
+        });
+    });
+
+    it('should push negation through elemMatch per binding', () => {
+        // the settled contract: group negation applies per binding with
+        // the quantifier outermost, so ¬elemMatch(c) selects bindings
+        // where an element fails c.
+        const plan = distributed(not(elemMatch('items', and(eq('a', 1), eq('b', 2)))));
+
+        expect(plan).toMatchObject({
+            kind: 'elem-match',
+            field: 'items',
+            condition: {
+                kind: 'compound',
+                operator: 'or',
+                negated: false,
+                children: [
+                    { kind: 'compare', negated: true },
+                    { kind: 'compare', negated: true },
+                ],
+            },
+        });
+    });
+
+    it('should keep a residual wrapper around kinds without a complement', () => {
+        const plan = distributed(not(mod('age', 2, 0)));
+
+        expect(plan).toMatchObject({
+            kind: 'compound',
+            negated: true,
+            children: [{ kind: 'mod' }],
+        });
+    });
+
+    it('should cancel a double negation', () => {
+        const plan = distributed(not(not(and(eq('a', 1), gte('b', 2)))));
+
+        assertDistributed(plan);
+        expect(plan).toEqual(planCondition(and(eq('a', 1), gte('b', 2))));
+    });
+
+    it('should flip a constant verdict', () => {
+        // in([]) lowers to a false constant; the negated group flips it.
+        expect(distributed(not(and(inArray('a', []))))).toEqual({
+            kind: 'constant',
+            verdict: true,
+        });
+    });
+});

--- a/packages/docs/.vitepress/config.mjs
+++ b/packages/docs/.vitepress/config.mjs
@@ -124,6 +124,7 @@ export default defineConfig({
                     items: [
                         { text: '@rapiq/sql', link: '/packages/sql' },
                         { text: '@rapiq/typeorm', link: '/packages/typeorm' },
+                        { text: '@rapiq/prisma', link: '/packages/prisma' },
                         { text: '@rapiq/memory', link: '/packages/memory' },
                     ],
                 },

--- a/packages/docs/.vitepress/theme/components/PackageLayers.vue
+++ b/packages/docs/.vitepress/theme/components/PackageLayers.vue
@@ -27,6 +27,7 @@ const layers: Layer[] = [
         packages: [
             { name: '@rapiq/parser-simple', href: '/packages/parser-simple', deps: 'core' },
             { name: '@rapiq/sql', href: '/packages/sql', deps: 'core' },
+            { name: '@rapiq/prisma', href: '/packages/prisma', deps: 'core' },
             { name: '@rapiq/memory', href: '/packages/memory', deps: 'core' },
         ],
     },

--- a/packages/docs/guide/executing-queries.md
+++ b/packages/docs/guide/executing-queries.md
@@ -1,14 +1,15 @@
 # Executing Queries
 
-A validated `Query` becomes results through an **adapter**. Three ship with rapiq — pick by where your data lives:
+A validated `Query` becomes results through an **adapter**. Four ship with rapiq; pick by where your data lives:
 
 | Adapter | Target | Returns |
 |---|---|---|
 | [@rapiq/typeorm](/packages/typeorm) | TypeORM `SelectQueryBuilder` | mutates the builder in place |
+| [@rapiq/prisma](/packages/prisma) | Prisma Client | a `findMany` argument object |
 | [@rapiq/sql](/packages/sql) | any SQL driver | parameterized SQL fragments |
 | [@rapiq/memory](/packages/memory) | plain objects & arrays | compiled functions / filtered data |
 
-All three consume the same AST, and they agree on semantics: the records a query selects in memory are the records it selects in the database.
+All four consume the same AST, and they agree on semantics: the records a query selects in memory are the records it selects in the database.
 
 ## TypeORM
 
@@ -30,6 +31,24 @@ const [entities, total] = await queryBuilder.getManyAndCount();
 ```
 
 `execute` returns the applied pagination — handy for the response `meta` block. Existing builder state is preserved: rapiq filters are appended with `AND` (under namespaced parameter bindings), and a query without sorts or pagination leaves a caller-owned `ORDER BY`/`take`/`skip` untouched — so tenant or authorization scopes applied before `execute` cannot be erased. Options (join types, the `onJoin` hook, alias conventions) are on the [package page](/packages/typeorm).
+
+## Prisma
+
+Prisma takes an argument object rather than a builder, so the adapter is a pure serializer that returns the object and touches nothing:
+
+```typescript
+import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+
+const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
+    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+});
+
+const { args, pagination } = adapter.execute(query);
+
+const users = await prisma.user.findMany(args);
+```
+
+An application-owned predicate is preserved the same way, by passing it as the baseline: `execute(query, { base: { where: { realm_id } } })` conjoins the client's filters with your scope. Unlike the builder-bound adapters, one `PrismaAdapter` instance is stateless and safely shared across requests. The [package page](/packages/prisma) covers the provider presets (`mode: 'insensitive'` support) and how negation is rendered exactly despite Prisma's three-valued `NOT`.
 
 ## Raw SQL
 

--- a/packages/docs/guide/installation.md
+++ b/packages/docs/guide/installation.md
@@ -28,6 +28,10 @@ Then add the backend that executes queries against your data:
 npm install @rapiq/sql @rapiq/typeorm
 ```
 
+```sh [Prisma]
+npm install @rapiq/prisma
+```
+
 ```sh [Raw SQL]
 npm install @rapiq/sql
 ```

--- a/packages/docs/packages/index.md
+++ b/packages/docs/packages/index.md
@@ -13,6 +13,7 @@ rapiq is a family of small packages around one shared data structure — the [`Q
 | [@rapiq/codec-url](/packages/codec-url) | URL codec façade; writes expressions and reads expression plus legacy simple filters |
 | [@rapiq/sql](/packages/sql) | Dialect-agnostic SQL adapter (pg, mysql, sqlite, mssql, oracle presets) |
 | [@rapiq/typeorm](/packages/typeorm) | Applies a `Query` to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](/packages/prisma) | Serializes a `Query` into a Prisma argument object |
 | [@rapiq/memory](/packages/memory) | Evaluates a `Query` against in-memory objects & arrays |
 
 ## Which packages do I need?
@@ -27,6 +28,12 @@ npm install @rapiq/core @rapiq/codec-url
 
 ```sh
 npm install @rapiq/core @rapiq/codec-url @rapiq/sql @rapiq/typeorm
+```
+
+**An HTTP API backed by Prisma:**
+
+```sh
+npm install @rapiq/core @rapiq/codec-url @rapiq/prisma
 ```
 
 **An HTTP API composing SQL by hand:**

--- a/packages/docs/packages/prisma.md
+++ b/packages/docs/packages/prisma.md
@@ -1,0 +1,197 @@
+# @rapiq/prisma
+
+Serializes a parsed [`Query`](/guide/query-ast) into a **Prisma argument object**: filters become `where`, fields become `select`, relations become `include`, sort becomes `orderBy` and pagination becomes `take`/`skip`.
+
+```sh
+npm install @rapiq/core @rapiq/prisma
+```
+
+Unlike the TypeORM adapter there is nothing to mutate: the adapter is a pure serializer that returns a plain object. `@prisma/client` is neither a runtime nor a peer dependency of this package. It is a devDependency only, because the test suite runs the emitted arguments through a real engine.
+
+## Usage
+
+```typescript
+import { Prisma } from '@prisma/client';
+import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+
+const adapter = new PrismaAdapter({
+    provider: 'postgresql',
+    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+});
+
+const { args, pagination } = adapter.execute(query);
+
+const users = await prisma.user.findMany(args);
+```
+
+`pagination` echoes the limit/offset actually applied, e.g. for a response `meta` block.
+
+Bind your generated argument type so the call site stays type-checked:
+
+```typescript
+const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({ /* … */ });
+```
+
+Because the adapter produces a value instead of writing into a builder, it is **stateless**: construct one instance per model and share it across requests. To combine several queries, compose them *before* serializing with [`mergeQueries`](/guide/merging-queries) or `query.filters.and(...)`; the adapter deliberately has no accumulation API.
+
+## Model metadata
+
+`metadata` is **required**. The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:
+
+| fact | what it decides |
+|---|---|
+| is the path a relation? | Prisma rejects `not: null` on a relation: absence is a presence test |
+| is that relation to-many? | `some`/`none` versus `is`; the wrong one is a validation error |
+| can the column hold `null`? | a null comparison on a required column is a validation error |
+| does it hold strings? | `mode: 'insensitive'` exists only on string filters |
+
+Guessing any of them produces a runtime validation error rather than graceful degradation, so the adapter asks for them up front. It is bound to one model anyway:
+
+```typescript
+const adapter = new PrismaAdapter({
+    provider: 'postgresql',
+    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+});
+```
+
+::: tip
+`Prisma.dmmf` is unavailable in some builds (edge/wasm targets, the new `prisma-client` generator). `defineMetadata` accepts any object of the same shape, `{ models: [{ name, fields: [{ name, kind, isList, isRequired, type }] }] }`, so a hand-written datamodel works just as well.
+:::
+
+## Parameter mapping
+
+| Query parameter | Prisma argument |
+|---|---|
+| `filters`    | `where` |
+| `fields`     | `select` |
+| `relations`  | `include` (nested `select` when fields are picked) |
+| `sort`       | `orderBy` (array of single-key objects, order preserved) |
+| `pagination` | `take` / `skip` |
+
+Prisma rejects `select` and `include` on the same level, so the adapter emits exactly one of them per level: a level that picks fields is projected sparsely with `select`, a level that only widens with relations uses `include`. An explicitly included relation is always hydrated whole: a sparse `relation.field` pick never narrows it, matching the projection contract of [@rapiq/memory](/packages/memory).
+
+```typescript
+// fields: ['id', 'realm.name']
+{ select: { id: true, realm: { select: { name: true } } } }
+
+// fields: ['id'], relations: ['realm']
+{ select: { id: true, realm: true } }
+
+// relations: ['items', 'items.realm']
+{ include: { items: { include: { realm: true } } } }
+```
+
+## Preserving an application-owned predicate
+
+Rapiq filters **narrow** a query, they never replace it. Hand the adapter a baseline argument object and the client's conditions are conjoined with your tenant or authorization scope:
+
+```typescript
+const { args } = adapter.execute(query, {
+    base: { where: { realm_id: realmId } },
+});
+
+// where: { AND: [ { realm_id: … }, { …client filters } ] }
+```
+
+Baseline keys the query does not produce (`take`, `orderBy`, …) survive untouched: the same preservation contract [@rapiq/typeorm](/packages/typeorm) applies to a query builder.
+
+## Negation
+
+rapiq's negated operators (`ne`, `nin`, `notContains`, …) and `not(...)` groups are the **exact null-inclusive complement** of their positive twin: they match precisely the records the positive form does not. Prisma's `not` and `NOT` instead follow three-valued SQL logic and silently drop rows whose column is `NULL`.
+
+The adapter therefore never delegates negation to Prisma. It pushes negation down to the leaves (De Morgan) and renders each complement itself:
+
+```typescript
+// ne('address', 'Mordor')
+{ OR: [ { address: { not: 'Mordor' } }, { address: null } ] }
+
+// ne('realm.name', 'master'): realm is an optional to-one relation
+{ OR: [
+    { realm: { is: { name: { not: 'master' } } } },
+    { NOT: { realm: { is: {} } } },      // …or there is no realm at all
+] }
+```
+
+The result set is identical to `@rapiq/sql`, `@rapiq/typeorm` and `@rapiq/memory`; the complement law is pinned by a cross-backend test suite. When metadata proves a column non-nullable the null arm is dropped, because no null can exist there.
+
+A **to-many** path quantifies existentially, for the negated form too: the SQL backends evaluate the condition once per joined row, so a record with one matching and one non-matching element satisfies both a condition and its negation:
+
+```typescript
+// ne('items.title', 'book'): items is to-many
+{ OR: [
+    { items: { some: { title: { not: 'book' } } } },
+    { items: { none: {} } },             // an empty collection is one null row
+] }
+```
+
+**Same-element binding holds.** Two conditions on one to-many path (`filter[items.title]` and `filter[items.color]`) bind to the *same* joined row in the SQL backends, so the adapter factors them into a single `some` scope instead of emitting independent existentials:
+
+```typescript
+// and(eq('items.title', 'book'), eq('items.color', 'red'))
+{ items: { some: { AND: [
+    { title: { equals: 'book' } },
+    { color: { equals: 'red' } },
+] } } }
+```
+
+A record whose elements satisfy the two conditions only separately does not match, on any backend. Trees mixing root and relation conditions are expanded distributively first, so the guarantee also covers nested expression-dialect input. [`elemMatch`](/guide/filters#elemmatch) remains the explicit same-element construct.
+
+## Case sensitivity
+
+String comparison is [case-insensitive by default](/guide/filters#case-sensitivity) across all rapiq backends. Prisma expresses that with `mode: 'insensitive'`, which only some connectors accept, so the adapter takes a provider:
+
+```typescript
+new PrismaAdapter({ provider: 'mysql' });
+```
+
+| provider | behavior |
+|---|---|
+| `postgresql`, `cockroachdb`, `mongodb` | `mode: 'insensitive'` is emitted |
+| `mysql`, `sqlserver` | nothing emitted: the default `*_ci` collation already compares case-insensitively |
+| `sqlite` | nothing emitted: `contains`/`startsWith`/`endsWith` are ASCII-case-insensitive, `equals`/`in` are **not** |
+
+`provider` is required, and an unrecognized name throws rather than falling back: emitting `mode` on a connector without support is a Prisma validation error on *every* case-insensitive filter, which is too sharp an edge to guess at.
+
+Two narrowing rules apply on top. A non-string column never folds. And an **equality** whose value contains `%` or `_` compares case-sensitively instead, because Prisma lowers an insensitive `equals` to `ILIKE` with the operand passed through verbatim ([#20318](https://github.com/prisma/prisma/issues/20318), [#10810](https://github.com/prisma/prisma/issues/10810)): measured on Postgres 18:
+
+```typescript
+{ address: { equals: 'a_b', mode: 'insensitive' } }  // also matches 'axb', 'a%b'
+{ address: { equals: 'a%b', mode: 'insensitive' } }  // matches everything
+```
+
+Matching too little is the safer failure, so those values keep the exact comparison. The rule is scoped to equality on purpose: `in`/`notIn` are never lowered to `ILIKE` and stay case-insensitive, while `contains`/`startsWith`/`endsWith` are `LIKE`-based with *or without* `mode`: that is Prisma's own behaviour, not something this adapter introduces.
+
+Opt individual fields out through the schema:
+
+```typescript
+defineSchema<User>({
+    filters: { allowed: ['id', 'token'], caseSensitive: ['token'] },
+});
+```
+
+## Limitations
+
+Operators without a Prisma equivalent raise a typed `AdapterError` (`FEATURE_UNSUPPORTED`) instead of being approximated:
+
+- `regex`: no connector exposes a regular-expression filter
+- `mod`: no modulo filter
+- `size`: no array-length filter
+- the `$this` element marker: the element itself is not addressable
+
+Four further deviations are worth knowing:
+
+- **Ordering by a to-many relation** is not expressible in Prisma (only `_count` is). Such a sort is emitted as written and rejected by Prisma.
+- **Same-element binding.** Two conditions on the same to-many path (`filter[items.title]` and `filter[items.color]`) bind to the *same* joined row in the SQL backends, but Prisma evaluates each `some` independently, so they may match different elements. Use [`elemMatch`](/guide/filters#elemmatch) when the conditions must hold for one and the same element; it maps to a single `some` scope and agrees on every backend.
+- **`elemMatch` targets a to-many relation.** Applying it to a to-one relation emits `some`, which Prisma rejects.
+- **SQLite compares case-sensitively.** It has no `mode: 'insensitive'` and its `=` is case-sensitive, so the case-insensitive default does not hold there. `contains`/`startsWith`/`endsWith` are ASCII-case-insensitive via `LIKE`. Column-level `COLLATE NOCASE` is the fix. This is measured by the engine suite, not assumed.
+
+## Verification
+
+`npm run test:db` runs the whole parity matrix through a real Prisma client: against SQLite by default, and against PostgreSQL when `DB_TYPE=postgres` names a live server (CI runs both). Every condition is executed three ways: through the engine, through [@rapiq/memory](/packages/memory), and through an in-test evaluator, and all three must select the same records. The connector-specific claims on this page (the case contract, the wildcard behaviour) are measurements from that suite rather than assumptions.
+
+A note on `exists()`: it asks whether a *value is present*, so on a to-many relation it is always true: a collection is possibly empty, never absent. That matches [@rapiq/memory](/packages/memory); "has no elements" is a different question that `exists` does not ask.
+
+## Documentation
+
+- [Filters](/guide/filters): operator reference and case semantics
+- [Executing Queries](/guide/executing-queries): the adapter surface shared by all backends

--- a/packages/memory/README.md
+++ b/packages/memory/README.md
@@ -97,6 +97,7 @@ const slicer = compilePagination(query.pagination); // (data) => data page
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | **[@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory)** | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/parser-expression/README.md
+++ b/packages/parser-expression/README.md
@@ -79,6 +79,7 @@ Syntax errors and schema violations throw `FiltersParseError` immediately; the e
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/parser-mongo/README.md
+++ b/packages/parser-mongo/README.md
@@ -80,6 +80,7 @@ Grammar errors (unknown `$`-operators, misplaced operators, malformed operator a
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/parser-simple/README.md
+++ b/packages/parser-simple/README.md
@@ -85,6 +85,7 @@ Per-parameter parser classes (`SimpleFieldsParser`, `SimpleFiltersParser`, `Simp
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/prisma/LICENSE
+++ b/packages/prisma/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2026 Peter Placzek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -1,0 +1,134 @@
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
+
+<h1 align="center">@rapiq/prisma</h1>
+
+<p align="center">
+  <b>Turn a rapiq <code>Query</code> into a Prisma argument object.</b><br>
+  A pure serializer: nothing is mutated, no database is touched,<br>
+  and <code>@prisma/client</code> is not a dependency.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/prisma"><img src="https://img.shields.io/npm/v/@rapiq/prisma/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/prisma"><img src="https://img.shields.io/npm/types/@rapiq/prisma?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/prisma?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/prisma"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/prisma">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+Where the TypeORM adapter writes into a query builder, this one returns a plain `findMany` argument object you hand straight to Prisma.
+
+- 🧾 **Just a value**: `execute(query)` returns `{ args, pagination }`. Nothing is mutated, so the adapter is trivial to test, log, cache or post-process.
+- 🔗 **Zero coupling**: `@prisma/client` is neither a runtime nor a peer dependency. Bind your generated `Prisma.<Model>FindManyArgs` type and the call site stays fully checked.
+- 🧮 **Exact semantics**: negation is the null-inclusive complement and conditions on one to-many path bind to the same element, exactly as in `@rapiq/sql`, `@rapiq/typeorm` and `@rapiq/memory`. Prisma's three-valued `not` and independent `some` scopes are never relied upon.
+- 🔬 **Measured, not modelled**: the parity suite runs every condition through a real Prisma engine (SQLite by default, PostgreSQL in CI) and cross-checks it against `@rapiq/memory`.
+
+```typescript
+import { Prisma } from '@prisma/client';
+import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+
+const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
+    provider: 'postgresql',
+    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+});
+
+const { args, pagination } = adapter.execute(query);
+
+const users = await prisma.user.findMany(args);
+```
+
+## Installation
+
+```sh
+npm install @rapiq/core @rapiq/prisma
+```
+
+## What a query becomes
+
+| Query parameter | Prisma argument |
+|---|---|
+| `filters` | `where` |
+| `fields` | `select` |
+| `relations` | `include`, or a nested `select` when fields are picked |
+| `sort` | `orderBy` (an array of single-key objects, order preserved) |
+| `pagination` | `take` / `skip` |
+
+`pagination` is echoed back from `execute()` as the limit/offset actually applied, ready for a response `meta` block.
+
+## Required options
+
+Both `provider` and `metadata` are required. The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:
+
+| fact | what it decides |
+|---|---|
+| is the path a relation? | Prisma rejects `not: null` on a relation, so absence is a presence test |
+| is that relation to-many? | `some` / `none` versus `is`; the wrong one is a validation error |
+| can the column hold `null`? | a null comparison on a required column is a validation error |
+| does it hold strings? | `mode: 'insensitive'` exists only on string filters |
+
+Guessing any of them produces a runtime validation error rather than graceful degradation. `defineMetadata` accepts any object shaped like a Prisma datamodel, so a hand-written one works where `Prisma.dmmf` is unavailable (edge and wasm builds, the new `prisma-client` generator).
+
+## Preserving an application-owned predicate
+
+Rapiq filters **narrow** a query, they never replace it. Pass a baseline argument object and the caller's conditions are conjoined with your tenant or authorization scope:
+
+```typescript
+const { args } = adapter.execute(query, {
+    base: { where: { realm_id: realmId } },
+});
+
+// where: { AND: [ { realm_id: ... }, { ...client filters } ] }
+```
+
+A baseline `select` is never widened either: relations the query hydrates join it instead of replacing it.
+
+## Case sensitivity
+
+String comparison is case-insensitive by default across all rapiq backends. Prisma expresses that with `mode: 'insensitive'`, which only some connectors accept, so the provider decides:
+
+| provider | behaviour |
+|---|---|
+| `postgresql`, `cockroachdb`, `mongodb` | `mode: 'insensitive'` is emitted |
+| `mysql`, `sqlserver` | nothing emitted; the default `*_ci` collation already compares case-insensitively |
+| `sqlite` | nothing emitted; `contains` / `startsWith` / `endsWith` are ASCII-case-insensitive, `equals` is not |
+
+## Limitations
+
+Operators without a Prisma equivalent raise a typed `AdapterError` instead of being approximated: `regex`, `mod`, `size` and the `$this` element marker. Ordering by a to-many relation is not expressible in Prisma either.
+
+Conditions on one to-many path are factored into a single `some` scope, so they bind to the same element on every backend; `elemMatch` remains the explicit same-element construct. `elemMatch` on a to-one relation raises a typed error.
+
+## The rapiq family
+
+| Package | Purpose |
+|---|---|
+| [@rapiq/core](https://github.com/tada5hi/rapiq/tree/master/packages/core) | Query AST, typed build layer & schema system (the shared foundation) |
+| [@rapiq/parser-simple](https://github.com/tada5hi/rapiq/tree/master/packages/parser-simple) | Parse plain object/array input (the "simple" dialect) |
+| [@rapiq/parser-expression](https://github.com/tada5hi/rapiq/tree/master/packages/parser-expression) | Parse filter expressions like `and(eq(name,'John'), gte(age,'18'))` |
+| [@rapiq/parser-mongo](https://github.com/tada5hi/rapiq/tree/master/packages/parser-mongo) | Parse MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
+| [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
+| [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
+| [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| **[@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma)** | Serialize a query into a Prisma argument object |
+| [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
+
+## Documentation
+
+To find out more, head over to the [documentation](https://rapiq.tada5hi.net/packages/prisma).
+
+## License
+
+Published under the [MIT License](https://github.com/tada5hi/rapiq/blob/master/LICENSE).

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -1,0 +1,71 @@
+{
+    "name": "@rapiq/prisma",
+    "version": "2.0.0-beta.9",
+    "description": "A prisma adapter for rapiq.",
+    "type": "module",
+    "main": "dist/index.mjs",
+    "types": "dist/index.d.mts",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        }
+    },
+    "files": [
+        "dist/"
+    ],
+    "devDependencies": {
+        "@prisma/client": "^6.19.3",
+        "@rapiq/core": "^2.0.0-beta.9",
+        "prisma": "^6.19.3"
+    },
+    "peerDependencies": {
+        "@rapiq/core": "^2.0.0-beta.9"
+    },
+    "scripts": {
+        "build:types": "tsc --noEmit -p tsconfig.build.json",
+        "build:js": "tsdown",
+        "build": "npm run build:types && npm run build:js",
+        "prisma:generate": "prisma generate --schema test/prisma/schema.prisma && prisma generate --schema test/prisma/schema.postgres.prisma",
+        "test": "vitest --config test/vitest.config.ts --run",
+        "test:coverage": "vitest --config test/vitest.config.ts --run --coverage",
+        "prepublishOnly": "npm run build",
+        "test:db": "npm run prisma:generate && vitest --config test/vitest.db.config.ts --run"
+    },
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public",
+        "tag": "beta"
+    },
+    "keywords": [
+        "query",
+        "json",
+        "json-api",
+        "api",
+        "rest",
+        "api-utils",
+        "prisma",
+        "include",
+        "pagination",
+        "sort",
+        "fields",
+        "filter",
+        "relations",
+        "typescript"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Tada5hi/rapiq.git",
+        "directory": "packages/prisma"
+    },
+    "bugs": {
+        "url": "https://github.com/Tada5hi/rapiq/issues"
+    },
+    "homepage": "https://github.com/Tada5hi/rapiq#readme"
+}

--- a/packages/prisma/src/adapter/fields.ts
+++ b/packages/prisma/src/adapter/fields.ts
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IFields } from '@rapiq/core';
+import { FieldOperator } from '@rapiq/core';
+
+type SelectionNode = {
+    /**
+     * Scalar field names picked at this level.
+     */
+    picks : Set<string>,
+
+    children : Map<string, SelectionNode>,
+
+    /**
+     * Explicitly requested through `relations`: hydrated as a whole
+     * record. A sparse `<relation>.<field>` pick never narrows it,
+     * matching the `@rapiq/memory` projection contract.
+     */
+    whole : boolean,
+
+    /**
+     * A pick exists somewhere in this subtree, so the level is
+     * projected sparsely (`select`) instead of wholly (`include`).
+     */
+    refined : boolean,
+};
+
+export type Selection = {
+    select?: Record<string, any>,
+    include?: Record<string, any>,
+};
+
+function createNode() : SelectionNode {
+    return {
+        picks: new Set(),
+        children: new Map(),
+        whole: false,
+        refined: false,
+    };
+}
+
+function descend(node: SelectionNode, segments: string[]) : SelectionNode {
+    let current = node;
+
+    for (const segment of segments) {
+        let child = current.children.get(segment);
+        if (!child) {
+            child = createNode();
+            current.children.set(segment, child);
+        }
+
+        current = child;
+    }
+
+    return current;
+}
+
+/**
+ * A pick of the property itself wins over a refinement of it:
+ * `fields: ['realm', 'realm.name']` hydrates the whole relation,
+ * matching the `@rapiq/memory` projection contract.
+ */
+function buildSelect(node: SelectionNode, children: Record<string, any>) : Record<string, any> {
+    const select : Record<string, any> = { ...children };
+
+    node.picks.forEach((pick) => {
+        select[pick] = true;
+    });
+
+    return select;
+}
+
+function materializeChildren(node: SelectionNode) : Record<string, any> {
+    const output : Record<string, any> = {};
+
+    node.children.forEach((child, name) => {
+        output[name] = materialize(child);
+    });
+
+    return output;
+}
+
+function materialize(node: SelectionNode) : true | Record<string, any> {
+    const children = materializeChildren(node);
+    const hasChildren = Object.keys(children).length > 0;
+
+    // an explicitly included relation is hydrated whole; deeper
+    // relations still have to be declared, and `include` keeps every
+    // scalar of the level alongside them.
+    if (node.whole) {
+        if (hasChildren) {
+            return { include: children };
+        }
+
+        return true;
+    }
+
+    if (node.picks.size > 0 || hasChildren) {
+        return { select: buildSelect(node, children) };
+    }
+
+    return true;
+}
+
+/**
+ * The `select` / `include` fragment of the argument object; empty when
+ * neither fields nor relations were requested.
+ *
+ * `select` and `include` are mutually exclusive per level in prisma,
+ * so exactly one of them is emitted: a level carrying picks is
+ * projected sparsely with `select`, a level that only widens with
+ * relations uses `include`. Excluded fields are simply not projected,
+ * the resolution every other rapiq backend applies.
+ */
+export function buildSelection(fields: IFields, relationPaths: string[]) : Selection {
+    const root = createNode();
+
+    for (const field of fields.value) {
+        if (field.operator === FieldOperator.EXCLUDE) {
+            continue;
+        }
+
+        const segments = field.name.split('.');
+        const last = segments.pop() as string;
+
+        root.refined = true;
+
+        let current = root;
+        for (const segment of segments) {
+            let child = current.children.get(segment);
+            if (!child) {
+                child = createNode();
+                current.children.set(segment, child);
+            }
+
+            child.refined = true;
+            current = child;
+        }
+
+        current.picks.add(last);
+    }
+
+    for (const path of relationPaths) {
+        descend(root, path.split('.')).whole = true;
+    }
+
+    const children = materializeChildren(root);
+    const hasChildren = Object.keys(children).length > 0;
+
+    if (root.refined) {
+        const select = buildSelect(root, children);
+
+        // prisma rejects an empty select.
+        if (Object.keys(select).length === 0) {
+            return {};
+        }
+
+        return { select };
+    }
+
+    if (hasChildren) {
+        return { include: children };
+    }
+
+    return {};
+}

--- a/packages/prisma/src/adapter/index.ts
+++ b/packages/prisma/src/adapter/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './fields';
+export * from './module';
+export * from './relations';
+export * from './sort';
+export * from './types';
+export * from './where';

--- a/packages/prisma/src/adapter/module.ts
+++ b/packages/prisma/src/adapter/module.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IQuery, IQueryVisitor } from '@rapiq/core';
+import { resolveProviderOptions } from '../provider';
+import { buildSelection } from './fields';
+import { collectRelationPaths } from './relations';
+import { buildOrderBy } from './sort';
+import { WhereRenderer } from './where';
+import type {
+    Args,
+    ExecuteOptions,
+    PrismaAdapterOptions,
+    PrismaAdapterOutput,
+    Where,
+} from './types';
+
+/**
+ * Serializes a parsed query into a prisma `findMany` argument object.
+ *
+ * A pure serializer: `execute` maps a value to a value, holds no
+ * per-call state, and one instance is safely shared across requests.
+ * Queries compose BEFORE serialization (`mergeQueries`,
+ * `query.filters.and(...)` in `@rapiq/core`), which is why there is
+ * no accumulation API. Nothing from prisma is imported; bind the
+ * generated argument type to keep the call site checked:
+ *
+ * ```typescript
+ * const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
+ *     provider: 'postgresql',
+ *     metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+ * });
+ *
+ * const { args, pagination } = adapter.execute(query);
+ * const users = await prisma.user.findMany(args);
+ * ```
+ */
+export class PrismaAdapter<
+    ARGS extends Args = Args,
+> implements IQueryVisitor<PrismaAdapterOutput<ARGS>> {
+    protected renderer : WhereRenderer;
+
+    protected options : PrismaAdapterOptions;
+
+    constructor(options: PrismaAdapterOptions) {
+        this.options = options;
+        this.renderer = new WhereRenderer(
+            options.metadata,
+            resolveProviderOptions(options.provider),
+        );
+    }
+
+    // -----------------------------------------------------------
+
+    execute(
+        query: IQuery,
+        options: ExecuteOptions<ARGS> = {},
+    ) : PrismaAdapterOutput<ARGS> {
+        const base = options.base as Args | undefined;
+        const args = { ...(base || {}) } as Args;
+
+        const filters = this.renderer.build(
+            query.filters,
+            options.filters || this.options.filters || {},
+        );
+
+        const where = this.buildWhere(filters, base?.where);
+        if (where) {
+            args.where = where;
+        }
+
+        this.applySelection(
+            args,
+            buildSelection(query.fields, collectRelationPaths(query.relations)),
+            base,
+        );
+
+        const orderBy = buildOrderBy(query.sorts);
+        if (orderBy.length > 0) {
+            args.orderBy = orderBy;
+        }
+
+        // a query without pagination leaves caller-owned take/skip
+        // untouched. Nullish (not falsy) checks: an explicit 0 is a
+        // value, not absence.
+        const { limit, offset } = query.pagination;
+
+        if (typeof limit !== 'undefined') {
+            args.take = limit;
+        }
+
+        if (typeof offset !== 'undefined') {
+            args.skip = offset;
+        }
+
+        return {
+            args: args as ARGS,
+            pagination: { limit, offset },
+        };
+    }
+
+    visitQuery(expr: IQuery) : PrismaAdapterOutput<ARGS> {
+        return this.execute(expr);
+    }
+
+    // -----------------------------------------------------------
+
+    protected buildWhere(
+        filters: { where?: Where, impossible: boolean },
+        base?: Where,
+    ) : Where | undefined {
+        if (filters.impossible) {
+            // `{ OR: [] }` is prisma's `1 = 0`, but only at the root;
+            // a nested empty group is stripped. Sibling operator keys
+            // are conjoined, so a caller-owned predicate rides along
+            // instead of being dropped.
+            return base ? { OR: [], AND: [base] } : { OR: [] };
+        }
+
+        const { where } = filters;
+
+        if (!where) {
+            return base;
+        }
+
+        if (!base) {
+            return where;
+        }
+
+        // rapiq filters narrow the query; they never replace an
+        // application-owned tenant or authorization predicate.
+        return { AND: [base, where] };
+    }
+
+    /**
+     * Prisma rejects `select` next to `include` (and next to `omit`)
+     * on the same level, so exactly one of them survives.
+     *
+     * A baseline `select` is a deliberate projection restriction and
+     * is therefore never dropped: relations the query hydrates join
+     * it instead. Widening a caller-owned projection would expose
+     * columns the application chose to withhold.
+     */
+    protected applySelection(
+        args: Args,
+        selection: { select?: Record<string, any>, include?: Record<string, any> },
+        base?: Args,
+    ) : void {
+        if (selection.select) {
+            args.select = selection.select;
+            delete args.include;
+            delete (args as Record<string, unknown>).omit;
+
+            return;
+        }
+
+        if (!selection.include) {
+            return;
+        }
+
+        if (base && base.select) {
+            args.select = { ...base.select, ...selection.include };
+            delete args.include;
+            delete (args as Record<string, unknown>).omit;
+
+            return;
+        }
+
+        args.include = selection.include;
+        delete args.select;
+    }
+}
+
+// -----------------------------------------------------------
+
+/**
+ * One-shot convenience over {@link PrismaAdapter}.
+ */
+export function buildPrismaArgs<ARGS extends Args = Args>(
+    query: IQuery,
+    options: PrismaAdapterOptions & ExecuteOptions<ARGS>,
+) : PrismaAdapterOutput<ARGS> {
+    return new PrismaAdapter<ARGS>(options).execute(query, options);
+}

--- a/packages/prisma/src/adapter/relations.ts
+++ b/packages/prisma/src/adapter/relations.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IRelations } from '@rapiq/core';
+
+/**
+ * Canonical relation paths a query hydrates, parents included and
+ * deduplicated, e.g. `['items', 'items.realm']`.
+ *
+ * Unlike the SQL backends there are no join aliases to derive:
+ * prisma addresses relations positionally through nested
+ * `include`/`select`, so paths are all the selection needs.
+ */
+export function collectRelationPaths(relations: IRelations) : string[] {
+    const output : string[] = [];
+
+    for (const relation of relations.value) {
+        const segments = relation.name.split('.');
+
+        for (let i = 0; i < segments.length; i++) {
+            const current = segments.slice(0, i + 1).join('.');
+
+            if (!output.includes(current)) {
+                output.push(current);
+            }
+        }
+    }
+
+    return output;
+}

--- a/packages/prisma/src/adapter/sort.ts
+++ b/packages/prisma/src/adapter/sort.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ISorts } from '@rapiq/core';
+import { SortDirection } from '@rapiq/core';
+
+/**
+ * The `orderBy` argument as an **array** of single-key objects, the
+ * only form in which prisma honors the order of multiple sort keys.
+ *
+ * Relation paths nest (`{ realm: { name: 'asc' } }`). Prisma can only
+ * order by a to-one relation's scalar (a to-many supports `_count`
+ * alone), so a to-many path is emitted as written and rejected by
+ * prisma rather than silently reinterpreted. Duplicate keys keep
+ * their first occurrence, mirroring the keyed collapse of the SQL
+ * adapters.
+ */
+export function buildOrderBy(sorts: ISorts) : Record<string, any>[] {
+    const output : Record<string, any>[] = [];
+    const seen = new Set<string>();
+
+    for (const sort of sorts.value) {
+        if (seen.has(sort.name)) {
+            continue;
+        }
+
+        seen.add(sort.name);
+
+        const direction = sort.operator === SortDirection.DESC ? 'desc' : 'asc';
+        const segments = sort.name.split('.');
+
+        let entry : Record<string, any> = { [segments[segments.length - 1] as string]: direction };
+
+        for (let i = segments.length - 2; i >= 0; i--) {
+            entry = { [segments[i] as string]: entry };
+        }
+
+        output.push(entry);
+    }
+
+    return output;
+}

--- a/packages/prisma/src/adapter/types.ts
+++ b/packages/prisma/src/adapter/types.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IMetadata } from '../metadata';
+import type { Provider, ProviderOptions } from '../provider';
+
+/**
+ * A prisma `where` input: an untyped record by construction, since
+ * the adapter emits plain objects and never imports prisma's
+ * generated types.
+ */
+export type Where = Record<string, any>;
+
+/**
+ * The subset of a `findMany` argument object rapiq populates.
+ * Assignable to the generated `Prisma.<Model>FindManyArgs`; bind that
+ * type through {@link PrismaAdapter}'s type parameter to keep the
+ * call site checked.
+ */
+export type Args = {
+    where?: Where,
+    select?: Record<string, any>,
+    include?: Record<string, any>,
+    orderBy?: Record<string, any>[],
+    take?: number,
+    skip?: number,
+};
+
+// -----------------------------------------------------------
+
+export type FiltersAdapterOptions = {
+    /**
+     * Field keys whose equality comparisons (eq/ne/in/nin) stay
+     * case-sensitive instead of the case-insensitive default.
+     * Typically forwarded from a schema's `filters.caseSensitive`.
+     */
+    caseSensitive?: string[] | boolean,
+};
+
+export type PrismaAdapterOptions = {
+    /**
+     * Datasource provider of the targeted prisma client, or an
+     * explicit capability preset. Decides whether
+     * `mode: 'insensitive'` may be emitted; a wrong answer is a
+     * prisma validation error on every case-insensitive filter, so
+     * there is no default to guess.
+     */
+    provider: `${Provider}` | ProviderOptions,
+
+    /**
+     * Model metadata: which paths are relations, which of those are
+     * to-many, which columns can hold null and which hold strings.
+     * Build it from a prisma datamodel with `defineMetadata()`.
+     *
+     * Required: the adapter is bound to one model anyway, and every
+     * one of these facts changes what a valid prisma filter looks
+     * like. Guessing them produces runtime validation errors, not
+     * graceful degradation.
+     */
+    metadata: IMetadata,
+
+    filters?: FiltersAdapterOptions,
+};
+
+// -----------------------------------------------------------
+
+export type ExecuteOptions<ARGS extends Args = Args> = {
+    /**
+     * Application-owned baseline arguments, e.g. a tenant or
+     * authorization scope. The rapiq `where` is **conjoined** with
+     * `base.where`, never substituted for it; every other baseline
+     * key survives unless the query produces one itself.
+     */
+    base?: ARGS,
+
+    filters?: FiltersAdapterOptions,
+};
+
+export type PrismaAdapterOutput<ARGS extends Args = Args> = {
+    /**
+     * The argument object to hand to `prisma.<model>.findMany()`.
+     */
+    args: ARGS,
+
+    /**
+     * The pagination actually applied, e.g. for the response meta
+     * block.
+     */
+    pagination: {
+        limit: number | undefined,
+        offset: number | undefined,
+    },
+};

--- a/packages/prisma/src/adapter/where.ts
+++ b/packages/prisma/src/adapter/where.ts
@@ -1,0 +1,855 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    ComparePlan,
+    ConditionPlan,
+    ElemMatchPlan,
+    ICondition,
+    MatchPlan,
+    NullCheckPlan,
+    OneOfPlan,
+} from '@rapiq/core';
+import {
+    AdapterError,
+    distributeNegation,
+    planCondition,
+} from '@rapiq/core';
+import type { IMetadata } from '../metadata';
+import type { ProviderOptions } from '../provider';
+import type { FiltersAdapterOptions, Where } from './types';
+
+/**
+ * A folded verdict short-circuits rendering: `in([])` matches
+ * nothing, `nin([])` matches everything. Keeping constants out of the
+ * emitted object matters because prisma strips empty groups below the
+ * root; a nested `{ OR: [] }` would silently widen the query.
+ */
+type Result = Where | boolean;
+
+type Context = {
+    metadata: IMetadata,
+    provider: ProviderOptions,
+
+    /**
+     * Absolute path prefix of the current quantifier scope, for
+     * metadata lookups.
+     */
+    base: string,
+
+    /**
+     * Leaf fields inside a factored scope still carry their original
+     * dotted path; this prefix is removed before rendering.
+     */
+    strip: string,
+};
+
+type Atom = {
+    plan: ConditionPlan,
+    key: string,
+};
+
+/**
+ * Ceiling on the number of conjuncts a mixed tree may expand to while
+ * factoring quantifiers. Wire filters are tiny; a tree that exceeds
+ * this is adversarial, and failing typed beats a silent semantic
+ * downgrade.
+ */
+const EXPANSION_LIMIT = 64;
+
+const MATCH_OPERATORS = {
+    starts: 'startsWith',
+    ends: 'endsWith',
+    contains: 'contains',
+} as const;
+
+/**
+ * `mode: 'insensitive'` lowers `equals` (and its scalar `not`) to
+ * `ILIKE` with the operand passed through verbatim, so `%` and `_`
+ * silently become wildcards (prisma#20318, #10810). Measured on
+ * postgres 18 / prisma 6.19.3: `equals` wildcards, `in`/`notIn` never
+ * do. The veto therefore applies to the equality family only; values
+ * carrying either character keep the exact comparison, matching too
+ * little rather than too much.
+ */
+const LIKE_WILDCARD = /[%_]/;
+
+// -----------------------------------------------------------
+
+function join(base: string, path: string) : string {
+    if (!base) {
+        return path;
+    }
+
+    return path ? `${base}.${path}` : base;
+}
+
+function andCombine(results: Result[]) : Result {
+    const parts : Where[] = [];
+
+    for (const result of results) {
+        if (result === false) {
+            return false;
+        }
+
+        if (result !== true) {
+            parts.push(result);
+        }
+    }
+
+    if (parts.length === 0) {
+        return true;
+    }
+
+    if (parts.length === 1) {
+        return parts[0] as Where;
+    }
+
+    return { AND: parts };
+}
+
+function orCombine(results: Result[]) : Result {
+    const parts : Where[] = [];
+
+    for (const result of results) {
+        if (result === true) {
+            return true;
+        }
+
+        if (result !== false) {
+            parts.push(result);
+        }
+    }
+
+    if (parts.length === 0) {
+        return false;
+    }
+
+    if (parts.length === 1) {
+        return parts[0] as Where;
+    }
+
+    return { OR: parts };
+}
+
+// -----------------------------------------------------------
+
+/**
+ * Renders a condition tree into a prisma `where` object, preserving
+ * the cross-backend semantics contract:
+ *
+ * - negation is eliminated up front by the core `distributeNegation`
+ *   transform, so this renderer only ever sees leaves in their final
+ *   (possibly complemented) form; prisma's three-valued `not`/`NOT`
+ *   is never relied upon,
+ * - relation traversal quantifies existentially with the quantifier
+ *   outermost, exactly like a left join evaluated per row
+ *   (`@rapiq/sql`) or a binding enumeration (`@rapiq/memory`),
+ * - conditions sharing a to-many path within a conjunction bind to
+ *   the SAME element: they are factored into one `some` scope (mixed
+ *   trees are expanded to reach that form; `∃` distributes over OR,
+ *   so disjunctions need no factoring),
+ * - an empty collection contributes exactly one all-null binding
+ *   (the left join's null row): every quantifier gains a
+ *   `{ none: {} }` arm precisely when its interior holds at that
+ *   binding, and every to-one hop an absence arm under the same rule.
+ */
+export class WhereRenderer {
+    protected metadata : IMetadata;
+
+    protected provider : ProviderOptions;
+
+    constructor(metadata: IMetadata, provider: ProviderOptions) {
+        this.metadata = metadata;
+        this.provider = provider;
+    }
+
+    // -----------------------------------------------------------
+
+    build(condition: ICondition, options: FiltersAdapterOptions = {}) : {
+        where?: Where,
+        impossible: boolean,
+    } {
+        const plan = planCondition(condition, { caseSensitive: options.caseSensitive });
+        if (!plan) {
+            return { impossible: false };
+        }
+
+        const result = this.render(distributeNegation(plan), {
+            metadata: this.metadata,
+            provider: this.provider,
+            base: '',
+            strip: '',
+        });
+
+        if (result === true) {
+            return { impossible: false };
+        }
+
+        if (result === false) {
+            return { impossible: true };
+        }
+
+        return { where: result, impossible: false };
+    }
+
+    // -----------------------------------------------------------
+
+    protected render(plan: ConditionPlan, ctx: Context) : Result {
+        switch (plan.kind) {
+            case 'constant': {
+                return plan.verdict;
+            }
+            case 'compound': {
+                if (plan.negated) {
+                    // a residual wrapper only ever encloses kinds
+                    // without a complement form; rendering the child
+                    // raises the matching typed error.
+                    return this.render(plan.children[0] as ConditionPlan, ctx);
+                }
+
+                if (plan.operator === 'or') {
+                    // ∃ distributes over OR, so disjuncts never share
+                    // a binding and render independently.
+                    return orCombine(plan.children.map((child) => this.render(child, ctx)));
+                }
+
+                return this.renderAnd(plan.children, ctx);
+            }
+            case 'elem-match': {
+                return this.renderElemMatch(plan, ctx);
+            }
+            default: {
+                return this.renderLeaf(plan, ctx);
+            }
+        }
+    }
+
+    /**
+     * A conjunction is where bindings are shared: conditions on one
+     * to-many path must land in one `some` scope. Children mixing
+     * quantifier keys are expanded to disjunctive form first, so each
+     * conjunct groups cleanly.
+     */
+    protected renderAnd(children: ConditionPlan[], ctx: Context) : Result {
+        const flattened : ConditionPlan[] = [];
+        for (const child of children) {
+            if (child.kind === 'compound' && !child.negated && child.operator === 'and') {
+                flattened.push(...child.children);
+            } else {
+                flattened.push(child);
+            }
+        }
+
+        const pure : Atom[] = [];
+        const mixed : ConditionPlan[] = [];
+
+        const seen = new Set<string>();
+
+        for (const child of flattened) {
+            const keys = this.keysOf(child, ctx);
+            keys.forEach((key) => seen.add(key));
+
+            if (keys.size <= 1) {
+                pure.push({ plan: child, key: keys.values().next().value ?? '' });
+            } else {
+                mixed.push(child);
+            }
+        }
+
+        if (mixed.length === 0) {
+            return this.renderConjunct(pure, ctx);
+        }
+
+        // a mixed child shares a binding with a sibling only through a
+        // non-root key that occurs elsewhere too; otherwise it factors
+        // internally on its own.
+        const shared = mixed.some((child) => {
+            const keys = this.keysOf(child, ctx);
+
+            for (const key of keys) {
+                if (!key) {
+                    continue;
+                }
+
+                const elsewhere = pure.some((atom) => atom.key === key) ||
+                    mixed.some((other) => other !== child && this.keysOf(other, ctx).has(key));
+
+                if (elsewhere) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        if (!shared) {
+            return andCombine([
+                this.renderConjunct(pure, ctx),
+                ...mixed.map((child) => this.render(child, ctx)),
+            ]);
+        }
+
+        const conjuncts = this.expand(flattened, ctx);
+
+        return orCombine(conjuncts.map((conjunct) => this.renderConjunct(conjunct, ctx)));
+    }
+
+    /**
+     * Disjunctive expansion of a conjunction whose children cross
+     * quantifier scopes: the standard identity
+     * `a ∧ (b ∨ c) = (a ∧ b) ∨ (a ∧ c)`, applied only as far as
+     * needed: subtrees confined to a single key stay opaque atoms.
+     */
+    protected expand(children: ConditionPlan[], ctx: Context) : Atom[][] {
+        let conjuncts : Atom[][] = [[]];
+
+        for (const child of children) {
+            const branches = this.branchesOf(child, ctx);
+
+            const next : Atom[][] = [];
+            for (const conjunct of conjuncts) {
+                for (const branch of branches) {
+                    next.push([...conjunct, ...branch]);
+                }
+            }
+
+            if (next.length > EXPANSION_LIMIT) {
+                throw AdapterError.featureUnsupported('filters:complexity');
+            }
+
+            conjuncts = next;
+        }
+
+        return conjuncts;
+    }
+
+    protected branchesOf(plan: ConditionPlan, ctx: Context) : Atom[][] {
+        const keys = this.keysOf(plan, ctx);
+
+        if (keys.size <= 1) {
+            return [[{ plan, key: keys.values().next().value ?? '' }]];
+        }
+
+        // only compounds can mix keys
+        const compound = plan as Extract<ConditionPlan, { kind: 'compound' }>;
+
+        if (compound.operator === 'or') {
+            const output : Atom[][] = [];
+            for (const child of compound.children) {
+                output.push(...this.branchesOf(child, ctx));
+            }
+
+            return output;
+        }
+
+        let conjuncts : Atom[][] = [[]];
+        for (const child of compound.children) {
+            const branches = this.branchesOf(child, ctx);
+
+            const next : Atom[][] = [];
+            for (const conjunct of conjuncts) {
+                for (const branch of branches) {
+                    next.push([...conjunct, ...branch]);
+                }
+            }
+
+            if (next.length > EXPANSION_LIMIT) {
+                throw AdapterError.featureUnsupported('filters:complexity');
+            }
+
+            conjuncts = next;
+        }
+
+        return conjuncts;
+    }
+
+    protected renderConjunct(atoms: Atom[], ctx: Context) : Result {
+        const parts : Result[] = [];
+        const groups = new Map<string, ConditionPlan[]>();
+
+        for (const atom of atoms) {
+            if (!atom.key) {
+                parts.push(this.render(atom.plan, ctx));
+                continue;
+            }
+
+            const group = groups.get(atom.key) ?? [];
+            group.push(atom.plan);
+            groups.set(atom.key, group);
+        }
+
+        groups.forEach((plans, key) => {
+            parts.push(this.factor(key, plans, ctx));
+        });
+
+        return andCombine(parts);
+    }
+
+    /**
+     * One `some` scope for every plan sharing the quantifier path:
+     * the same-element binding of a left join, where each join row is
+     * tested against ALL conditions at once.
+     */
+    protected factor(path: string, plans: ConditionPlan[], ctx: Context) : Result {
+        const segments = path.split('.');
+        const name = segments.pop() as string;
+
+        const scoped : Context = {
+            ...ctx,
+            base: join(ctx.base, path),
+            strip: `${ctx.strip}${path}.`,
+        };
+
+        const interior = andCombine(plans.map((plan) => this.render(plan, scoped)));
+        const matchesNull = plans.every((plan) => this.evalAtNull(plan));
+
+        let node : Result;
+        if (interior === false) {
+            node = false;
+        } else {
+            node = { [name]: { some: interior === true ? {} : interior } };
+        }
+
+        if (matchesNull) {
+            // the empty collection: its left join contributes exactly
+            // one all-null row, and the interior holds there.
+            node = orCombine([node, { [name]: { none: {} } }]);
+        }
+
+        return this.wrapToOne(segments, node, matchesNull, ctx);
+    }
+
+    /**
+     * Wrap leading to-one segments (`is`), adding the absence arm
+     * when the interior holds at a null binding: an absent relation
+     * is the same all-null row a left join produces.
+     */
+    protected wrapToOne(
+        segments: string[],
+        node: Result,
+        matchesNull: boolean,
+        _ctx: Context,
+    ) : Result {
+        let current = node;
+
+        for (let i = segments.length - 1; i >= 0; i--) {
+            const name = segments[i] as string;
+
+            let branch : Result;
+            if (current === false) {
+                branch = false;
+            } else {
+                branch = { [name]: { is: current === true ? {} : current } };
+            }
+
+            if (matchesNull) {
+                current = orCombine([branch, { NOT: { [name]: { is: {} } } }]);
+            } else {
+                current = branch;
+            }
+        }
+
+        return current;
+    }
+
+    // -----------------------------------------------------------
+
+    protected renderElemMatch(plan: ElemMatchPlan, ctx: Context) : Result {
+        const relative = this.stripField(plan.field, ctx);
+        const absolute = join(ctx.base, relative);
+
+        const segments = relative.split('.');
+        const name = segments.pop() as string;
+
+        // walk any to-many prefix through the ordinary factoring path
+        const key = this.keyOfPath(relative, ctx);
+        if (key && key !== relative) {
+            return this.factor(key, [plan], ctx);
+        }
+
+        if (this.metadata.isToMany(absolute) === false && this.metadata.isRelation(absolute)) {
+            // elemMatch quantifies over elements; a to-one relation
+            // has none, and prisma's own error for a `some` on it is
+            // misleading.
+            throw AdapterError.featureUnsupported('filters:elemMatch');
+        }
+
+        const scoped : Context = {
+            ...ctx, 
+            base: absolute, 
+            strip: '',
+        };
+
+        const interior = this.render(plan.condition, scoped);
+        const matchesNull = this.evalAtNull(plan);
+
+        let node : Result;
+        if (interior === false) {
+            node = false;
+        } else {
+            node = { [name]: { some: interior === true ? {} : interior } };
+        }
+
+        if (matchesNull) {
+            node = orCombine([node, { [name]: { none: {} } }]);
+        }
+
+        return this.wrapToOne(segments, node, matchesNull, ctx);
+    }
+
+    protected renderLeaf(plan: ConditionPlan, ctx: Context) : Result {
+        const leaf = plan as Exclude<ConditionPlan, { kind: 'compound' | 'constant' | 'elem-match' }>;
+        const relative = this.stripField(leaf.field, ctx);
+        const absolute = join(ctx.base, relative);
+
+        // a null check on the relation itself addresses the value as
+        // a whole, not its elements.
+        if (leaf.kind === 'null-check' && this.metadata.isRelation(absolute)) {
+            if (this.metadata.isToMany(absolute)) {
+                // a collection is always present: possibly empty,
+                // never absent, matching @rapiq/memory.
+                return leaf.negated;
+            }
+
+            const present = this.presence(relative, ctx);
+
+            return leaf.negated ? present : { NOT: present as Where };
+        }
+
+        const key = this.keyOfPath(relative, ctx);
+        if (key) {
+            return this.factor(key, [leaf], ctx);
+        }
+
+        const segments = relative.split('.');
+        const name = segments.pop() as string;
+
+        return this.wrapToOne(
+            segments,
+            this.renderLiteral(leaf, name, absolute),
+            this.evalAtNull(leaf),
+            ctx,
+        );
+    }
+
+    /**
+     * "The relation path exists": every hop as a plain presence test,
+     * two-valued by construction and therefore safe under `NOT`.
+     */
+    protected presence(path: string, ctx: Context) : Result {
+        const segments = path.split('.');
+
+        let node : Result = true;
+
+        for (let i = segments.length - 1; i >= 0; i--) {
+            const name = segments[i] as string;
+            const absolute = join(ctx.base, segments.slice(0, i + 1).join('.'));
+
+            const interior : Where = node === true ? {} : node as Where;
+
+            if (this.metadata.isToMany(absolute)) {
+                node = { [name]: { some: interior } };
+            } else {
+                node = { [name]: { is: interior } };
+            }
+        }
+
+        return node;
+    }
+
+    // -----------------------------------------------------------
+
+    protected renderLiteral(
+        plan: Exclude<ConditionPlan, { kind: 'compound' | 'constant' | 'elem-match' }>,
+        name: string,
+        absolute: string,
+    ) : Result {
+        switch (plan.kind) {
+            case 'null-check': {
+                return this.renderNullCheck(plan, name, absolute);
+            }
+            case 'compare': {
+                return this.renderCompare(plan, name, absolute);
+            }
+            case 'one-of': {
+                return this.renderOneOf(plan, name, absolute);
+            }
+            case 'match': {
+                return this.renderMatch(plan, name, absolute);
+            }
+            default: {
+                // mod, size: no prisma operator exists.
+                throw AdapterError.featureUnsupported(`filters:${plan.kind}`);
+            }
+        }
+    }
+
+    protected renderNullCheck(plan: NullCheckPlan, name: string, absolute: string) : Result {
+        // a column that cannot hold null decides the check; prisma
+        // would reject the comparison outright.
+        if (this.metadata.isNullable(absolute) === false) {
+            return plan.negated;
+        }
+
+        return plan.negated ?
+            { [name]: { not: null } } :
+            { [name]: null };
+    }
+
+    protected renderCompare(plan: ComparePlan, name: string, absolute: string) : Result {
+        if (plan.op !== 'eq') {
+            // ordering never carries negation after distribution: its
+            // complement became the dual operator or a null check.
+            return { [name]: { [plan.op]: plan.value } };
+        }
+
+        const mode = this.buildMode(absolute, plan.caseFold, [plan.value]);
+
+        if (plan.negated) {
+            return this.orNull(
+                name,
+                { [name]: { not: plan.value, ...mode } },
+                absolute,
+            );
+        }
+
+        return { [name]: { equals: plan.value, ...mode } };
+    }
+
+    /**
+     * The in/nin four-case contract: a null member also matches the
+     * absence of a value, and the negated form is the exact
+     * complement; prisma's `in`/`notIn` accept no null member and
+     * skip null rows on their own.
+     */
+    protected renderOneOf(plan: OneOfPlan, name: string, absolute: string) : Result {
+        // no wildcard veto here: `in`/`notIn` are never lowered to
+        // ILIKE, so they stay case-insensitive even for values
+        // carrying % or _.
+        const mode = this.buildMode(
+            absolute,
+            plan.caseFold && plan.values.some((value) => typeof value === 'string'),
+        );
+
+        const positive = { [name]: { in: plan.values, ...mode } };
+        const negative = { [name]: { notIn: plan.values, ...mode } };
+
+        if (plan.includesNull) {
+            if (plan.negated) {
+                return this.andNotNull(name, negative, absolute);
+            }
+
+            if (this.metadata.isNullable(absolute) === false) {
+                // the null member is dead on a required column, and
+                // prisma rejects the comparison there.
+                return positive;
+            }
+
+            return { OR: [positive, { [name]: null }] };
+        }
+
+        if (plan.negated) {
+            return this.orNull(name, negative, absolute);
+        }
+
+        return positive;
+    }
+
+    protected renderMatch(plan: MatchPlan, name: string, absolute: string) : Result {
+        if (plan.pattern.mode === 'regex') {
+            // prisma exposes no regular-expression filter on any
+            // connector; the anchored operators map natively instead.
+            throw AdapterError.featureUnsupported('filters:regex');
+        }
+
+        const operator = MATCH_OPERATORS[plan.pattern.mode];
+        const { text } = plan.pattern;
+        const mode = this.buildMode(absolute, plan.ignoreCase);
+
+        if (plan.negated) {
+            // `mode` is a sibling of `not`, never nested inside it:
+            // the nested filter input carries no mode member, but the
+            // outer one is applied into the negated subtree.
+            return this.orNull(
+                name,
+                { [name]: { not: { [operator]: text }, ...mode } },
+                absolute,
+            );
+        }
+
+        return { [name]: { [operator]: text, ...mode } };
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * Whether the plan holds at the all-null binding an empty
+     * collection (or absent to-one relation) contributes; decides the
+     * `{ none: {} }` and absence arms. Deliberately independent of
+     * column nullability: a left join produces null for non-nullable
+     * columns too.
+     */
+    protected evalAtNull(plan: ConditionPlan) : boolean {
+        switch (plan.kind) {
+            case 'constant': {
+                return plan.verdict;
+            }
+            case 'compound': {
+                if (plan.negated) {
+                    return false;
+                }
+
+                if (plan.operator === 'or') {
+                    return plan.children.some((child) => this.evalAtNull(child));
+                }
+
+                return plan.children.every((child) => this.evalAtNull(child));
+            }
+            case 'null-check': {
+                return !plan.negated;
+            }
+            case 'compare': {
+                return plan.op === 'eq' && plan.negated;
+            }
+            case 'one-of': {
+                return plan.negated ? !plan.includesNull : plan.includesNull;
+            }
+            case 'match': {
+                return plan.negated;
+            }
+            case 'elem-match': {
+                // a null collection contributes one null binding of
+                // its own, matching @rapiq/memory.
+                return this.evalAtNull(plan.condition);
+            }
+            default: {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Quantifier key of a leaf path, the prefix up to and including
+     * the first to-many segment, or the empty string for paths that
+     * traverse none. Leaves sharing a key share a binding.
+     */
+    protected keyOfPath(relative: string, ctx: Context) : string {
+        const segments = relative.split('.');
+
+        // the final segment is the addressed value, not a hop:
+        // except when the leaf addresses through it (dotted).
+        for (let i = 0; i < segments.length - 1; i++) {
+            const prefix = segments.slice(0, i + 1).join('.');
+
+            if (this.metadata.isToMany(join(ctx.base, prefix))) {
+                return prefix;
+            }
+        }
+
+        return '';
+    }
+
+    protected keysOf(plan: ConditionPlan, ctx: Context) : Set<string> {
+        switch (plan.kind) {
+            case 'compound': {
+                const output = new Set<string>();
+
+                for (const child of plan.children) {
+                    this.keysOf(child, ctx).forEach((key) => output.add(key));
+                }
+
+                return output;
+            }
+            case 'constant': {
+                return new Set();
+            }
+            case 'elem-match': {
+                // an elemMatch opens its own quantifier scope and
+                // never shares a binding, so it behaves like a root
+                // atom unless its own path traverses a to-many first.
+                const key = this.keyOfPath(this.stripField(plan.field, ctx), ctx);
+
+                return new Set([key && key !== this.stripField(plan.field, ctx) ? key : '']);
+            }
+            default: {
+                const leaf = plan as Extract<ConditionPlan, { field: string }>;
+
+                if (
+                    plan.kind === 'null-check' &&
+                    this.metadata.isRelation(join(ctx.base, this.stripField(leaf.field, ctx)))
+                ) {
+                    // addresses the relation value itself, no binding
+                    return new Set(['']);
+                }
+
+                return new Set([this.keyOfPath(this.stripField(leaf.field, ctx), ctx)]);
+            }
+        }
+    }
+
+    protected stripField(field: string, ctx: Context) : string {
+        if (ctx.strip && field.startsWith(ctx.strip)) {
+            return field.slice(ctx.strip.length);
+        }
+
+        return field;
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * The case-fold policy verdict from the core lowering, narrowed
+     * by the capability vetoes, the connector must accept
+     * `mode: 'insensitive'`, the column must hold strings, and (for
+     * the equality family only) no value may carry a LIKE wildcard.
+     */
+    protected buildMode(
+        absolute: string,
+        caseFold: boolean,
+        values?: unknown[],
+    ) : Record<string, string> {
+        if (!caseFold || !this.provider.caseInsensitiveMode) {
+            return {};
+        }
+
+        if (this.metadata.isString(absolute) === false) {
+            return {};
+        }
+
+        if (
+            values &&
+            values.some((value) => typeof value === 'string' && LIKE_WILDCARD.test(value))
+        ) {
+            return {};
+        }
+
+        return { mode: 'insensitive' };
+    }
+
+    /**
+     * The null arm that makes a negated leaf the exact complement of
+     * its positive twin, dropped when the column provably never holds
+     * null (prisma rejects the comparison there, and no null can
+     * exist).
+     */
+    protected orNull(name: string, where: Where, absolute: string) : Where {
+        if (this.metadata.isNullable(absolute) === false) {
+            return where;
+        }
+
+        return { OR: [where, { [name]: null }] };
+    }
+
+    protected andNotNull(name: string, where: Where, absolute: string) : Where {
+        if (this.metadata.isNullable(absolute) === false) {
+            return where;
+        }
+
+        return { AND: [where, { [name]: { not: null } }] };
+    }
+}

--- a/packages/prisma/src/index.ts
+++ b/packages/prisma/src/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './adapter';
+export * from './metadata';
+export * from './provider';

--- a/packages/prisma/src/metadata/index.ts
+++ b/packages/prisma/src/metadata/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';
+export * from './types';

--- a/packages/prisma/src/metadata/module.ts
+++ b/packages/prisma/src/metadata/module.ts
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError, ErrorCode } from '@rapiq/core';
+import type {
+    Datamodel,
+    DatamodelField,
+    DatamodelModel,
+    IMetadata,
+} from './types';
+
+const RELATION_KIND = 'object';
+
+const STRING_TYPE = 'String';
+
+/**
+ * Answers the adapter's two metadata questions from a prisma
+ * datamodel (`Prisma.dmmf.datamodel`) by walking dotted paths
+ * segment by segment. Unknown segments answer `undefined`, never a
+ * guess.
+ */
+export class Metadata implements IMetadata {
+    protected models : Map<string, DatamodelModel>;
+
+    protected root : string;
+
+    constructor(datamodel: Datamodel, model: string) {
+        this.models = new Map();
+        this.root = model;
+
+        for (const item of datamodel.models) {
+            this.models.set(item.name, item);
+        }
+
+        // a misspelled root (prisma models are PascalCase, the client
+        // accessors are not) would answer "unknown" to every question
+        // and silently degrade the adapter to its defaults.
+        if (!this.models.has(model)) {
+            throw new AdapterError({
+                message: `The model "${model}" is not part of the datamodel.`,
+                code: ErrorCode.SCHEMA_UNRESOLVABLE,
+            });
+        }
+    }
+
+    // -----------------------------------------------------------
+
+    isRelation(path: string) : boolean | undefined {
+        const field = this.resolve(path);
+        if (!field) {
+            return undefined;
+        }
+
+        return field.kind === RELATION_KIND;
+    }
+
+    isToMany(path: string) : boolean | undefined {
+        const field = this.resolve(path);
+        if (!field || field.kind !== RELATION_KIND) {
+            return undefined;
+        }
+
+        return field.isList;
+    }
+
+    isString(path: string) : boolean | undefined {
+        const field = this.resolve(path);
+        if (!field || field.kind === RELATION_KIND) {
+            return undefined;
+        }
+
+        return field.type === STRING_TYPE;
+    }
+
+    isNullable(path: string) : boolean | undefined {
+        const field = this.resolve(path);
+        if (!field || typeof field.isRequired !== 'boolean') {
+            // a pruned datamodel (edge/wasm builds) drops the flag:
+            // unknown, never assumed.
+            return undefined;
+        }
+
+        return !field.isRequired;
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * Resolve a dotted path to its field descriptor: every segment but
+     * the last must be a relation field, and each hop switches to the
+     * related model.
+     */
+    protected resolve(path: string) : DatamodelField | undefined {
+        const segments = path.split('.');
+
+        let model = this.models.get(this.root);
+        let field : DatamodelField | undefined;
+
+        for (let i = 0; i < segments.length; i++) {
+            if (!model) {
+                return undefined;
+            }
+
+            field = model.fields.find((item) => item.name === segments[i]);
+            if (!field) {
+                return undefined;
+            }
+
+            if (i === segments.length - 1) {
+                return field;
+            }
+
+            if (field.kind !== RELATION_KIND) {
+                return undefined;
+            }
+
+            model = this.models.get(field.type);
+        }
+
+        return undefined;
+    }
+}
+
+/**
+ * Bind a prisma datamodel to the model a query targets.
+ *
+ * ```typescript
+ * import { Prisma } from '@prisma/client';
+ *
+ * const metadata = defineMetadata(Prisma.dmmf.datamodel, 'User');
+ * ```
+ */
+export function defineMetadata(datamodel: Datamodel, model: string) : Metadata {
+    return new Metadata(datamodel, model);
+}

--- a/packages/prisma/src/metadata/types.ts
+++ b/packages/prisma/src/metadata/types.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Structural subset of a prisma DMMF field. Declared locally so this
+ * package never imports from `@prisma/client`: `Prisma.dmmf.datamodel`
+ * is assignable to {@link Datamodel} as-is, and a hand-written literal
+ * works just as well.
+ */
+export type DatamodelField = {
+    name: string,
+
+    /**
+     * `'object'` marks a relation field; scalars and enums address
+     * columns.
+     */
+    kind: string,
+
+    /**
+     * Relation fields: to-many. Scalars: a scalar list.
+     */
+    isList: boolean,
+
+    /**
+     * Inverse of nullability: a required field can never hold null.
+     */
+    isRequired: boolean,
+
+    /**
+     * Scalar type name (`'String'`, `'Int'`, …) or, for relation
+     * fields, the related model name.
+     */
+    type: string,
+};
+
+export type DatamodelModel = {
+    name: string,
+    fields: DatamodelField[],
+};
+
+export type Datamodel = {
+    models: DatamodelModel[],
+};
+
+/**
+ * What the adapter needs to know about the targeted model. Every
+ * question may answer `undefined` for "unknown": the adapter then
+ * falls back to its documented default instead of guessing silently.
+ */
+export interface IMetadata {
+    /**
+     * Whether the addressed path is a relation rather than a column.
+     * A relation accepts only `is`/`isNot`/`some`/`every`/`none`, so a
+     * null check on one must be expressed as presence, not as a null
+     * comparison.
+     */
+    isRelation(path: string): boolean | undefined;
+
+    /**
+     * Whether the relation addressed by a dotted path is to-many
+     * (`some`/`none`) rather than to-one (`is`).
+     */
+    isToMany(path: string): boolean | undefined;
+
+    /**
+     * Whether the field addressed by a dotted path holds strings and
+     * may therefore participate in case-insensitive comparison. The
+     * capability veto on the fold policy: the direct analogue of the
+     * `@rapiq/typeorm` column-type check.
+     */
+    isString(path: string): boolean | undefined;
+
+    /**
+     * Whether the field addressed by a dotted path can hold null.
+     *
+     * Load-bearing: the null-inclusive complement of a negated
+     * operator adds a `{ field: null }` arm, and prisma rejects that
+     * arm on a required column with a validation error. Known-required
+     * fields drop the arm: semantically identical, since no null can
+     * exist there.
+     */
+    isNullable(path: string): boolean | undefined;
+}

--- a/packages/prisma/src/provider/constants.ts
+++ b/packages/prisma/src/provider/constants.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ProviderOptions } from './types';
+
+/**
+ * Datasource providers a prisma schema can declare.
+ */
+export enum Provider {
+    POSTGRESQL = 'postgresql',
+    MYSQL = 'mysql',
+    SQLITE = 'sqlite',
+    SQLSERVER = 'sqlserver',
+    MONGODB = 'mongodb',
+    COCKROACHDB = 'cockroachdb',
+}
+
+/**
+ * Capability preset per provider: the prisma counterpart of the
+ * `@rapiq/sql` dialect presets.
+ *
+ * `mode: 'insensitive'` exists on the postgres family and mongodb
+ * only. mysql and sqlserver compare case-insensitively under their
+ * default collations, so nothing has to be emitted there. sqlite
+ * supports neither: its `LIKE` is case-insensitive for ASCII, but
+ * `equals` is not: a documented limitation rather than a silent
+ * divergence.
+ */
+export const PROVIDERS : Record<`${Provider}`, ProviderOptions> = {
+    [Provider.POSTGRESQL]: { caseInsensitiveMode: true },
+    [Provider.COCKROACHDB]: { caseInsensitiveMode: true },
+    [Provider.MONGODB]: { caseInsensitiveMode: true },
+    [Provider.MYSQL]: { caseInsensitiveMode: false },
+    [Provider.SQLSERVER]: { caseInsensitiveMode: false },
+    [Provider.SQLITE]: { caseInsensitiveMode: false },
+};

--- a/packages/prisma/src/provider/index.ts
+++ b/packages/prisma/src/provider/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './constants';
+export * from './module';
+export * from './types';

--- a/packages/prisma/src/provider/module.ts
+++ b/packages/prisma/src/provider/module.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError, ErrorCode } from '@rapiq/core';
+import { PROVIDERS, Provider } from './constants';
+import type { ProviderOptions } from './types';
+
+const ALIASES : Record<string, `${Provider}`> = {
+    postgres: Provider.POSTGRESQL,
+    pg: Provider.POSTGRESQL,
+    cockroach: Provider.COCKROACHDB,
+    mssql: Provider.SQLSERVER,
+    sqlserver: Provider.SQLSERVER,
+    mongo: Provider.MONGODB,
+};
+
+/**
+ * Resolve a provider name (the `provider` of a prisma datasource
+ * block, or a `PrismaClient`'s active provider) to its capability
+ * preset. Common aliases resolve to their canonical provider.
+ */
+export function resolveProvider(name: string) : ProviderOptions | undefined {
+    const normalized = name.toLowerCase();
+
+    return PROVIDERS[ALIASES[normalized] ?? normalized as `${Provider}`];
+}
+
+/**
+ * The documented last-resort default: postgres: the most common
+ * prisma provider and the one whose case contract needs
+ * `mode: 'insensitive'` to hold. Mirrors the `@rapiq/typeorm`
+ * dialect fallback.
+ */
+export function resolveProviderOptions(
+    input?: `${Provider}` | string | ProviderOptions,
+) : ProviderOptions {
+    if (typeof input === 'undefined') {
+        return PROVIDERS[Provider.POSTGRESQL];
+    }
+
+    if (typeof input === 'string') {
+        const options = resolveProvider(input);
+        if (options) {
+            return options;
+        }
+
+        // an unknown name must never fall back to a preset: silently
+        // treating a typo as postgres would emit `mode: 'insensitive'`
+        // that the real connector rejects on every filter.
+        throw new AdapterError({
+            message: `The prisma provider "${input}" is unknown.`,
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
+    }
+
+    return input;
+}

--- a/packages/prisma/src/provider/types.ts
+++ b/packages/prisma/src/provider/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type ProviderOptions = {
+    /**
+     * Whether the connector accepts `mode: 'insensitive'` on string
+     * filters. The rapiq case contract (eq/ne/in/nin and the anchored
+     * operators compare case-insensitively by default) is expressed
+     * with that flag where it exists.
+     *
+     * Connectors whose default collation already compares
+     * case-insensitively (mysql, sqlserver) set this to `false`:
+     * exactly like the identity `caseFold` of the `@rapiq/sql`
+     * mysql/mssql dialects.
+     */
+    caseInsensitiveMode: boolean,
+};

--- a/packages/prisma/test/data/client.ts
+++ b/packages/prisma/test/data/client.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Provider } from '../../src';
+import type { User } from './type';
+
+/**
+ * A real, throwaway database driven by a generated prisma client: the
+ * ground truth the adapter is measured against.
+ *
+ * SQLite needs no infrastructure and runs everywhere. Postgres is the
+ * connector that actually implements `mode: 'insensitive'`, so the
+ * case contract can only be measured there; it runs when `DB_TYPE`
+ * names it (the CI `tests-db` job provides the server).
+ */
+export type TestDatabase = {
+    client: any,
+    datamodel: { models: any[] },
+    provider: `${Provider}`,
+    destroy: () => Promise<void>,
+};
+
+const DDL = [
+    'drop table if exists "Item"',
+    'drop table if exists "User"',
+    'drop table if exists "Realm"',
+    `create table "Realm" (
+        "id" integer not null primary key,
+        "name" text not null,
+        "description" text
+    )`,
+    `create table "User" (
+        "id" integer not null primary key,
+        "first_name" text not null,
+        "last_name" text not null,
+        "email" text not null,
+        "age" integer not null,
+        "address" text,
+        "realm_id" integer references "Realm"("id")
+    )`,
+    `create table "Item" (
+        "id" integer not null primary key,
+        "title" text not null,
+        "color" text,
+        "user_id" integer not null references "User"("id")
+    )`,
+];
+
+/**
+ * Which engine the suite runs against. `postgres` requires a live
+ * server; anything else falls back to a SQLite file.
+ */
+export function resolveProviderName() : `${Provider}` {
+    const type = (process.env.DB_TYPE || '').toLowerCase();
+
+    if (type === 'postgres' || type === 'postgresql') {
+        return 'postgresql';
+    }
+
+    return 'sqlite';
+}
+
+function resolveUrl(provider: `${Provider}`, directory: string) : string {
+    if (provider === 'sqlite') {
+        return `file:${join(directory, 'test.db')}`;
+    }
+
+    const host = process.env.DB_HOST || '127.0.0.1';
+    const port = process.env.DB_PORT || '5432';
+    const user = process.env.DB_USERNAME || 'postgres';
+    const password = process.env.DB_PASSWORD || 'start123';
+    const database = process.env.DB_DATABASE || 'test';
+
+    return `postgresql://${user}:${password}@${host}:${port}/${database}`;
+}
+
+export async function createDatabase(records: User[]) : Promise<TestDatabase> {
+    const provider = resolveProviderName();
+
+    const directory = mkdtempSync(join(tmpdir(), 'rapiq-prisma-'));
+    const url = resolveUrl(provider, directory);
+
+    process.env.PRISMA_TEST_DATABASE_URL = url;
+
+    const generated = provider === 'sqlite' ?
+        await import('../../node_modules/.prisma-test-client/index.js') :
+        await import('../../node_modules/.prisma-test-client-postgres/index.js');
+
+    const client = new generated.PrismaClient({ datasourceUrl: url });
+
+    for (const statement of DDL) {
+        await client.$executeRawUnsafe(statement);
+    }
+
+    const realms = new Map<number, any>();
+    for (const record of records) {
+        if (record.realm) {
+            realms.set(record.realm.id, record.realm);
+        }
+    }
+
+    for (const realm of realms.values()) {
+        await client.realm.create({ data: realm });
+    }
+
+    for (const record of records) {
+        await client.user.create({
+            data: {
+                id: record.id,
+                first_name: record.first_name,
+                last_name: record.last_name,
+                email: record.email,
+                age: record.age,
+                address: record.address,
+                realm_id: record.realm_id,
+                items: {
+                    create: record.items.map((item) => ({
+                        id: item.id,
+                        title: item.title,
+                        color: item.color,
+                    })),
+                },
+            },
+        });
+    }
+
+    return {
+        client,
+        datamodel: generated.Prisma.dmmf.datamodel,
+        provider,
+        destroy: async () => {
+            await client.$disconnect();
+            rmSync(directory, { recursive: true, force: true });
+        },
+    };
+}

--- a/packages/prisma/test/data/datamodel.ts
+++ b/packages/prisma/test/data/datamodel.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Datamodel } from '../../src';
+
+const scalar = (name: string, type: string, isRequired = true) => ({
+    name,
+    kind: 'scalar',
+    isList: false,
+    isRequired,
+    type,
+});
+
+const relation = (name: string, type: string, isList: boolean, isRequired = true) => ({
+    name,
+    kind: 'object',
+    isList,
+    isRequired,
+    type,
+});
+
+/**
+ * Shaped exactly like `Prisma.dmmf.datamodel` so the fixture doubles
+ * as a check that a real datamodel is assignable.
+ */
+export const datamodel : Datamodel = {
+    models: [
+        {
+            name: 'User',
+            fields: [
+                scalar('id', 'Int'),
+                scalar('first_name', 'String'),
+                scalar('last_name', 'String'),
+                scalar('email', 'String'),
+                scalar('age', 'Int'),
+                scalar('address', 'String', false),
+                scalar('realm_id', 'Int', false),
+                relation('realm', 'Realm', false, false),
+                relation('items', 'Item', true),
+            ],
+        },
+        {
+            name: 'Realm',
+            fields: [
+                scalar('id', 'Int'),
+                scalar('name', 'String'),
+                scalar('description', 'String', false),
+            ],
+        },
+        {
+            name: 'Item',
+            fields: [
+                scalar('id', 'Int'),
+                scalar('title', 'String'),
+                scalar('color', 'String', false),
+            ],
+        },
+    ],
+};

--- a/packages/prisma/test/data/evaluate.ts
+++ b/packages/prisma/test/data/evaluate.ts
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * A faithful, deliberately small evaluator for the prisma `where`
+ * objects this adapter emits: the stand-in for a query engine so the
+ * cross-backend semantics can be asserted without a database.
+ *
+ * It reproduces prisma's *three-valued* behavior, because that is
+ * precisely what the adapter has to work around:
+ *
+ * - a scalar comparison against null/absent yields UNKNOWN, and a row
+ *   only matches when the whole tree evaluates to TRUE,
+ * - `equals: null` / `not: null` are the two-valued IS (NOT) NULL
+ *   checks,
+ * - `is` adds an "exists" conjunct, `isNot` an "or absent" disjunct,
+ * - `some` / `none` are EXISTS / NOT EXISTS, hence two-valued,
+ * - an empty `AND` is TRUE, an empty `OR` is FALSE.
+ */
+export type Verdict = boolean | null;
+
+const RELATION_OPERATORS = ['is', 'isNot', 'some', 'every', 'none'];
+
+function isPlainObject(input: unknown) : input is Record<string, any> {
+    return typeof input === 'object' &&
+        input !== null &&
+        !Array.isArray(input) &&
+        !(input instanceof Date) &&
+        !(input instanceof RegExp);
+}
+
+function and(input: Verdict[]) : Verdict {
+    let unknown = false;
+
+    for (const item of input) {
+        if (item === false) {
+            return false;
+        }
+
+        if (item === null) {
+            unknown = true;
+        }
+    }
+
+    return unknown ? null : true;
+}
+
+function or(input: Verdict[]) : Verdict {
+    let unknown = false;
+
+    for (const item of input) {
+        if (item === true) {
+            return true;
+        }
+
+        if (item === null) {
+            unknown = true;
+        }
+    }
+
+    return unknown ? null : false;
+}
+
+function not(input: Verdict) : Verdict {
+    return input === null ? null : !input;
+}
+
+function toArray(input: unknown) : any[] {
+    return Array.isArray(input) ? input : [input];
+}
+
+// -----------------------------------------------------------
+
+function normalize(input: unknown) : unknown {
+    return typeof input === 'undefined' ? null : input;
+}
+
+function equals(value: unknown, operand: unknown, insensitive: boolean) : boolean {
+    if (
+        insensitive &&
+        typeof value === 'string' &&
+        typeof operand === 'string'
+    ) {
+        return value.toLowerCase() === operand.toLowerCase();
+    }
+
+    return value === operand;
+}
+
+function compare(value: any, operand: any) : number | undefined {
+    if (typeof value === 'string' && typeof operand === 'string') {
+        if (value === operand) {
+            return 0;
+        }
+
+        return value < operand ? -1 : 1;
+    }
+
+    if (typeof value === 'number' && typeof operand === 'number') {
+        if (value === operand) {
+            return 0;
+        }
+
+        return value < operand ? -1 : 1;
+    }
+
+    return undefined;
+}
+
+function text(value: unknown, operand: string, insensitive: boolean) : [string, string] | undefined {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    if (insensitive) {
+        return [value.toLowerCase(), operand.toLowerCase()];
+    }
+
+    return [value, operand];
+}
+
+// -----------------------------------------------------------
+
+function evaluateOperator(
+    operator: string,
+    operand: any,
+    value: unknown,
+    insensitive: boolean,
+) : Verdict {
+    if (operator === 'equals') {
+        if (operand === null) {
+            return normalize(value) === null;
+        }
+
+        if (normalize(value) === null) {
+            return null;
+        }
+
+        return equals(value, operand, insensitive);
+    }
+
+    if (operator === 'not') {
+        if (operand === null) {
+            return normalize(value) !== null;
+        }
+
+        if (isPlainObject(operand)) {
+            // the sibling `mode` applies into the negated subtree.
+            return not(evaluateScalar(value, operand, insensitive));
+        }
+
+        if (normalize(value) === null) {
+            return null;
+        }
+
+        return !equals(value, operand, insensitive);
+    }
+
+    if (operator === 'in' || operator === 'notIn') {
+        if (normalize(value) === null) {
+            return null;
+        }
+
+        const contained = (operand as unknown[]).some(
+            (item) => equals(value, item, insensitive),
+        );
+
+        return operator === 'in' ? contained : !contained;
+    }
+
+    if (
+        operator === 'lt' ||
+        operator === 'lte' ||
+        operator === 'gt' ||
+        operator === 'gte'
+    ) {
+        if (normalize(value) === null || operand === null) {
+            return null;
+        }
+
+        const result = compare(value, operand);
+        if (typeof result === 'undefined') {
+            return null;
+        }
+
+        switch (operator) {
+            case 'lt': return result === -1;
+            case 'lte': return result <= 0;
+            case 'gt': return result === 1;
+            default: return result >= 0;
+        }
+    }
+
+    if (
+        operator === 'contains' ||
+        operator === 'startsWith' ||
+        operator === 'endsWith'
+    ) {
+        if (normalize(value) === null) {
+            return null;
+        }
+
+        const pair = text(value, operand as string, insensitive);
+        if (!pair) {
+            return null;
+        }
+
+        const [haystack, needle] = pair;
+
+        switch (operator) {
+            case 'contains': return haystack.includes(needle);
+            case 'startsWith': return haystack.startsWith(needle);
+            default: return haystack.endsWith(needle);
+        }
+    }
+
+    throw new Error(`Unsupported prisma filter operator: ${operator}`);
+}
+
+function evaluateScalar(
+    value: unknown,
+    filter: Record<string, any>,
+    inherited = false,
+) : Verdict {
+    const insensitive = inherited || filter.mode === 'insensitive';
+
+    const results : Verdict[] = [];
+
+    for (const key of Object.keys(filter)) {
+        if (key === 'mode') {
+            continue;
+        }
+
+        results.push(evaluateOperator(key, filter[key], value, insensitive));
+    }
+
+    return and(results);
+}
+
+function evaluateRelation(value: unknown, filter: Record<string, any>) : Verdict {
+    const results : Verdict[] = [];
+
+    for (const key of Object.keys(filter)) {
+        const operand = filter[key];
+
+        if (key === 'is' || key === 'isNot') {
+            const present = normalize(value) !== null;
+
+            if (operand === null) {
+                results.push(key === 'is' ? !present : present);
+                continue;
+            }
+
+            const inner = evaluateWhere(operand, (value || {}) as Record<string, any>);
+
+            // `is` renders the interior plus an exists guard; `isNot`
+            // the negated interior or the absence of the record.
+            results.push(key === 'is' ?
+                and([inner, present]) :
+                or([not(inner), !present]));
+
+            continue;
+        }
+
+        const items = Array.isArray(value) ? value : [];
+
+        if (key === 'some' || key === 'none') {
+            const exists = items.some(
+                (item) => evaluateWhere(operand, item) === true,
+            );
+
+            results.push(key === 'some' ? exists : !exists);
+            continue;
+        }
+
+        if (key === 'every') {
+            results.push(!items.some(
+                (item) => not(evaluateWhere(operand, item)) === true,
+            ));
+            continue;
+        }
+
+        throw new Error(`Unsupported prisma relation operator: ${key}`);
+    }
+
+    return and(results);
+}
+
+function evaluateField(value: unknown, filter: unknown) : Verdict {
+    if (filter === null) {
+        return normalize(value) === null;
+    }
+
+    if (!isPlainObject(filter)) {
+        return evaluateOperator('equals', filter, value, false);
+    }
+
+    if (Object.keys(filter).some((key) => RELATION_OPERATORS.includes(key))) {
+        return evaluateRelation(value, filter);
+    }
+
+    return evaluateScalar(value, filter);
+}
+
+export function evaluateWhere(where: Record<string, any>, row: Record<string, any>) : Verdict {
+    const results : Verdict[] = [];
+
+    for (const key of Object.keys(where)) {
+        const value = where[key];
+
+        if (key === 'AND') {
+            results.push(and(toArray(value).map((item) => evaluateWhere(item, row))));
+            continue;
+        }
+
+        if (key === 'OR') {
+            results.push(or((value as any[]).map((item) => evaluateWhere(item, row))));
+            continue;
+        }
+
+        if (key === 'NOT') {
+            results.push(and(toArray(value).map((item) => not(evaluateWhere(item, row)))));
+            continue;
+        }
+
+        results.push(evaluateField(row[key], value));
+    }
+
+    return and(results);
+}
+
+/**
+ * The rows a `where` selects: a row matches only when the tree
+ * evaluates to TRUE, exactly like a SQL `WHERE`.
+ */
+export function selectRows<T extends Record<string, any>>(
+    where: Record<string, any> | undefined,
+    rows: T[],
+) : T[] {
+    if (!where) {
+        return [...rows];
+    }
+
+    return rows.filter((row) => evaluateWhere(where, row) === true);
+}

--- a/packages/prisma/test/data/index.ts
+++ b/packages/prisma/test/data/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './datamodel';
+export * from './evaluate';
+export * from './schema';
+export * from './type';

--- a/packages/prisma/test/data/schema.ts
+++ b/packages/prisma/test/data/schema.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import { defineMetadata } from '../../src';
+import { datamodel } from './datamodel';
+import type { Item, Realm, User } from './type';
+
+export const realmSchema = defineSchema<Realm>({
+    name: 'realm',
+    fields: { allowed: ['id', 'name', 'description'] },
+    filters: { allowed: ['id', 'name'] },
+    sort: { allowed: ['id', 'name'] },
+});
+
+export const itemSchema = defineSchema<Item>({
+    name: 'item',
+    fields: { allowed: ['id', 'title', 'color'] },
+    filters: { allowed: ['id', 'title', 'color'] },
+    sort: { allowed: ['id', 'title'] },
+});
+
+export const userSchema = defineSchema<User>({
+    name: 'user',
+    fields: {
+        default: ['id', 'first_name', 'last_name', 'age'],
+        allowed: ['email'],
+    },
+    filters: { allowed: ['id', 'first_name', 'realm_id', 'age', 'address'] },
+    pagination: { maxLimit: 50 },
+    relations: { allowed: ['realm', 'items'] },
+    sort: { allowed: ['id', 'age', 'first_name'] },
+    schemaMapping: { realm: 'realm', items: 'item' },
+});
+
+export function createRegistry() : SchemaRegistry {
+    const registry = new SchemaRegistry();
+
+    registry.add(userSchema);
+    registry.add(realmSchema);
+    registry.add(itemSchema);
+
+    return registry;
+}
+
+// -----------------------------------------------------------
+
+/**
+ * The default adapter binding for the engine-free specs: postgres (so
+ * the case-insensitive default is exercised) over the fixture
+ * datamodel.
+ */
+export function createAdapterOptions(overrides: Record<string, any> = {}) {
+    return {
+        provider: 'postgresql',
+        metadata: defineMetadata(datamodel, 'User'),
+        ...overrides,
+    } as any;
+}

--- a/packages/prisma/test/data/type.ts
+++ b/packages/prisma/test/data/type.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type Realm = {
+    id: number,
+    name: string,
+    description: string | null,
+};
+
+export type Item = {
+    id: number,
+    title: string,
+    color: string | null,
+};
+
+export type User = {
+    id: number,
+    first_name: string,
+    last_name: string,
+    email: string,
+    age: number,
+    address: string | null,
+    realm_id: number | null,
+    realm: Realm | null,
+    items: Item[],
+};

--- a/packages/prisma/test/prisma/schema.postgres.prisma
+++ b/packages/prisma/test/prisma/schema.postgres.prisma
@@ -1,0 +1,44 @@
+// The postgres twin of schema.prisma. Prisma fixes the datasource
+// provider at generate time, so the connector-specific matrix needs its
+// own schema and its own generated client.
+//
+// The models are deliberately identical to schema.prisma: the engine
+// suite asserts both datamodels against the same fixture, so a drift
+// between the two files fails the run rather than passing silently.
+
+generator client {
+    provider = "prisma-client-js"
+    output   = "../../node_modules/.prisma-test-client-postgres"
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("PRISMA_TEST_DATABASE_URL")
+}
+
+model User {
+    id         Int     @id
+    first_name String
+    last_name  String
+    email      String
+    age        Int
+    address    String?
+    realm_id   Int?
+    realm      Realm?  @relation(fields: [realm_id], references: [id])
+    items      Item[]
+}
+
+model Realm {
+    id          Int     @id
+    name        String
+    description String?
+    users       User[]
+}
+
+model Item {
+    id      Int     @id
+    title   String
+    color   String?
+    user_id Int
+    user    User    @relation(fields: [user_id], references: [id])
+}

--- a/packages/prisma/test/prisma/schema.prisma
+++ b/packages/prisma/test/prisma/schema.prisma
@@ -1,0 +1,42 @@
+// Fixture schema for the engine-backed parity suite. SQLite keeps the
+// tests dependency-free: no server, no container, just a file.
+//
+// The models mirror test/data/type.ts, so the same fixture records feed
+// the in-memory backend and the real database.
+
+generator client {
+    provider = "prisma-client-js"
+    output   = "../../node_modules/.prisma-test-client"
+}
+
+datasource db {
+    provider = "sqlite"
+    url      = env("PRISMA_TEST_DATABASE_URL")
+}
+
+model User {
+    id         Int     @id
+    first_name String
+    last_name  String
+    email      String
+    age        Int
+    address    String?
+    realm_id   Int?
+    realm      Realm?  @relation(fields: [realm_id], references: [id])
+    items      Item[]
+}
+
+model Realm {
+    id          Int     @id
+    name        String
+    description String?
+    users       User[]
+}
+
+model Item {
+    id      Int     @id
+    title   String
+    color   String?
+    user_id Int
+    user    User    @relation(fields: [user_id], references: [id])
+}

--- a/packages/prisma/test/unit/acceptance.spec.ts
+++ b/packages/prisma/test/unit/acceptance.spec.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createURLCodec } from '@rapiq/codec-url';
+import type { Schema } from '@rapiq/core';
+import { 
+    Query, 
+    SchemaRegistry, 
+    defineSchema, 
+    eq, 
+} from '@rapiq/core';
+import type { Args } from '../../src';
+import { PrismaAdapter } from '../../src';
+import { selectRows } from '../data/evaluate';
+import { createAdapterOptions, createRegistry } from '../data/schema';
+import type { User } from '../data/type';
+
+const records : User[] = [
+    {
+        id: 1,
+        first_name: 'Caleb',
+        last_name: 'Barrows',
+        email: 'caleb.barrows@gmail.com',
+        age: 18,
+        address: 'Hogwarts',
+        realm_id: null,
+        realm: null,
+        items: [],
+    },
+    {
+        id: 2,
+        first_name: 'Aston',
+        last_name: 'Nel',
+        email: 'ashton.nel@gmail.com',
+        age: 60,
+        address: null,
+        realm_id: 1,
+        realm: {
+            id: 1, 
+            name: 'master', 
+            description: null, 
+        },
+        items: [{
+            id: 1, 
+            title: 'book', 
+            color: 'red', 
+        }],
+    },
+];
+
+/**
+ * M2 gate archetype, ported to the args-object adapter: a repository
+ * takes raw client input, validates it against a schema and hands the
+ * result to prisma.
+ */
+function createUserRepository(schema?: Schema<User>) {
+    let registry : SchemaRegistry;
+
+    if (schema) {
+        registry = new SchemaRegistry();
+        registry.add(schema);
+    } else {
+        registry = createRegistry();
+    }
+
+    const codec = createURLCodec(registry);
+    const adapter = new PrismaAdapter(createAdapterOptions());
+
+    return {
+        findMany(input: string | Record<string, any>, base?: Args) {
+            const query = codec.decode(input, { schema: 'user' });
+            expect(query).toBeDefined();
+
+            return adapter.execute(query!, { base });
+        },
+    };
+}
+
+describe('acceptance: request query to prisma arguments', () => {
+    const repository = createUserRepository();
+
+    it('should map a full client request', () => {
+        const { args, pagination } = repository.findMany(
+            'fields=%2Bemail&filter[realm_id]=1,null&include=realm&sort=-age&page[limit]=100',
+        );
+
+        // the requested limit is clamped to maxLimit and echoed back
+        expect(pagination).toEqual({ limit: 50, offset: 0 });
+
+        expect(args.take).toEqual(50);
+        expect(args.skip).toEqual(0);
+        expect(args.orderBy).toEqual([{ age: 'desc' }]);
+
+        // null-aware membership: records of the realm *or* without one
+        expect(args.where).toEqual({
+            OR: [
+                { realm_id: { in: [1] } },
+                { realm_id: null },
+            ],
+        });
+
+        // the sensitive field is projected only because the client
+        // opted in; the hydrated relation joins the same select level.
+        expect(args.select).toEqual({
+            id: true,
+            first_name: true,
+            last_name: true,
+            age: true,
+            email: true,
+            realm: true,
+        });
+
+        expect(selectRows(args.where, records).map((record) => record.id)).toEqual([1, 2]);
+    });
+
+    it('should hide undeclared parameters', () => {
+        const { args, pagination } = repository.findMany({
+            filter: { age: '18' },
+            sort: '-email',
+        });
+
+        expect(pagination).toEqual({ limit: 50, offset: 0 });
+
+        // age is filterable, email is not sortable
+        expect(args.where).toEqual({ age: { equals: 18 } });
+        expect(args.orderBy).toBeUndefined();
+
+        expect(args.select).toEqual({
+            id: true,
+            first_name: true,
+            last_name: true,
+            age: true,
+        });
+    });
+
+    it('should enforce server-injected scoping regardless of client input', () => {
+        const registry = new SchemaRegistry();
+        registry.add(defineSchema<User>({
+            name: 'user',
+            filters: { allowed: ['first_name'] },
+        }));
+
+        const codec = createURLCodec(registry);
+        const adapter = new PrismaAdapter(createAdapterOptions());
+
+        const applyScoped = (input: string) => {
+            const query = codec.decode(input, { schema: 'user' });
+
+            // post-parse wrap & inject: a later replace-merge cannot
+            // displace the condition.
+            const scoped = new Query({
+                ...query,
+                filters: query!.filters.and(eq('realm_id', 1)),
+            });
+
+            return adapter.execute(scoped).args;
+        };
+
+        const bare = applyScoped('');
+        expect(selectRows(bare.where, records).map((record) => record.id)).toEqual([2]);
+
+        // the client filter matches caleb, who is outside the scope
+        const filtered = applyScoped('filter[first_name]=Caleb');
+        expect(selectRows(filtered.where, records)).toHaveLength(0);
+    });
+
+    it('should keep an application-owned predicate alongside client filters', () => {
+        const { args } = repository.findMany(
+            'filter[first_name]=Caleb',
+            { where: { realm_id: 1 } },
+        );
+
+        expect(args.where).toEqual({
+            AND: [
+                { realm_id: 1 },
+                { first_name: { equals: 'Caleb', mode: 'insensitive' } },
+            ],
+        });
+
+        expect(selectRows(args.where, records)).toHaveLength(0);
+    });
+
+    it('should reject all client parameters on a strict repository', () => {
+        const strict = createUserRepository(defineSchema<User>({
+            name: 'user',
+            strict: true,
+            pagination: { maxLimit: 50 },
+        }));
+
+        const { args, pagination } = strict.findMany(
+            'fields=email&filter[first_name]=Caleb&include=realm&sort=-age&page[limit]=100',
+        );
+
+        expect(pagination).toEqual({ limit: 50, offset: 0 });
+
+        expect(args.where).toBeUndefined();
+        expect(args.select).toBeUndefined();
+        expect(args.include).toBeUndefined();
+        expect(args.orderBy).toBeUndefined();
+        expect(args.take).toEqual(50);
+    });
+});

--- a/packages/prisma/test/unit/complement.spec.ts
+++ b/packages/prisma/test/unit/complement.spec.ts
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition, Filter, Filters } from '@rapiq/core';
+import {
+    FilterCompoundOperator,
+    Filters as FiltersNode,
+    Query,
+    and,
+    contains,
+    elemMatch,
+    endsWith,
+    eq,
+    exists,
+    gte,
+    inArray,
+    lt,
+    ne,
+    nin,
+    not,
+    notContains,
+    notEndsWith,
+    notStartsWith,
+    or,
+    startsWith,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/memory';
+import { PrismaAdapter } from '../../src';
+import { createAdapterOptions } from '../data/schema';
+import { selectRows } from '../data/evaluate';
+import type { User } from '../data/type';
+
+/**
+ * The cross-backend semantics gate, the emitted prisma `where` is
+ * evaluated with prisma's own three-valued rules and must select
+ * exactly the records `@rapiq/memory` selects, the same obligation
+ * `@rapiq/typeorm` discharges against a live database.
+ */
+describe('cross-adapter complement law (memory vs prisma)', () => {
+    const records : User[] = [
+        {
+            id: 1,
+            first_name: 'Caleb',
+            last_name: 'Barrows',
+            email: 'caleb.barrows@gmail.com',
+            age: 18,
+            address: 'Hogwarts',
+            realm_id: 1,
+            realm: {
+                id: 1, 
+                name: 'master', 
+                description: null, 
+            },
+            items: [{
+                id: 1, 
+                title: 'book', 
+                color: 'red', 
+            }],
+        },
+        {
+            id: 2,
+            first_name: 'Aston',
+            last_name: 'Nel',
+            email: 'ashton.nel@gmail.com',
+            age: 60,
+            address: null,
+            realm_id: null,
+            realm: null,
+            items: [],
+        },
+        {
+            id: 3,
+            first_name: 'Frodo',
+            last_name: 'Baggins',
+            email: 'frodo.baggins@gmail.com',
+            age: 33,
+            address: 'Mordor',
+            realm_id: 2,
+            realm: {
+                id: 2, 
+                name: 'shire', 
+                description: 'the shire', 
+            },
+            items: [
+                {
+                    id: 2,
+                    title: 'ring',
+                    color: null,
+                },
+                {
+                    id: 3,
+                    title: 'book',
+                    color: 'blue',
+                },
+            ],
+        },
+    ];
+
+    const allIds = records.map((record) => record.id).sort((a, b) => a - b);
+
+    const prismaIds = (condition: Condition) : number[] => {
+        const filters = new FiltersNode(FilterCompoundOperator.AND, [condition]);
+        const { args } = new PrismaAdapter(createAdapterOptions()).execute(new Query({ filters }));
+
+        return selectRows(args.where, records)
+            .map((record) => record.id)
+            .sort((a, b) => a - b);
+    };
+
+    const memoryIds = (condition: Condition) : number[] => {
+        const predicate = compileFilters(condition as Filter | Filters);
+
+        return records
+            .filter((record) => predicate(record))
+            .map((record) => record.id)
+            .sort((a, b) => a - b);
+    };
+
+    // address is 'Hogwarts', NULL and 'Mordor'; realm is present,
+    // absent and present; items has one, zero and one element.
+    const pairs : [string, Condition, Condition][] = [
+        ['eq/ne', eq('address', 'Hogwarts'), ne('address', 'Hogwarts')],
+        ['eq/ne (null)', eq('address', null), ne('address', null)],
+        ['in/nin', inArray('address', ['Hogwarts', 'Mordor']), nin('address', ['Hogwarts', 'Mordor'])],
+        ['in/nin (null member)', inArray('address', ['Hogwarts', null]), nin('address', ['Hogwarts', null])],
+        ['in/nin (empty)', inArray('address', []), nin('address', [])],
+        ['contains/notContains', contains('address', 'wart'), notContains('address', 'wart')],
+        ['startsWith/notStartsWith', startsWith('address', 'Hog'), notStartsWith('address', 'Hog')],
+        ['endsWith/notEndsWith', endsWith('address', 'arts'), notEndsWith('address', 'arts')],
+        ['exists true/false', exists('address'), exists('address', false)],
+        ['eq/ne (to-one relation)', eq('realm.name', 'master'), ne('realm.name', 'master')],
+        ['eq/ne (case)', eq('first_name', 'caleb'), ne('first_name', 'caleb')],
+    ];
+
+    pairs.forEach(([name, positive, negative]) => {
+        it(`should agree for ${name}`, () => {
+            const positiveIds = prismaIds(positive);
+            const negativeIds = prismaIds(negative);
+
+            expect(positiveIds).toEqual(memoryIds(positive));
+            expect(negativeIds).toEqual(memoryIds(negative));
+
+            // the negation selects exactly the remaining records.
+            expect([...positiveIds, ...negativeIds].sort((a, b) => a - b)).toEqual(allIds);
+
+            // the first-class NOT node is the same complement.
+            expect(prismaIds(not(positive))).toEqual(negativeIds);
+            expect(memoryIds(not(positive))).toEqual(negativeIds);
+        });
+    });
+
+    // De Morgan push-down has to hold for whole trees, not just leaves.
+    const compounds : [string, Condition][] = [
+        ['not(and)', not(and(eq('address', 'Hogwarts'), gte('age', 18)))],
+        ['not(or)', not(or(eq('address', 'Hogwarts'), eq('address', 'Mordor')))],
+        ['not(not(and))', not(not(and(eq('address', 'Hogwarts'), gte('age', 18))))],
+        ['nested', not(or(and(eq('address', 'Mordor'), lt('age', 40)), exists('address', false)))],
+        ['relation inside a negated group', not(and(eq('realm.name', 'master'), gte('age', 18)))],
+    ];
+
+    compounds.forEach(([name, condition]) => {
+        it(`should agree for ${name}`, () => {
+            expect(prismaIds(condition)).toEqual(memoryIds(condition));
+        });
+    });
+
+    /**
+     * A to-many path binds per element (per left-joined row), so a
+     * record with a matching *and* a non-matching element satisfies
+     * both a condition and its negation, the pair does not partition
+     * the records, and only agreement with the reference backend is
+     * asserted. Record 3 carries two items exactly for this.
+     */
+    const collections : [string, Condition][] = [
+        ['eq', eq('items.title', 'book')],
+        ['ne', ne('items.title', 'book')],
+        ['not(eq)', not(eq('items.title', 'book'))],
+        ['eq (null column)', eq('items.color', null)],
+        ['ne (null column)', ne('items.color', null)],
+        ['exists', exists('items.color')],
+        ['exists false', exists('items.color', false)],
+        ['in', inArray('items.color', ['red', null])],
+        ['nin', nin('items.color', ['red', null])],
+        ['contains', contains('items.title', 'oo')],
+        ['notContains', notContains('items.title', 'oo')],
+        ['elemMatch', elemMatch('items', and(eq('title', 'book'), eq('color', 'red')))],
+        ['not(elemMatch)', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
+    ];
+
+    collections.forEach(([name, condition]) => {
+        it(`should agree for a to-many path: ${name}`, () => {
+            expect(prismaIds(condition)).toEqual(memoryIds(condition));
+        });
+    });
+
+    /**
+     * Same-element binding: sibling conditions on one to-many path
+     * bind to the SAME element on every backend. The factoring pass
+     * groups them into one `some` scope, so prisma agrees with the
+     * per-join-row evaluation of sql/typeorm and the per-binding
+     * evaluation of memory. This record satisfies each condition on a
+     * DIFFERENT element and must not match.
+     */
+    const split : User[] = [{
+        id: 9,
+        first_name: 'Split',
+        last_name: 'Case',
+        email: 'split@case.io',
+        age: 1,
+        address: null,
+        realm_id: null,
+        realm: null,
+        items: [
+            {
+                id: 90,
+                title: 'book',
+                color: 'blue',
+            },
+            {
+                id: 91,
+                title: 'ring',
+                color: 'red',
+            },
+        ],
+    }];
+
+    const sameElement : [string, Condition][] = [
+        ['and on one path', and(eq('items.title', 'book'), eq('items.color', 'red'))],
+        ['or on one path', or(eq('items.title', 'ring'), eq('items.color', 'blue'))],
+        ['negated leaf in the group', and(ne('items.title', 'ring'), eq('items.color', 'red'))],
+        ['mixed root and relation', and(eq('items.title', 'book'), or(eq('items.color', 'red'), eq('id', 9)))],
+        ['negated group over one path', not(and(eq('items.title', 'book'), eq('items.color', 'red')))],
+        ['not(elemMatch) with a mixed record', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
+    ];
+
+    sameElement.forEach(([name, condition]) => {
+        it(`should bind to the same element for ${name}`, () => {
+            const rows = [...records, ...split];
+
+            const filters = new FiltersNode(FilterCompoundOperator.AND, [condition]);
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(new Query({ filters }));
+
+            const prisma = selectRows(args.where, rows)
+                .map((record) => record.id)
+                .sort((a, b) => a - b);
+            const memory = rows
+                .filter((record) => compileFilters(condition as Filter)(record))
+                .map((record) => record.id)
+                .sort((a, b) => a - b);
+
+            expect(prisma).toEqual(memory);
+        });
+    });
+});

--- a/packages/prisma/test/unit/engine.db.spec.ts
+++ b/packages/prisma/test/unit/engine.db.spec.ts
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition, Filter, Filters } from '@rapiq/core';
+import {
+    FilterCompoundOperator,
+    Filters as FiltersNode,
+    Query,
+    and,
+    contains,
+    elemMatch,
+    endsWith,
+    eq,
+    exists,
+    gte,
+    inArray,
+    lt,
+    ne,
+    nin,
+    not,
+    notContains,
+    notEndsWith,
+    notStartsWith,
+    or,
+    startsWith,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/memory';
+import { PrismaAdapter, defineMetadata } from '../../src';
+import type { TestDatabase } from '../data/client';
+import { createDatabase } from '../data/client';
+import { datamodel } from '../data/datamodel';
+import { selectRows } from '../data/evaluate';
+import type { User } from '../data/type';
+
+/**
+ * The parity gate, executed by a real prisma query engine.
+ *
+ * Every condition is run three ways: through the engine against a
+ * live SQLite database, through `@rapiq/memory`, and through the
+ * in-test evaluator, and all three must select the same records. The
+ * engine is the ground truth: it decides whether the emitted argument
+ * object is even *valid*, whether the semantics hold, and whether the
+ * evaluator used by the engine-free suite is a faithful model.
+ */
+describe('engine parity (prisma vs memory)', () => {
+    const records : User[] = [
+        {
+            id: 1,
+            first_name: 'Caleb',
+            last_name: 'Barrows',
+            email: 'caleb.barrows@gmail.com',
+            age: 18,
+            address: 'Hogwarts',
+            realm_id: 1,
+            realm: {
+                id: 1, 
+                name: 'master', 
+                description: null, 
+            },
+            items: [{
+                id: 1, 
+                title: 'book', 
+                color: 'red', 
+            }],
+        },
+        {
+            id: 2,
+            first_name: 'Aston',
+            last_name: 'Nel',
+            email: 'ashton.nel@gmail.com',
+            age: 60,
+            address: null,
+            realm_id: null,
+            realm: null,
+            items: [],
+        },
+        {
+            id: 3,
+            first_name: 'Frodo',
+            last_name: 'Baggins',
+            email: 'frodo.baggins@gmail.com',
+            age: 33,
+            address: 'Mordor',
+            realm_id: 2,
+            realm: {
+                id: 2, 
+                name: 'shire', 
+                description: 'the shire', 
+            },
+            items: [
+                {
+                    id: 2, 
+                    title: 'ring', 
+                    color: null, 
+                },
+                {
+                    id: 3, 
+                    title: 'book', 
+                    color: 'blue', 
+                },
+            ],
+        },
+
+        {
+            id: 4,
+            first_name: 'Split',
+            last_name: 'Case',
+            email: 'split@case.io',
+            age: 21,
+            address: null,
+            realm_id: null,
+            realm: null,
+            items: [
+                {
+                    id: 4,
+                    title: 'book',
+                    color: 'silver',
+                },
+                {
+                    id: 5,
+                    title: 'ring',
+                    color: 'red',
+                },
+            ],
+        },
+    ];
+
+    let database : TestDatabase;
+    let adapter : PrismaAdapter;
+
+    beforeAll(async () => {
+        database = await createDatabase(records);
+
+        // the metadata the adapter consumes comes from the REAL
+        // datamodel of the engine under test, not the fixture.
+        adapter = new PrismaAdapter({
+            provider: database.provider,
+            metadata: defineMetadata(database.datamodel, 'User'),
+        });
+    }, 120_000);
+
+    afterAll(async () => {
+        await database.destroy();
+    });
+
+    const build = (condition: Condition) => adapter.execute(new Query({ filters: new FiltersNode(FilterCompoundOperator.AND, [condition]) })).args;
+
+    const engineIds = async (condition: Condition) : Promise<number[]> => {
+        const rows = await database.client.user.findMany({
+            where: build(condition).where,
+            select: { id: true },
+        });
+
+        return rows.map((row) => row.id).sort((a, b) => a - b);
+    };
+
+    const memoryIds = (condition: Condition) : number[] => records
+        .filter((record) => compileFilters(condition as Filter | Filters)(record))
+        .map((record) => record.id)
+        .sort((a, b) => a - b);
+
+    const evaluatorIds = (condition: Condition) : number[] => selectRows(build(condition).where, records)
+        .map((record) => record.id)
+        .sort((a, b) => a - b);
+
+    // Case-matched literals throughout: SQLite compares `equals`
+    // case-sensitively and has no `mode`, which the dedicated test
+    // below measures instead of assuming.
+    const conditions : [string, Condition][] = [
+        ['eq', eq('address', 'Hogwarts')],
+        ['ne', ne('address', 'Hogwarts')],
+        ['eq (null)', eq('address', null)],
+        ['ne (null)', ne('address', null)],
+        ['exists', exists('address')],
+        ['exists false', exists('address', false)],
+        ['in', inArray('address', ['Hogwarts', 'Mordor'])],
+        ['nin', nin('address', ['Hogwarts', 'Mordor'])],
+        ['in (null member)', inArray('address', ['Hogwarts', null])],
+        ['nin (null member)', nin('address', ['Hogwarts', null])],
+        ['in (empty)', inArray('address', [])],
+        ['nin (empty)', nin('address', [])],
+        ['gte', gte('age', 33)],
+        ['not(gte)', not(gte('age', 33))],
+        ['contains', contains('address', 'ord')],
+        ['notContains', notContains('address', 'ord')],
+        ['startsWith', startsWith('address', 'Hog')],
+        ['notStartsWith', notStartsWith('address', 'Hog')],
+        ['endsWith', endsWith('address', 'arts')],
+        ['notEndsWith', notEndsWith('address', 'arts')],
+
+        ['to-one eq', eq('realm.name', 'master')],
+        ['to-one ne', ne('realm.name', 'master')],
+        ['to-one null column', eq('realm.description', null)],
+        ['to-one null column (negated)', ne('realm.description', null)],
+        ['to-one relation exists', exists('realm')],
+        ['to-one relation absent', exists('realm', false)],
+
+        ['to-many eq', eq('items.title', 'book')],
+        ['to-many ne', ne('items.title', 'book')],
+        ['to-many not(eq)', not(eq('items.title', 'book'))],
+        ['to-many null column', eq('items.color', null)],
+        ['to-many null column (negated)', ne('items.color', null)],
+        ['to-many in', inArray('items.color', ['red', null])],
+        ['to-many nin', nin('items.color', ['red', null])],
+        ['to-many contains', contains('items.title', 'oo')],
+        ['to-many notContains', notContains('items.title', 'oo')],
+        ['to-many relation exists', exists('items')],
+        ['to-many relation absent', exists('items', false)],
+
+        ['same-element and', and(eq('items.title', 'book'), eq('items.color', 'red'))],
+        ['same-element or', or(eq('items.title', 'ring'), eq('items.color', 'silver'))],
+        ['same-element negated leaf', and(ne('items.title', 'ring'), eq('items.color', 'red'))],
+        ['same-element mixed nesting', and(eq('items.title', 'book'), or(eq('items.color', 'red'), gte('age', 21)))],
+        ['same-element negated group', not(and(eq('items.title', 'book'), eq('items.color', 'red')))],
+
+        ['elemMatch', elemMatch('items', and(eq('title', 'book'), eq('color', 'red')))],
+        ['elemMatch (null interior)', elemMatch('items', eq('color', null))],
+        ['not(elemMatch)', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
+
+        ['not(and)', not(and(eq('address', 'Hogwarts'), gte('age', 18)))],
+        ['not(or)', not(or(eq('address', 'Hogwarts'), eq('address', 'Mordor')))],
+        ['nested', not(or(and(eq('address', 'Mordor'), lt('age', 40)), exists('address', false)))],
+        ['relation in a negated group', not(and(eq('realm.name', 'master'), gte('age', 18)))],
+    ];
+
+    conditions.forEach(([name, condition]) => {
+        it(`should agree with the engine for ${name}`, async () => {
+            const ids = await engineIds(condition);
+
+            // the contract, the records a query selects in memory are
+            // the records it selects in the database.
+            expect(ids).toEqual(memoryIds(condition));
+
+            // and the engine-free suite's model of prisma is faithful.
+            expect(ids).toEqual(evaluatorIds(condition));
+        });
+    });
+
+    it('should apply the whole argument object', async () => {
+        const { args, pagination } = adapter.execute(new Query({
+            ...new Query(),
+            filters: new FiltersNode(FilterCompoundOperator.AND, [gte('age', 18)]),
+        }));
+
+        expect(pagination).toEqual({ limit: undefined, offset: undefined });
+
+        const rows = await database.client.user.findMany(args);
+        expect(rows).toHaveLength(4);
+    });
+
+    it('should keep the engine-free fixture datamodel faithful', () => {
+        // the engine-free specs run against a hand-written datamodel;
+        // if it drifts from the real one they prove nothing.
+        const real = defineMetadata(database.datamodel, 'User');
+        const fixture = defineMetadata(datamodel, 'User');
+
+        const paths = [
+            'id', 
+            'first_name', 
+            'address', 
+            'age', 
+            'realm_id',
+            'realm', 
+            'items', 
+            'realm.name', 
+            'realm.description',
+            'items.title', 
+            'items.color',
+        ];
+
+        for (const path of paths) {
+            expect([path, fixture.isRelation(path)]).toEqual([path, real.isRelation(path)]);
+            expect([path, fixture.isToMany(path)]).toEqual([path, real.isToMany(path)]);
+            expect([path, fixture.isNullable(path)]).toEqual([path, real.isNullable(path)]);
+            expect([path, fixture.isString(path)]).toEqual([path, real.isString(path)]);
+        }
+    });
+
+    it('should apply the case contract of the connector', async () => {
+        // measured, not assumed. Postgres accepts `mode: 'insensitive'`
+        // so the rapiq default holds; sqlite has no `mode` and compares
+        // `=` case-sensitively, which is the documented limitation.
+        const ids = await engineIds(eq('first_name', 'caleb'));
+
+        if (database.provider === 'sqlite') {
+            expect(ids).toEqual([]);
+        } else {
+            expect(ids).toEqual(memoryIds(eq('first_name', 'caleb')));
+            expect(ids).toEqual([1]);
+        }
+    });
+
+    it('should not let a like wildcard widen an equality', async () => {
+        // The reason `buildMode` vetoes `%`/`_`, an insensitive
+        // `equals` lowers to ILIKE with the operand passed through
+        // verbatim (prisma#20318), so `_` would match any character.
+        // This measures whether the veto is actually load-bearing.
+        await database.client.user.createMany({
+            data: [
+                {
+                    id: 90, 
+                    first_name: 'A_B', 
+                    last_name: 'x', 
+                    email: 'x', 
+                    age: 1, 
+                    address: 'a_b',
+                },
+                {
+                    id: 91, 
+                    first_name: 'AxB', 
+                    last_name: 'x', 
+                    email: 'x', 
+                    age: 1, 
+                    address: 'axb',
+                },
+            ],
+        });
+
+        try {
+            const { args } = adapter.execute(new Query({ filters: new FiltersNode(FilterCompoundOperator.AND, [eq('address', 'a_b')]) }));
+
+            const rows = await database.client.user.findMany({
+                where: args.where,
+                select: { id: true },
+            });
+
+            // exactly the literal match: never the wildcard neighbour
+            expect(rows.map((row: any) => row.id)).toEqual([90]);
+
+            if (database.provider !== 'postgresql') {
+                return;
+            }
+
+            // and the veto is genuinely load-bearing, the same filter
+            // WITH `mode` matches the neighbour too, because prisma
+            // lowers an insensitive `equals` to ILIKE.
+            const widened = await database.client.user.findMany({
+                where: { address: { equals: 'a_b', mode: 'insensitive' } },
+                select: { id: true },
+            });
+
+            expect(widened.map((row: any) => row.id)).toEqual([90, 91]);
+
+            // `in` is NOT lowered, so it keeps case-insensitivity even
+            // for a value carrying a wildcard, the veto stays off it.
+            const membership = adapter.execute(new Query({ filters: new FiltersNode(FilterCompoundOperator.AND, [inArray('address', ['A_B'])]) })).args;
+
+            expect(membership.where).toEqual({ address: { in: ['A_B'], mode: 'insensitive' } });
+
+            const matched = await database.client.user.findMany({
+                where: membership.where,
+                select: { id: true },
+            });
+
+            expect(matched.map((row: any) => row.id)).toEqual([90]);
+        } finally {
+            await database.client.user.deleteMany({ where: { id: { in: [90, 91] } } });
+        }
+    });
+});

--- a/packages/prisma/test/unit/fields.spec.ts
+++ b/packages/prisma/test/unit/fields.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    FieldOperator,
+    Fields,
+    Query,
+    Relation,
+    Relations,
+} from '@rapiq/core';
+import { createAdapterOptions } from '../data/schema';
+import { PrismaAdapter } from '../../src';
+
+function build(fields: string[] = [], relations: string[] = []) {
+    const adapter = new PrismaAdapter(createAdapterOptions());
+
+    const { args } = adapter.execute(new Query({
+        fields: new Fields(fields.map((field) => {
+            if (field.startsWith('-')) {
+                return new Field(field.substring(1), FieldOperator.EXCLUDE);
+            }
+
+            return new Field(field);
+        })),
+        relations: new Relations(relations.map((relation) => new Relation(relation))),
+    }));
+
+    return args;
+}
+
+describe('src/adapter/fields.ts', () => {
+    it('should emit nothing without fields or relations', () => {
+        expect(build()).toEqual({});
+    });
+
+    it('should project picked fields with select', () => {
+        expect(build(['id', 'first_name'])).toEqual({ select: { id: true, first_name: true } });
+    });
+
+    it('should drop excluded fields instead of emitting omit', () => {
+        // prisma rejects select together with omit; an excluded field is
+        // simply not projected, as on every other rapiq backend.
+        expect(build(['id', '-email'])).toEqual({ select: { id: true } });
+    });
+
+    it('should hydrate relations with include', () => {
+        expect(build([], ['realm'])).toEqual({ include: { realm: true } });
+    });
+
+    it('should nest a relation chain', () => {
+        expect(build([], ['realm', 'items'])).toEqual({ include: { realm: true, items: true } });
+    });
+
+    it('should nest a dotted relation path', () => {
+        expect(build([], ['items.realm'])).toEqual({ include: { items: { include: { realm: true } } } });
+    });
+
+    it('should switch to select once a field is picked', () => {
+        // select and include are mutually exclusive per level, so an
+        // included relation joins the select tree.
+        expect(build(['id'], ['realm'])).toEqual({ select: { id: true, realm: true } });
+    });
+
+    it('should keep an included relation whole despite a sparse pick', () => {
+        // relations widen a sparse field selection: the projection
+        // contract shared with @rapiq/memory.
+        expect(build(['id', 'realm.name'], ['realm'])).toEqual({ select: { id: true, realm: true } });
+    });
+
+    it('should project a relation sparsely when it is not included', () => {
+        expect(build(['id', 'realm.name'])).toEqual({ select: { id: true, realm: { select: { name: true } } } });
+    });
+
+    it('should keep deeper relations of a wholly hydrated one', () => {
+        expect(build(['id'], ['items', 'items.realm'])).toEqual({
+            select: {
+                id: true,
+                items: { include: { realm: true } },
+            },
+        });
+    });
+
+    it('should project through a relation without root picks', () => {
+        expect(build(['realm.name'])).toEqual({ select: { realm: { select: { name: true } } } });
+    });
+});

--- a/packages/prisma/test/unit/filters.spec.ts
+++ b/packages/prisma/test/unit/filters.spec.ts
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition } from '@rapiq/core';
+import {
+    ErrorCode,
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    and,
+    contains,
+    elemMatch,
+    endsWith,
+    eq,
+    exists,
+    gt,
+    gte,
+    inArray,
+    lt,
+    mod,
+    ne,
+    nin,
+    not,
+    notContains,
+    or,
+    regex,
+    size,
+    startsWith,
+} from '@rapiq/core';
+import { PrismaAdapter } from '../../src';
+import { createAdapterOptions } from '../data/schema';
+
+function build(condition: Condition, options: Record<string, any> = {}) {
+    const adapter = new PrismaAdapter(createAdapterOptions(options));
+    const { args } = adapter.execute(new Query({ filters: new Filters(FilterCompoundOperator.AND, [condition]) }));
+
+    return args.where;
+}
+
+describe('src/adapter/filters.ts', () => {
+    describe('equality', () => {
+        it('should render eq', () => {
+            expect(build(eq('first_name', 'Peter'))).toEqual({ first_name: { equals: 'Peter', mode: 'insensitive' } });
+        });
+
+        it('should render ne as the exact null-inclusive complement', () => {
+            expect(build(ne('address', 'Mordor'))).toEqual({
+                OR: [
+                    { address: { not: 'Mordor', mode: 'insensitive' } },
+                    { address: null },
+                ],
+            });
+        });
+
+        it('should drop the null arm for a non-nullable column', () => {
+            expect(build(ne('first_name', 'Peter'))).toEqual({ first_name: { not: 'Peter', mode: 'insensitive' } });
+        });
+
+        it('should render an eq against null as is null', () => {
+            expect(build(eq('address', null))).toEqual({ address: null });
+        });
+
+        it('should render a ne against null as is not null', () => {
+            expect(build(ne('address', null))).toEqual({ address: { not: null } });
+        });
+
+        it('should decide a null check on a non-nullable column', () => {
+            // the column cannot hold null, so the condition is constant:
+            // and prisma would reject the null comparison outright.
+            expect(build(eq('first_name', null))).toEqual({ OR: [] });
+            expect(build(ne('first_name', null))).toBeUndefined();
+        });
+
+        it('should render exists', () => {
+            expect(build(exists('address'))).toEqual({ address: { not: null } });
+            expect(build(exists('address', false))).toEqual({ address: null });
+        });
+    });
+
+    describe('ordering', () => {
+        it('should render comparisons', () => {
+            expect(build(gte('age', 18))).toEqual({ age: { gte: 18 } });
+            expect(build(lt('age', 18))).toEqual({ age: { lt: 18 } });
+        });
+
+        it('should complement a comparison with the inverse operator', () => {
+            // age is non-nullable, so the complement needs no null arm.
+            expect(build(not(gt('age', 18)))).toEqual({ age: { lte: 18 } });
+        });
+
+        it('should never case-fold an ordering comparison', () => {
+            expect(build(gte('first_name', 'a'))).toEqual({ first_name: { gte: 'a' } });
+        });
+    });
+
+    describe('membership', () => {
+        it('should render in', () => {
+            expect(build(inArray('id', [1, 2]))).toEqual({ id: { in: [1, 2] } });
+        });
+
+        it('should render nin as the exact complement', () => {
+            expect(build(nin('address', ['Mordor']))).toEqual({
+                OR: [
+                    { address: { notIn: ['Mordor'], mode: 'insensitive' } },
+                    { address: null },
+                ],
+            });
+        });
+
+        it('should split a null member out of the value list', () => {
+            expect(build(inArray('realm_id', [1, null]))).toEqual({
+                OR: [
+                    { realm_id: { in: [1] } },
+                    { realm_id: null },
+                ],
+            });
+        });
+
+        it('should render the negated null-member case null-exclusively', () => {
+            expect(build(nin('realm_id', [1, null]))).toEqual({
+                AND: [
+                    { realm_id: { notIn: [1] } },
+                    { realm_id: { not: null } },
+                ],
+            });
+        });
+
+        it('should fold an empty membership list to a constant', () => {
+            // `in([])` matches nothing, `nin([])` everything.
+            expect(build(inArray('id', []))).toEqual({ OR: [] });
+            expect(build(nin('id', []))).toBeUndefined();
+        });
+    });
+
+    describe('anchored', () => {
+        it('should render the anchored operators', () => {
+            expect(build(contains('first_name', 'et'))).toEqual({ first_name: { contains: 'et', mode: 'insensitive' } });
+            expect(build(startsWith('first_name', 'Pe'))).toEqual({ first_name: { startsWith: 'Pe', mode: 'insensitive' } });
+            expect(build(endsWith('first_name', 'er'))).toEqual({ first_name: { endsWith: 'er', mode: 'insensitive' } });
+        });
+
+        it('should keep mode a sibling of not in the negated form', () => {
+            expect(build(notContains('address', 'wart'))).toEqual({
+                OR: [
+                    { address: { not: { contains: 'wart' }, mode: 'insensitive' } },
+                    { address: null },
+                ],
+            });
+        });
+    });
+
+    describe('case sensitivity', () => {
+        it('should omit mode for a provider without insensitive filters', () => {
+            expect(build(eq('first_name', 'Peter'), { provider: 'mysql' })).toEqual({ first_name: { equals: 'Peter' } });
+        });
+
+        it('should omit mode for a non-string column', () => {
+            expect(build(eq('age', 18))).toEqual({ age: { equals: 18 } });
+        });
+
+        it('should honor the per-field opt-out', () => {
+            expect(build(eq('email', 'a@b.c'), { filters: { caseSensitive: ['email'] } })).toEqual({ email: { equals: 'a@b.c' } });
+        });
+
+        it('should keep membership case-insensitive despite a wildcard', () => {
+            // measured: `in`/`notIn` are never lowered to ILIKE, so the
+            // veto below does not apply to them.
+            expect(build(inArray('email', ['john_doe@x.com']))).toEqual({ email: { in: ['john_doe@x.com'], mode: 'insensitive' } });
+        });
+
+        it('should not case-fold a value carrying a like wildcard', () => {
+            // `mode: 'insensitive'` lowers equals to ILIKE, where `_`
+            // and `%` would silently widen the match.
+            expect(build(eq('email', 'john_doe@x.com'))).toEqual({ email: { equals: 'john_doe@x.com' } });
+        });
+    });
+
+    describe('compounds', () => {
+        it('should render and/or', () => {
+            expect(build(or(eq('id', 1), eq('id', 2)))).toEqual({
+                OR: [
+                    { id: { equals: 1 } },
+                    { id: { equals: 2 } },
+                ],
+            });
+        });
+
+        it('should push a group negation down to the leaves', () => {
+            // prisma NOT is three-valued and would drop null rows, so
+            // De Morgan is applied instead, and no NOT key is emitted.
+            expect(build(not(and(eq('id', 1), gt('age', 18))))).toEqual({
+                OR: [
+                    { id: { not: 1 } },
+                    { age: { lte: 18 } },
+                ],
+            });
+        });
+
+        it('should cancel a double negation', () => {
+            expect(build(not(not(eq('id', 1))))).toEqual({ id: { equals: 1 } });
+        });
+
+        it('should fold a constant child out of a compound', () => {
+            expect(build(and(eq('id', 1), nin('id', [])))).toEqual({ id: { equals: 1 } });
+            expect(build(and(eq('id', 1), inArray('id', [])))).toEqual({ OR: [] });
+            expect(build(or(eq('id', 1), nin('id', [])))).toBeUndefined();
+        });
+    });
+
+    describe('relation paths', () => {
+        it('should traverse a to-one relation with is', () => {
+            expect(build(eq('realm.name', 'master'))).toEqual({ realm: { is: { name: { equals: 'master', mode: 'insensitive' } } } });
+        });
+
+        it('should admit an absent to-one relation in the complement', () => {
+            expect(build(ne('realm.name', 'master'))).toEqual({
+                OR: [
+                    { realm: { is: { name: { not: 'master', mode: 'insensitive' } } } },
+                    { NOT: { realm: { is: {} } } },
+                ],
+            });
+        });
+
+        it('should traverse a to-many relation with some', () => {
+            expect(build(eq('items.title', 'book'))).toEqual({ items: { some: { title: { equals: 'book', mode: 'insensitive' } } } });
+        });
+
+        it('should quantify a negated to-many condition existentially', () => {
+            // a left join evaluates the condition per joined row, so a
+            // record with a matching *and* a non-matching element
+            // satisfies both the condition and its negation: `none`
+            // would be the row-level complement instead.
+            expect(build(ne('items.title', 'book'))).toEqual({
+                OR: [
+                    { items: { some: { title: { not: 'book', mode: 'insensitive' } } } },
+                    { items: { none: {} } },
+                ],
+            });
+        });
+
+        it('should treat an empty collection as one null binding', () => {
+            expect(build(eq('items.color', null))).toEqual({
+                OR: [
+                    { items: { some: { color: null } } },
+                    { items: { none: {} } },
+                ],
+            });
+
+            expect(build(ne('items.color', null))).toEqual({ items: { some: { color: { not: null } } } });
+        });
+
+        it('should express a null check on a relation as a presence test', () => {
+            // prisma rejects `not: null` on a relation field.
+            expect(build(exists('realm'))).toEqual({ realm: { is: {} } });
+            expect(build(exists('realm', false))).toEqual({ NOT: { realm: { is: {} } } });
+
+            // a collection is always present, never absent, the same
+            // answer @rapiq/memory gives.
+            expect(build(exists('items'))).toBeUndefined();
+            expect(build(exists('items', false))).toEqual({ OR: [] });
+        });
+
+        it('should decide a null check on a required column behind a relation', () => {
+            // the column cannot hold null, so only the traversal selects.
+            expect(build(eq('realm.name', null))).toEqual({ NOT: { realm: { is: {} } } });
+            expect(build(ne('realm.name', null))).toEqual({ realm: { is: {} } });
+        });
+
+        it('should drop a dead null member on a required column', () => {
+            expect(build(inArray('first_name', ['a', null]))).toEqual({ first_name: { in: ['a'], mode: 'insensitive' } });
+        });
+
+        it('should accept an explicit to-many declaration without metadata', () => {
+            expect(build(eq('items.title', 'book'), { relations: { toMany: ['items'] } })).toEqual({ items: { some: { title: { equals: 'book', mode: 'insensitive' } } } });
+        });
+    });
+
+    describe('elemMatch', () => {
+        it('should render a single some scope', () => {
+            expect(build(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))).toEqual({
+                items: {
+                    some: {
+                        AND: [
+                            { title: { equals: 'book', mode: 'insensitive' } },
+                            { color: { equals: 'red', mode: 'insensitive' } },
+                        ],
+                    },
+                },
+            });
+        });
+
+        it('should complement per binding, with the quantifier outside', () => {
+            // the settled contract: group negation applies per binding
+            // (memory negates per binding context, sql wraps CASE per
+            // join row), so not(elemMatch(c)) selects records with an
+            // element FAILING c, plus empty collections.
+            expect(build(not(elemMatch('items', eq('title', 'book'))))).toEqual({
+                OR: [
+                    { items: { some: { title: { not: 'book', mode: 'insensitive' } } } },
+                    { items: { none: {} } },
+                ],
+            });
+        });
+
+        it('should cover the empty collection when the interior matches null', () => {
+            expect(build(elemMatch('items', eq('color', null)))).toEqual({
+                OR: [
+                    { items: { some: { color: null } } },
+                    { items: { none: {} } },
+                ],
+            });
+        });
+    });
+
+    describe('unsupported features', () => {
+        const cases : [string, Condition][] = [
+            ['regex', regex('first_name', '^Pe')],
+            ['mod', mod('age', 2, 0)],
+            ['size', size('items', 2)],
+        ];
+
+        cases.forEach(([name, condition]) => {
+            it(`should fail typed for ${name}`, () => {
+                expect(() => build(condition)).toThrowError(
+                    expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
+                );
+            });
+        });
+    });
+});

--- a/packages/prisma/test/unit/metadata.spec.ts
+++ b/packages/prisma/test/unit/metadata.spec.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ErrorCode } from '@rapiq/core';
+import { PrismaAdapter, defineMetadata, resolveProvider } from '../../src';
+import { datamodel } from '../data/datamodel';
+
+describe('src/metadata/module.ts', () => {
+    const metadata = defineMetadata(datamodel, 'User');
+
+    it('should resolve relation cardinality', () => {
+        expect(metadata.isToMany('items')).toBe(true);
+        expect(metadata.isToMany('realm')).toBe(false);
+    });
+
+    it('should resolve cardinality through a relation chain', () => {
+        expect(metadata.isToMany('realm.name')).toBeUndefined();
+        expect(metadata.isToMany('items.title')).toBeUndefined();
+    });
+
+    it('should resolve string-typedness', () => {
+        expect(metadata.isString('first_name')).toBe(true);
+        expect(metadata.isString('age')).toBe(false);
+        expect(metadata.isString('realm.name')).toBe(true);
+        expect(metadata.isString('items.title')).toBe(true);
+    });
+
+    it('should resolve nullability', () => {
+        expect(metadata.isNullable('first_name')).toBe(false);
+        expect(metadata.isNullable('address')).toBe(true);
+        expect(metadata.isNullable('realm')).toBe(true);
+        expect(metadata.isNullable('realm.description')).toBe(true);
+    });
+
+    it('should distinguish relations from columns', () => {
+        expect(metadata.isRelation('realm')).toBe(true);
+        expect(metadata.isRelation('items')).toBe(true);
+        expect(metadata.isRelation('first_name')).toBe(false);
+        expect(metadata.isRelation('realm.name')).toBe(false);
+    });
+
+    it('should reject a root model outside the datamodel', () => {
+        // prisma models are PascalCase; the client accessor is not.
+        expect(() => defineMetadata(datamodel, 'user')).toThrowError(
+            expect.objectContaining({ code: ErrorCode.SCHEMA_UNRESOLVABLE }),
+        );
+    });
+
+    it('should answer unknown for keys outside the datamodel', () => {
+        expect(metadata.isToMany('unknown')).toBeUndefined();
+        expect(metadata.isString('unknown')).toBeUndefined();
+        expect(metadata.isNullable('unknown')).toBeUndefined();
+
+        // a scalar cannot be traversed further
+        expect(metadata.isString('age.nested')).toBeUndefined();
+    });
+});
+
+describe('src/provider/module.ts', () => {
+    const metadata = defineMetadata(datamodel, 'User');
+
+    it('should resolve providers and their aliases', () => {
+        expect(resolveProvider('postgresql')).toEqual({ caseInsensitiveMode: true });
+        expect(resolveProvider('postgres')).toEqual({ caseInsensitiveMode: true });
+        expect(resolveProvider('mssql')).toEqual({ caseInsensitiveMode: false });
+        expect(resolveProvider('sqlserver')).toEqual({ caseInsensitiveMode: false });
+        expect(resolveProvider('unknown')).toBeUndefined();
+    });
+
+    it('should reject an unknown provider instead of defaulting', () => {
+        // a silent fallback to postgres would emit `mode: 'insensitive'`
+        // that the real connector rejects on every filter.
+        expect(() => new PrismaAdapter({ provider: 'postgre', metadata })).toThrowError(
+            expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
+        );
+    });
+
+    it('should accept an explicit capability preset', () => {
+        expect(() => new PrismaAdapter({ provider: { caseInsensitiveMode: false }, metadata })).not.toThrow();
+    });
+});

--- a/packages/prisma/test/unit/query.spec.ts
+++ b/packages/prisma/test/unit/query.spec.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    Fields,
+    FilterCompoundOperator,
+    Filters,
+    Pagination,
+    Query,
+    Relation,
+    Relations,
+    Sort,
+    SortDirection,
+    Sorts,
+    eq,
+    inArray,
+} from '@rapiq/core';
+import { createAdapterOptions } from '../data/schema';
+import { PrismaAdapter, buildPrismaArgs } from '../../src';
+
+describe('src/adapter/module.ts', () => {
+    it('should compose the whole argument object', () => {
+        const query = new Query({
+            fields: new Fields([new Field('id'), new Field('first_name')]),
+            filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]),
+            pagination: new Pagination(10, 20),
+            sorts: new Sorts([
+                new Sort('age', SortDirection.DESC),
+                new Sort('first_name'),
+            ]),
+        });
+
+        const { args, pagination } = new PrismaAdapter(createAdapterOptions()).execute(query);
+
+        expect(args).toEqual({
+            select: { id: true, first_name: true },
+            where: { age: { equals: 18 } },
+            orderBy: [{ age: 'desc' }, { first_name: 'asc' }],
+            take: 10,
+            skip: 20,
+        });
+
+        expect(pagination).toEqual({ limit: 10, offset: 20 });
+    });
+
+    it('should emit no keys for an empty query', () => {
+        const { args, pagination } = new PrismaAdapter(createAdapterOptions()).execute(new Query());
+
+        expect(args).toEqual({});
+        expect(pagination).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    describe('baseline arguments', () => {
+        it('should narrow a caller-owned predicate instead of replacing it', () => {
+            const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]) });
+
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(query, { base: { where: { realm_id: 1 } } });
+
+            expect(args.where).toEqual({
+                AND: [
+                    { realm_id: 1 },
+                    { age: { equals: 18 } },
+                ],
+            });
+        });
+
+        it('should keep a caller-owned predicate without query filters', () => {
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(new Query(), { base: { where: { realm_id: 1 } } });
+
+            expect(args.where).toEqual({ realm_id: 1 });
+        });
+
+        it('should keep the baseline alongside an unsatisfiable condition', () => {
+            // `{ OR: [] }` is prisma's `1 = 0`: valid at the root only,
+            // where sibling operator keys are conjoined.
+            const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [inArray('id', [])]) });
+
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(query, { base: { where: { realm_id: 1 } } });
+
+            expect(args.where).toEqual({
+                OR: [],
+                AND: [{ realm_id: 1 }],
+            });
+        });
+
+        it('should preserve unrelated baseline keys', () => {
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(new Query(), { base: { take: 5, orderBy: [{ id: 'asc' }] } });
+
+            expect(args).toEqual({ take: 5, orderBy: [{ id: 'asc' }] });
+        });
+
+        it('should replace a baseline selection to keep select and include exclusive', () => {
+            const query = new Query({ fields: new Fields([new Field('id')]) });
+
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(query, { base: { include: { realm: true } } });
+
+            expect(args).toEqual({ select: { id: true } });
+        });
+
+        it('should never widen a caller-owned projection', () => {
+            // relations join the baseline's select instead of replacing
+            // it: dropping it would expose every column of the model.
+            const query = new Query({ relations: new Relations([new Relation('realm')]) });
+
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(query, { base: { select: { id: true, first_name: true } } });
+
+            expect(args).toEqual({
+                select: {
+                    id: true, 
+                    first_name: true, 
+                    realm: true, 
+                }, 
+            });
+        });
+
+        it('should drop a baseline omit next to a produced select', () => {
+            const query = new Query({ fields: new Fields([new Field('id')]) });
+
+            const { args } = new PrismaAdapter(createAdapterOptions()).execute(query, { base: { omit: { email: true } } as any });
+
+            expect(args).toEqual({ select: { id: true } });
+        });
+    });
+
+    it('should hold no state between runs', () => {
+        const adapter = new PrismaAdapter(createAdapterOptions());
+
+        adapter.execute(new Query({
+            filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]),
+            sorts: new Sorts([new Sort('age', SortDirection.DESC)]),
+        }));
+
+        const { args } = adapter.execute(new Query());
+
+        expect(args).toEqual({});
+    });
+
+    it('should not carry per-call filter options into the next run', () => {
+        const adapter = new PrismaAdapter(createAdapterOptions());
+        const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('first_name', 'Peter')]) });
+
+        adapter.execute(query, { filters: { caseSensitive: true } });
+
+        expect(adapter.execute(query).args.where).toEqual({ first_name: { equals: 'Peter', mode: 'insensitive' } });
+    });
+
+    it('should expose a one-shot helper', () => {
+        const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]) });
+
+        expect(buildPrismaArgs(query, createAdapterOptions()).args).toEqual({ where: { age: { equals: 18 } } });
+    });
+});

--- a/packages/prisma/test/unit/relations.spec.ts
+++ b/packages/prisma/test/unit/relations.spec.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { Relation, Relations } from '@rapiq/core';
+import { collectRelationPaths } from '../../src';
+
+describe('src/adapter/relations.ts', () => {
+    it('should collect a dotted path with its parents', () => {
+        expect(collectRelationPaths(new Relations([
+            new Relation('items.realm'),
+        ]))).toEqual(['items', 'items.realm']);
+    });
+
+    it('should collect a path only once', () => {
+        expect(collectRelationPaths(new Relations([
+            new Relation('items'),
+            new Relation('items.realm'),
+        ]))).toEqual(['items', 'items.realm']);
+    });
+
+    it('should collect nothing without relations', () => {
+        expect(collectRelationPaths(new Relations())).toEqual([]);
+    });
+});

--- a/packages/prisma/test/unit/sort.spec.ts
+++ b/packages/prisma/test/unit/sort.spec.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Pagination,
+    Query,
+    Sort,
+    SortDirection,
+    Sorts,
+} from '@rapiq/core';
+import { createAdapterOptions } from '../data/schema';
+import { PrismaAdapter } from '../../src';
+
+function orderBy(sorts: Sorts) {
+    return new PrismaAdapter(createAdapterOptions()).execute(new Query({ sorts })).args.orderBy;
+}
+
+describe('src/adapter/sort.ts', () => {
+    it('should emit nothing without sorts', () => {
+        expect(orderBy(new Sorts())).toBeUndefined();
+    });
+
+    it('should emit an array of single-key objects', () => {
+        // a multi-key object is rejected by prisma and would lose the
+        // order of the keys anyway.
+        expect(orderBy(new Sorts([
+            new Sort('age', SortDirection.DESC),
+            new Sort('first_name', SortDirection.ASC),
+        ]))).toEqual([
+            { age: 'desc' },
+            { first_name: 'asc' },
+        ]);
+    });
+
+    it('should default to ascending', () => {
+        expect(orderBy(new Sorts([new Sort('id')]))).toEqual([{ id: 'asc' }]);
+    });
+
+    it('should nest a relation path', () => {
+        expect(orderBy(new Sorts([
+            new Sort('realm.name', SortDirection.DESC),
+        ]))).toEqual([{ realm: { name: 'desc' } }]);
+    });
+
+    it('should keep the first occurrence of a duplicated key', () => {
+        expect(orderBy(new Sorts([
+            new Sort('id', SortDirection.DESC),
+            new Sort('id', SortDirection.ASC),
+        ]))).toEqual([{ id: 'desc' }]);
+    });
+});
+
+describe('src/adapter/pagination.ts', () => {
+    const build = (pagination: Pagination) => new PrismaAdapter(createAdapterOptions())
+        .execute(new Query({ pagination }));
+
+    it('should emit nothing without pagination', () => {
+        const { args, pagination } = build(new Pagination());
+
+        expect(args).toEqual({});
+        expect(pagination).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('should render take and skip', () => {
+        expect(build(new Pagination(10, 20)).args).toEqual({ take: 10, skip: 20 });
+    });
+
+    it('should render an explicit zero', () => {
+        expect(build(new Pagination(0, 0)).args).toEqual({ take: 0, skip: 0 });
+    });
+
+    it('should render a limit without an offset', () => {
+        expect(build(new Pagination(10)).args).toEqual({ take: 10 });
+    });
+});

--- a/packages/prisma/test/vitest.config.ts
+++ b/packages/prisma/test/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/unit/**/*.{spec,test}.{ts,js}'],
+        // engine-backed specs need a generated prisma client, so they
+        // live behind `test:db` (see test/vitest.db.config.ts) and the
+        // default suite stays codegen-free.
+        exclude: ['**/node_modules/**', '**/dist/**', '**/*.db.spec.ts'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            exclude: ['src/**/*.d.ts'],
+        },
+    },
+});

--- a/packages/prisma/test/vitest.db.config.ts
+++ b/packages/prisma/test/vitest.db.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * The engine-backed suite: a generated prisma client executing the
+ * emitted arguments against a real database. SQLite runs everywhere;
+ * the postgres specs skip themselves unless `DB_TYPE=postgres` points
+ * at a live server (the CI `tests-db` job provides one).
+ */
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/unit/**/*.db.spec.{ts,js}'],
+        // one engine, one schema, one database file at a time
+        fileParallelism: false,
+    },
+});

--- a/packages/prisma/tsconfig.build.json
+++ b/packages/prisma/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src/**/*"]
+}

--- a/packages/prisma/tsconfig.json
+++ b/packages/prisma/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "types": ["node", "vitest/globals"]
+    },
+    "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/prisma/tsdown.config.ts
+++ b/packages/prisma/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: 'src/index.ts',
+    format: 'esm',
+    dts: true,
+    sourcemap: true,
+    tsconfig: 'tsconfig.build.json',
+});

--- a/packages/sql/README.md
+++ b/packages/sql/README.md
@@ -93,6 +93,7 @@ The package deliberately stops at fragments: composing the final `SELECT`, in pa
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | **[@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql)** | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm) | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/packages/typeorm/README.md
+++ b/packages/typeorm/README.md
@@ -176,6 +176,7 @@ Migrating from typeorm-extension's `applyQuery`? The defaults mirror its contrac
 | [@rapiq/codec-url](https://github.com/tada5hi/rapiq/tree/master/packages/codec-url) | URL query-string transport codec |
 | [@rapiq/sql](https://github.com/tada5hi/rapiq/tree/master/packages/sql) | Dialect-agnostic SQL fragment adapter (pg, mysql, sqlite, mssql, oracle) |
 | **[@rapiq/typeorm](https://github.com/tada5hi/rapiq/tree/master/packages/typeorm)** | Apply a query to a TypeORM `SelectQueryBuilder` |
+| [@rapiq/prisma](https://github.com/tada5hi/rapiq/tree/master/packages/prisma) | Serialize a query into a Prisma argument object |
 | [@rapiq/memory](https://github.com/tada5hi/rapiq/tree/master/packages/memory) | Evaluate a query against in-memory objects & arrays |
 
 ## Documentation

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
         "packages/codec-url": { "component": "codec-url" },
         "packages/sql": { "component": "sql" },
         "packages/typeorm": { "component": "typeorm" },
+        "packages/prisma": { "component": "prisma" },
         "packages/memory": { "component": "memory" }
     },
     "plugins": [
@@ -33,6 +34,7 @@
                 "codec-url",
                 "sql",
                 "typeorm",
+                "prisma",
                 "memory"
             ]
         }


### PR DESCRIPTION
Adds `@rapiq/prisma`, the first of the additional ORM adapters from the plan-023 direction doc, plus the core plan transform it (and the next adapters) build on.

## What it does

Serializes a parsed `Query` into a Prisma `findMany` argument object. A pure, **stateless** serializer: `execute` maps a value to a value, and `@prisma/client` is neither a runtime nor a peer dependency (devDependency only, for the engine tests). Queries compose *before* serialization (`mergeQueries`, `filters.and()`), so there is no accumulation API.

```typescript
const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
    provider: 'postgresql',
    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
});

const { args, pagination } = adapter.execute(query);
const users = await prisma.user.findMany(args);
```

| Query parameter | Prisma argument |
|---|---|
| `filters` | `where` |
| `fields` | `select` |
| `relations` | `include`, or a nested `select` when fields are picked |
| `sort` | `orderBy` |
| `pagination` | `take` / `skip` |

## Architecture: pure passes, semantics stay in core

The `where` is produced by a pipeline: `planCondition` -> **`distributeNegation` (new in `@rapiq/core`)** -> quantifier factoring -> a leaf-literal table.

`distributeNegation` eliminates group negation by pushing it to the leaves: De Morgan over compounds, leaf twins toggled, `not(ordering)` rewritten as the dual operator OR a null check (complements derived from the semantics table, not hardcoded). Core keeps group negation for sql/memory, which render it two-valued cheaply; backends without a two-valued NOT (prisma now, Drizzle/MikroORM next per plan 023) consume the transform instead of re-deriving operator semantics locally. Prisma's three-valued `not`/`NOT` is never relied upon.

## Cross-backend semantics hold exactly

Two contracts that are easy to get wrong, both pinned by probing `@rapiq/memory` and by the engine suite:

- **Same-element binding.** `filter[items.title]` + `filter[items.color]` bind to the *same* joined row in sql/typeorm/memory. The renderer factors conditions sharing a to-many path into ONE `some` scope; mixed root/relation trees are expanded distributively first (`∃` distributes over OR; capped at 64 conjuncts with a typed error). A record satisfying the conditions only on different elements does not match, on any backend.
- **`not(elemMatch(c))` is per-binding.** Group negation applies per binding with the quantifier outermost (sql wraps CASE per join row), so the complement is `some(not c)` plus the empty-collection arm, NOT `none(c)`. Every `none: {}`/absence arm follows one rule: the interior evaluated at the all-null binding an empty collection contributes.

`provider` and `metadata` are required: each metadata fact (relation, cardinality, nullability, string-typedness) changes what a *valid* prisma filter looks like, so a wrong guess is a validation error rather than degradation.

## Parity is measured, not modelled

`npm run test:db` runs the matrix through a real Prisma client and cross-checks every condition three ways: engine, `@rapiq/memory`, and an in-test evaluator. SQLite by default; PostgreSQL under `DB_TYPE=postgres` in the existing `tests-db` job (the only connector where `mode: 'insensitive'` exists, so the case contract and the ILIKE-wildcard veto are measured there). The fixtures include a mixed-element record that would have caught both semantics bugs above; earlier fixtures were too weak to distinguish them.

Measured on Postgres 18 / Prisma 6.19.3: `{ equals: 'a_b', mode: 'insensitive' }` lowers to ILIKE and wildcards (`a%b` matches every row), while `in`/`notIn` never do, so the wildcard veto applies to the equality family only.

## Known limitations

Typed `AdapterError` rather than an approximation: `regex`, `mod`, `size`, the `$this` marker, `elemMatch` on a to-one relation, and filter trees beyond the expansion ceiling. To-many `orderBy` is not expressible in Prisma; SQLite compares case-sensitively (measured, documented).

## Notes

- Release-please wiring (component and manifest) is included.
- Docs: package page, README in the #836 layout, family-table rows in every sibling README, and references from the overview, installation and executing-queries pages.
- Schema derivation from DMMF (the plan-017 analogue) is deliberately deferred, same staging as typeorm.
