### PR TITLE
feat(prisma): derive schemas from a datamodel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10453,6 +10453,9 @@
             "name": "@rapiq/prisma",
             "version": "2.0.0-beta.9",
             "license": "MIT",
+            "dependencies": {
+                "change-case": "^5.4.4"
+            },
             "devDependencies": {
                 "@prisma/client": "^6.19.3",
                 "@rapiq/core": "^2.0.0-beta.9",

--- a/packages/docs/packages/prisma.md
+++ b/packages/docs/packages/prisma.md
@@ -81,6 +81,34 @@ Prisma rejects `select` and `include` on the same level, so the adapter emits ex
 { include: { items: { include: { realm: true } } } }
 ```
 
+## Schema derivation
+
+The datamodel can also supply the *shape* of your schemas, the same staging as [@rapiq/typeorm](/packages/typeorm)'s entity derivation: the schema name, the relation allow-list and the `schemaMapping` used for relation traversal are derived, while authorization stays explicit. A derived schema without per-parameter options allows nothing.
+
+```typescript
+import { defineSchemaRegistryWithDatamodel } from '@rapiq/prisma';
+
+const registry = defineSchemaRegistryWithDatamodel(Prisma.dmmf.datamodel, {
+    schemas: {
+        user: {
+            fields: { allowed: 'inherit' },       // the model's field names
+            filters: { allowed: ['id', 'name'] }, // authorization stays yours
+        },
+    },
+});
+```
+
+One schema per model is registered under the lower-camel model name; hand-written schemas already in the registry take precedence. `defineSchemaWithModel(datamodel, 'User', options)` derives a single schema, and the `'inherit'` sentinel expands to the model's scalar and enum field names.
+
+To catch schema/model drift (a renamed field, a stale allow-list entry) at boot time instead of as a dead entry:
+
+```typescript
+import { assertSchemaMatchesModel } from '@rapiq/prisma';
+
+assertSchemaMatchesModel(schema, Prisma.dmmf.datamodel, 'User');
+// throws SchemaModelMismatchError carrying EVERY offending key
+```
+
 ## Preserving an application-owned predicate
 
 Rapiq filters **narrow** a query, they never replace it. Hand the adapter a baseline argument object and the client's conditions are conjoined with your tenant or authorization scope:

--- a/packages/docs/packages/prisma.md
+++ b/packages/docs/packages/prisma.md
@@ -11,20 +11,16 @@ Unlike the TypeORM adapter there is nothing to mutate: the adapter is a pure ser
 ## Usage
 
 ```typescript
-import { Prisma } from '@prisma/client';
-import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+import { PrismaAdapter } from '@rapiq/prisma';
 
-const adapter = new PrismaAdapter({
-    provider: 'postgresql',
-    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
-});
+const adapter = new PrismaAdapter({ model: prisma.user });
 
 const { args, pagination } = adapter.execute(query);
 
 const users = await prisma.user.findMany(args);
 ```
 
-`pagination` echoes the limit/offset actually applied, e.g. for a response `meta` block.
+A model delegate is all it takes: the model name, the datamodel (relations, cardinality, nullability, column types) and the active provider are read off the client the delegate belongs to. `pagination` echoes the limit/offset actually applied, e.g. for a response `meta` block.
 
 Bind your generated argument type so the call site stays type-checked:
 
@@ -36,7 +32,7 @@ Because the adapter produces a value instead of writing into a builder, it is **
 
 ## Model metadata
 
-`metadata` is **required**. The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:
+The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:
 
 | fact | what it decides |
 |---|---|
@@ -45,17 +41,26 @@ Because the adapter produces a value instead of writing into a builder, it is **
 | can the column hold `null`? | a null comparison on a required column is a validation error |
 | does it hold strings? | `mode: 'insensitive'` exists only on string filters |
 
-Guessing any of them produces a runtime validation error rather than graceful degradation, so the adapter asks for them up front. It is bound to one model anyway:
+Guessing any of them produces a runtime validation error rather than graceful degradation, so the adapter refuses to run without them. The client-bound form above derives all of it; the fully explicit form takes the same facts by hand:
 
 ```typescript
+import { Prisma } from '@prisma/client';
+import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+
 const adapter = new PrismaAdapter({
     provider: 'postgresql',
     metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
 });
 ```
 
+Between the two sit `{ client: prisma, model: 'User' }` and per-option overrides (`provider`, `metadata`) on the client-bound shape.
+
+::: warning
+The client-bound form reads `_runtimeDataModel`, `_activeProvider` and the delegate's `$parent` backref: private but long-stable client internals (Prisma has no public reflection API, [prisma#19392](https://github.com/prisma/prisma/issues/19392)). The engine-backed test suite pins them against real generated clients, and every read fails typed rather than guessing. The explicit form is the private-API-free path.
+:::
+
 ::: tip
-`Prisma.dmmf` is unavailable in some builds (edge/wasm targets, the new `prisma-client` generator). `defineMetadata` accepts any object of the same shape, `{ models: [{ name, fields: [{ name, kind, isList, isRequired, type }] }] }`, so a hand-written datamodel works just as well.
+`Prisma.dmmf` is unavailable in some builds (edge/wasm targets, the new `prisma-client` generator), and edge/wasm runtime datamodels are *pruned* (no cardinality or nullability); the adapter rejects those typed. `defineMetadata` accepts any object of the shape `{ models: [{ name, fields: [{ name, kind, isList, isRequired, type }] }] }`, so a hand-written datamodel works everywhere.
 :::
 
 ## Parameter mapping

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -81,6 +81,20 @@ Both `provider` and `metadata` are required. The adapter needs four facts about 
 
 Guessing any of them produces a runtime validation error rather than graceful degradation. `defineMetadata` accepts any object shaped like a Prisma datamodel, so a hand-written one works where `Prisma.dmmf` is unavailable (edge and wasm builds, the new `prisma-client` generator).
 
+## Schema derivation
+
+The datamodel can also supply the *shape* of your schemas: derived name, relation allow-list and `schemaMapping`, with authorization staying explicit (`allowed: 'inherit'` opts a parameter into the model's field names). Hand-written schemas take precedence, and `assertSchemaMatchesModel` turns schema/model drift into a boot-time failure carrying every offending key.
+
+```typescript
+import { defineSchemaRegistryWithDatamodel } from '@rapiq/prisma';
+
+const registry = defineSchemaRegistryWithDatamodel(Prisma.dmmf.datamodel, {
+    schemas: {
+        user: { filters: { allowed: ['id', 'name'] } },
+    },
+});
+```
+
 ## Preserving an application-owned predicate
 
 Rapiq filters **narrow** a query, they never replace it. Pass a baseline argument object and the caller's conditions are conjoined with your tenant or authorization scope:

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -37,13 +37,9 @@ Where the TypeORM adapter writes into a query builder, this one returns a plain 
 - 🔬 **Measured, not modelled**: the parity suite runs every condition through a real Prisma engine (SQLite by default, PostgreSQL in CI) and cross-checks it against `@rapiq/memory`.
 
 ```typescript
-import { Prisma } from '@prisma/client';
-import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+import { PrismaAdapter } from '@rapiq/prisma';
 
-const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
-    provider: 'postgresql',
-    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
-});
+const adapter = new PrismaAdapter({ model: prisma.user });
 
 const { args, pagination } = adapter.execute(query);
 
@@ -68,9 +64,21 @@ npm install @rapiq/core @rapiq/prisma
 
 `pagination` is echoed back from `execute()` as the limit/offset actually applied, ready for a response `meta` block.
 
-## Required options
+## Model binding
 
-Both `provider` and `metadata` are required. The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:
+A model delegate binds everything: the model name, the datamodel and the active provider are read off its client (private but long-stable internals, pinned against real generated clients by the engine suite; every read fails typed rather than guessing). The private-API-free alternative supplies the same facts explicitly:
+
+```typescript
+import { Prisma } from '@prisma/client';
+import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+
+const adapter = new PrismaAdapter({
+    provider: 'postgresql',
+    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+});
+```
+
+The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:
 
 | fact | what it decides |
 |---|---|
@@ -79,7 +87,7 @@ Both `provider` and `metadata` are required. The adapter needs four facts about 
 | can the column hold `null`? | a null comparison on a required column is a validation error |
 | does it hold strings? | `mode: 'insensitive'` exists only on string filters |
 
-Guessing any of them produces a runtime validation error rather than graceful degradation. `defineMetadata` accepts any object shaped like a Prisma datamodel, so a hand-written one works where `Prisma.dmmf` is unavailable (edge and wasm builds, the new `prisma-client` generator).
+Guessing any of them produces a runtime validation error rather than graceful degradation. `defineMetadata` accepts a client, a runtime datamodel or any object shaped like a Prisma datamodel, so a hand-written one works where `Prisma.dmmf` is unavailable (edge and wasm builds, the new `prisma-client` generator; pruned edge/wasm runtime datamodels are rejected typed).
 
 ## Schema derivation
 

--- a/packages/prisma/package.json
+++ b/packages/prisma/package.json
@@ -15,6 +15,9 @@
     "files": [
         "dist/"
     ],
+    "dependencies": {
+        "change-case": "^5.4.4"
+    },
     "devDependencies": {
         "@prisma/client": "^6.19.3",
         "@rapiq/core": "^2.0.0-beta.9",

--- a/packages/prisma/src/adapter/module.ts
+++ b/packages/prisma/src/adapter/module.ts
@@ -6,7 +6,11 @@
  */
 
 import type { IQuery, IQueryVisitor } from '@rapiq/core';
-import { resolveProviderOptions } from '../provider';
+import { AdapterError, ErrorCode } from '@rapiq/core';
+import type { IMetadata } from '../metadata';
+import { defineMetadata, resolveDelegateClient } from '../metadata';
+import type { ProviderOptions } from '../provider';
+import { resolveClientProvider, resolveProviderOptions } from '../provider';
 import { buildSelection } from './fields';
 import { collectRelationPaths } from './relations';
 import { buildOrderBy } from './sort';
@@ -14,10 +18,39 @@ import { WhereRenderer } from './where';
 import type {
     Args,
     ExecuteOptions,
+    PrismaAdapterClientOptions,
     PrismaAdapterOptions,
     PrismaAdapterOutput,
     Where,
 } from './types';
+
+/**
+ * Resolve the client-bound options shape: the client comes from the
+ * delegate's runtime backref (or explicitly), metadata from its
+ * runtime datamodel and the provider from its active connector, each
+ * overridable.
+ */
+function resolveClientOptions(options: PrismaAdapterClientOptions) : {
+    metadata: IMetadata,
+    provider: ProviderOptions,
+} {
+    const client = options.client ?? resolveDelegateClient(options.model);
+
+    if (!client && !(options.metadata && options.provider)) {
+        throw new AdapterError({
+            message: 'The client could not be resolved from the model delegate; ' +
+                'pass it explicitly.',
+            code: ErrorCode.SCHEMA_UNRESOLVABLE,
+        });
+    }
+
+    return {
+        metadata: options.metadata ?? defineMetadata(client as object, options.model),
+        provider: resolveProviderOptions(
+            options.provider ?? resolveClientProvider(client as object),
+        ),
+    };
+}
 
 /**
  * Serializes a parsed query into a prisma `findMany` argument object.
@@ -48,6 +81,18 @@ export class PrismaAdapter<
 
     constructor(options: PrismaAdapterOptions) {
         this.options = options;
+
+        if ('model' in options) {
+            const resolved = resolveClientOptions(options);
+
+            this.renderer = new WhereRenderer(
+                resolved.metadata,
+                resolved.provider,
+            );
+
+            return;
+        }
+
         this.renderer = new WhereRenderer(
             options.metadata,
             resolveProviderOptions(options.provider),

--- a/packages/prisma/src/adapter/types.ts
+++ b/packages/prisma/src/adapter/types.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { IMetadata } from '../metadata';
+import type { IMetadata, ModelInput } from '../metadata';
 import type { Provider, ProviderOptions } from '../provider';
 
 /**
@@ -41,7 +41,7 @@ export type FiltersAdapterOptions = {
     caseSensitive?: string[] | boolean,
 };
 
-export type PrismaAdapterOptions = {
+export type PrismaAdapterExplicitOptions = {
     /**
      * Datasource provider of the targeted prisma client, or an
      * explicit capability preset. Decides whether
@@ -65,6 +65,38 @@ export type PrismaAdapterOptions = {
 
     filters?: FiltersAdapterOptions,
 };
+
+/**
+ * The client-bound shape: metadata and provider are read off the
+ * client (its runtime datamodel and active provider), so a model
+ * delegate is all it takes:
+ *
+ * ```typescript
+ * new PrismaAdapter({ model: prisma.user })
+ * ```
+ *
+ * The client resolves from the delegate's runtime backref; pass it
+ * explicitly when the model is a plain name, and any of `provider`
+ * or `metadata` to override the derived value. These reads use
+ * private but long-stable client internals, verified against real
+ * generated clients by the engine suite;
+ * {@link PrismaAdapterExplicitOptions} stays the private-API-free
+ * path.
+ */
+export type PrismaAdapterClientOptions = {
+    model: ModelInput,
+
+    client?: object,
+
+    provider?: `${Provider}` | ProviderOptions,
+
+    metadata?: IMetadata,
+
+    filters?: FiltersAdapterOptions,
+};
+
+export type PrismaAdapterOptions =    PrismaAdapterExplicitOptions |
+    PrismaAdapterClientOptions;
 
 // -----------------------------------------------------------
 

--- a/packages/prisma/src/errors/index.ts
+++ b/packages/prisma/src/errors/index.ts
@@ -5,8 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './adapter';
-export * from './errors';
-export * from './metadata';
-export * from './provider';
-export * from './schema';
+export * from './module';
+export * from './types';

--- a/packages/prisma/src/errors/module.ts
+++ b/packages/prisma/src/errors/module.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ErrorCode, SchemaError } from '@rapiq/core';
+import type { SchemaModelMismatchErrorOptions } from './types';
+
+/**
+ * A schema references keys unknown to the model it targets: thrown
+ * by `assertSchemaMatchesModel` with **every** offending key
+ * collected, not just the first one.
+ */
+export class SchemaModelMismatchError extends SchemaError {
+    public readonly schema : string | undefined;
+
+    public readonly model : string;
+
+    public readonly keys : string[];
+
+    constructor(options: SchemaModelMismatchErrorOptions) {
+        super({
+            message: `The ${options.schema ? `schema "${options.schema}"` : 'schema'} ` +
+                `references keys unknown to the model ${options.model}: ${options.keys.join(', ')}.`,
+            code: ErrorCode.SCHEMA_ENTITY_MISMATCH,
+        });
+
+        this.schema = options.schema;
+        this.model = options.model;
+        this.keys = options.keys;
+    }
+}

--- a/packages/prisma/src/errors/types.ts
+++ b/packages/prisma/src/errors/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type SchemaModelMismatchErrorOptions = {
+    /**
+     * Name of the offending schema (a schema may be unnamed).
+     */
+    schema?: string,
+
+    /**
+     * Name of the model the schema was validated against.
+     */
+    model: string,
+
+    /**
+     * Every schema key unknown to the model.
+     */
+    keys: string[],
+};

--- a/packages/prisma/src/metadata/index.ts
+++ b/packages/prisma/src/metadata/index.ts
@@ -6,4 +6,5 @@
  */
 
 export * from './module';
+export * from './normalize';
 export * from './types';

--- a/packages/prisma/src/metadata/module.ts
+++ b/packages/prisma/src/metadata/module.ts
@@ -6,6 +6,8 @@
  */
 
 import { AdapterError, ErrorCode } from '@rapiq/core';
+import type { DatamodelInput, ModelInput } from './normalize';
+import { normalizeDatamodel, resolveModelName } from './normalize';
 import type {
     Datamodel,
     DatamodelField,
@@ -126,14 +128,17 @@ export class Metadata implements IMetadata {
 }
 
 /**
- * Bind a prisma datamodel to the model a query targets.
+ * Bind a datamodel to the model a query targets. Accepts a prisma
+ * client instance, its runtime datamodel, `Prisma.dmmf.datamodel` or
+ * any hand-written object of the same shape; the model is a name or
+ * a model delegate.
  *
  * ```typescript
- * import { Prisma } from '@prisma/client';
- *
+ * const metadata = defineMetadata(prisma, prisma.user);
+ * // or, private-API-free:
  * const metadata = defineMetadata(Prisma.dmmf.datamodel, 'User');
  * ```
  */
-export function defineMetadata(datamodel: Datamodel, model: string) : Metadata {
-    return new Metadata(datamodel, model);
+export function defineMetadata(datamodel: DatamodelInput, model: ModelInput) : Metadata {
+    return new Metadata(normalizeDatamodel(datamodel), resolveModelName(model));
 }

--- a/packages/prisma/src/metadata/normalize.ts
+++ b/packages/prisma/src/metadata/normalize.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError, ErrorCode } from '@rapiq/core';
+import type { Datamodel, DatamodelField, DatamodelModel } from './types';
+
+/**
+ * Anything a datamodel can be read from:
+ *
+ * - `Prisma.dmmf.datamodel` (models as an array), or any hand-written
+ *   object of the same shape,
+ * - `client._runtimeDataModel` (models as a record keyed by name),
+ * - a `PrismaClient` instance, which carries the latter.
+ *
+ * The client paths read `_runtimeDataModel`, a private but
+ * long-stable client internal (prisma has no public reflection API,
+ * prisma/prisma#19392); the engine-backed test suite verifies it
+ * against real generated clients. The datamodel shapes are the
+ * private-API-free fallback.
+ */
+export type DatamodelInput = Datamodel | object;
+
+/**
+ * A model delegate (`prisma.user`), or a plain model name (`'User'`).
+ * The delegate resolves through its public field references, with the
+ * runtime `$name` marker as the primary source.
+ */
+export type ModelInput = string | { fields: object };
+
+function isField(input: unknown) : input is DatamodelField {
+    return typeof input === 'object' &&
+        input !== null &&
+        typeof (input as DatamodelField).name === 'string' &&
+        typeof (input as DatamodelField).kind === 'string';
+}
+
+/**
+ * Edge and wasm builds (`engineType = "client"`) strip the runtime
+ * datamodel down to names and kinds: no cardinality, no nullability.
+ * Deriving metadata from that would silently degrade every adapter
+ * default, so it fails here instead; a hand-written datamodel is the
+ * documented escape hatch.
+ */
+function assertComplete(models: DatamodelModel[]) : void {
+    for (const model of models) {
+        for (const field of model.fields) {
+            if (
+                typeof field.isList !== 'boolean' ||
+                typeof field.isRequired !== 'boolean'
+            ) {
+                throw new AdapterError({
+                    message: 'The datamodel is pruned (no cardinality or nullability, ' +
+                        'e.g. an edge/wasm build); supply a hand-written datamodel instead.',
+                    code: ErrorCode.SCHEMA_UNRESOLVABLE,
+                });
+            }
+        }
+    }
+}
+
+/**
+ * Normalize any {@link DatamodelInput} to the array-shaped datamodel
+ * the metadata and schema modules consume.
+ */
+export function normalizeDatamodel(input: DatamodelInput) : Datamodel {
+    if (typeof input === 'object' && input !== null) {
+        const source = input as Record<string, any>;
+
+        // a client instance carries the runtime datamodel
+        if (source._runtimeDataModel) {
+            return normalizeDatamodel(source._runtimeDataModel as object);
+        }
+
+        if (Array.isArray(source.models)) {
+            const models = source.models as DatamodelModel[];
+            assertComplete(models);
+
+            return { models };
+        }
+
+        // the runtime datamodel keys models by name and strips it
+        // from the entries
+        if (typeof source.models === 'object' && source.models !== null) {
+            const models : DatamodelModel[] = [];
+
+            for (const [name, model] of Object.entries(source.models as Record<string, any>)) {
+                if (!model || !Array.isArray(model.fields)) {
+                    continue;
+                }
+
+                models.push({ name, fields: model.fields.filter(isField) });
+            }
+
+            if (models.length > 0) {
+                assertComplete(models);
+
+                return { models };
+            }
+        }
+    }
+
+    throw new AdapterError({
+        message: 'The datamodel could not be resolved: expected a datamodel, ' +
+            'a runtime datamodel or a prisma client instance.',
+        code: ErrorCode.SCHEMA_UNRESOLVABLE,
+    });
+}
+
+/**
+ * Resolve a {@link ModelInput} to the model name: a string passes
+ * through, a delegate answers through its runtime `$name` marker or,
+ * failing that, the `modelName` of its public field references.
+ */
+export function resolveModelName(input: ModelInput) : string {
+    if (typeof input === 'string') {
+        return input;
+    }
+
+    if (typeof input === 'object' && input !== null) {
+        const source = input as Record<string, any>;
+
+        if (typeof source.$name === 'string') {
+            return source.$name;
+        }
+
+        if (typeof source.fields === 'object' && source.fields !== null) {
+            for (const field of Object.values(source.fields as Record<string, any>)) {
+                if (field && typeof field.modelName === 'string') {
+                    return field.modelName;
+                }
+            }
+        }
+
+        if (typeof source.name === 'string') {
+            return source.name;
+        }
+    }
+
+    throw new AdapterError({
+        message: 'The model could not be resolved: expected a model name or a model delegate.',
+        code: ErrorCode.SCHEMA_UNRESOLVABLE,
+    });
+}
+
+/**
+ * The client a model delegate belongs to (`prisma.user` back to
+ * `prisma`), through the runtime `$parent` backref.
+ */
+export function resolveDelegateClient(input: ModelInput) : object | undefined {
+    if (
+        typeof input === 'object' &&
+        input !== null &&
+        typeof (input as Record<string, any>).$parent === 'object' &&
+        (input as Record<string, any>).$parent !== null
+    ) {
+        return (input as Record<string, any>).$parent;
+    }
+
+    return undefined;
+}

--- a/packages/prisma/src/provider/module.ts
+++ b/packages/prisma/src/provider/module.ts
@@ -59,3 +59,26 @@ export function resolveProviderOptions(
 
     return input;
 }
+
+/**
+ * Read the active provider off a prisma client instance
+ * (`_activeProvider`, a private but long-stable client internal;
+ * verified against real generated clients by the engine suite).
+ * Fails typed instead of guessing: a wrong provider breaks every
+ * case-insensitive filter.
+ */
+export function resolveClientProvider(client: object) : `${Provider}` {
+    const source = client as Record<string, any>;
+
+    const name = source._activeProvider ??
+        source._engineConfig?.activeProvider;
+
+    if (typeof name === 'string') {
+        return name as `${Provider}`;
+    }
+
+    throw new AdapterError({
+        message: 'The provider could not be resolved from the client; pass it explicitly.',
+        code: ErrorCode.FEATURE_UNSUPPORTED,
+    });
+}

--- a/packages/prisma/src/schema/assert.ts
+++ b/packages/prisma/src/schema/assert.ts
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition, ObjectLiteral, Schema } from '@rapiq/core';
+import {
+    AdapterError,
+    ErrorCode,
+    isFilter,
+    isFilters,
+} from '@rapiq/core';
+import { SchemaModelMismatchError } from '../errors';
+import type { Datamodel } from '../metadata';
+
+const RELATION_KIND = 'object';
+
+/**
+ * Verify that every key referenced by the schema exists on the model:
+ * plain keys must be scalar or enum field names, dotted keys must be
+ * headed by a relation (the remainder belongs to the related model's
+ * own schema), and `relations.allowed` keys must be relation field
+ * names. Turns silent schema/model drift (e.g. a renamed field) into
+ * a boot-time failure instead of a dead allow-list entry or a runtime
+ * validation error.
+ *
+ * @throws SchemaModelMismatchError carrying every offending key.
+ */
+export function assertSchemaMatchesModel<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    schema: Schema<RECORD>,
+    datamodel: Datamodel,
+    model: string,
+) : void {
+    const target = datamodel.models.find((item) => item.name === model);
+    if (!target) {
+        throw new AdapterError({
+            message: `The model "${model}" is not part of the datamodel.`,
+            code: ErrorCode.SCHEMA_UNRESOLVABLE,
+        });
+    }
+
+    const columns = new Set<string>();
+    const relations = new Set<string>();
+    for (const field of target.fields) {
+        if (field.kind === RELATION_KIND) {
+            relations.add(field.name);
+        } else {
+            columns.add(field.name);
+        }
+    }
+
+    const invalid = new Set<string>();
+
+    const headOf = (key: string) => {
+        const index = key.indexOf('.');
+        return index === -1 ? key : key.substring(0, index);
+    };
+
+    const checkColumnKey = (key: unknown) => {
+        if (typeof key !== 'string' || columns.has(key)) {
+            return;
+        }
+
+        // dotted keys must be headed by a relation; the remainder
+        // belongs to the related model's own schema.
+        const head = headOf(key);
+        if (head !== key && relations.has(head)) {
+            return;
+        }
+
+        invalid.add(key);
+    };
+    const checkColumnKeys = (keys: string[] | string[][]) => {
+        for (const key of keys.flat()) {
+            checkColumnKey(key);
+        }
+    };
+    // a filters default is a condition tree, not a key list: walk it
+    // and validate every leaf field like a filters allow-list entry.
+    const checkCondition = (condition: ICondition) => {
+        if (isFilters(condition)) {
+            for (const child of condition.value) {
+                checkCondition(child);
+            }
+            return;
+        }
+
+        if (isFilter(condition)) {
+            checkColumnKey(condition.field);
+        }
+    };
+
+    checkColumnKeys(schema.fields.default);
+    checkColumnKeys(schema.fields.allowed);
+
+    checkColumnKeys(schema.filters.allowed);
+    if (schema.filters.default) {
+        checkCondition(schema.filters.default);
+    }
+
+    checkColumnKeys(schema.sort.allowed);
+    checkColumnKeys(schema.sort.defaultKeys);
+
+    // relation keys resolve against relations only: the first
+    // (or sole) segment must be a relation field name.
+    for (const key of schema.relations.allowed || []) {
+        if (!relations.has(headOf(key))) {
+            invalid.add(key);
+        }
+    }
+
+    if (invalid.size > 0) {
+        throw new SchemaModelMismatchError({
+            schema: schema.name,
+            model,
+            keys: [...invalid],
+        });
+    }
+}

--- a/packages/prisma/src/schema/assert.ts
+++ b/packages/prisma/src/schema/assert.ts
@@ -13,7 +13,8 @@ import {
     isFilters,
 } from '@rapiq/core';
 import { SchemaModelMismatchError } from '../errors';
-import type { Datamodel } from '../metadata';
+import type { DatamodelInput, ModelInput } from '../metadata';
+import { normalizeDatamodel, resolveModelName } from '../metadata';
 
 const RELATION_KIND = 'object';
 
@@ -32,10 +33,12 @@ export function assertSchemaMatchesModel<
     RECORD extends ObjectLiteral = ObjectLiteral,
 >(
     schema: Schema<RECORD>,
-    datamodel: Datamodel,
-    model: string,
+    input: DatamodelInput,
+    modelInput: ModelInput,
 ) : void {
-    const target = datamodel.models.find((item) => item.name === model);
+    const model = resolveModelName(modelInput);
+
+    const target = normalizeDatamodel(input).models.find((item) => item.name === model);
     if (!target) {
         throw new AdapterError({
             message: `The model "${model}" is not part of the datamodel.`,

--- a/packages/prisma/src/schema/index.ts
+++ b/packages/prisma/src/schema/index.ts
@@ -5,8 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './adapter';
-export * from './errors';
-export * from './metadata';
-export * from './provider';
-export * from './schema';
+export * from './assert';
+export * from './module';
+export * from './types';

--- a/packages/prisma/src/schema/module.ts
+++ b/packages/prisma/src/schema/module.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    ObjectLiteral,
+    Schema,
+    SchemaOptions,
+} from '@rapiq/core';
+import {
+    AdapterError,
+    ErrorCode,
+    SchemaRegistry,
+    defineSchema,
+} from '@rapiq/core';
+import { camelCase } from 'change-case';
+import type { Datamodel, DatamodelModel } from '../metadata';
+import type {
+    ModelSchemaOptions,
+    SchemaRegistryWithDatamodelOptions,
+} from './types';
+
+const RELATION_KIND = 'object';
+
+export function buildModelSchemaName(input: DatamodelModel | string) : string {
+    return camelCase(typeof input === 'string' ? input : input.name);
+}
+
+function resolveModel(datamodel: Datamodel, name: string) : DatamodelModel {
+    const model = datamodel.models.find((item) => item.name === name);
+    if (!model) {
+        throw new AdapterError({
+            message: `The model "${name}" is not part of the datamodel.`,
+            code: ErrorCode.SCHEMA_UNRESOLVABLE,
+        });
+    }
+
+    return model;
+}
+
+/**
+ * Scalar and enum field names; relation fields are keys of the
+ * related model's own schema, never of this one.
+ */
+function deriveColumnKeys(model: DatamodelModel) : string[] {
+    const output : string[] = [];
+
+    for (const field of model.fields) {
+        if (field.kind === RELATION_KIND) {
+            continue;
+        }
+
+        output.push(field.name);
+    }
+
+    return output;
+}
+
+/**
+ * Derivation supplies *shape*: the schema name, the relation
+ * traversal map and, on request (`allowed: 'inherit'`), the model's
+ * field names. Authorization stays explicit; a derived schema without
+ * per-parameter options allows nothing more than a hand-written one.
+ */
+function buildSchemaOptions(
+    model: DatamodelModel,
+    input: ModelSchemaOptions<any> = {},
+) : SchemaOptions {
+    const {
+        fields,
+        filters,
+        sort,
+        relations,
+        pagination,
+        ...base
+    } = input;
+
+    const relationKeys : string[] = [];
+    const schemaMapping : Record<string, string> = {};
+    for (const field of model.fields) {
+        if (field.kind !== RELATION_KIND) {
+            continue;
+        }
+
+        relationKeys.push(field.name);
+        schemaMapping[field.name] = buildModelSchemaName(field.type);
+    }
+
+    let columnKeys : string[] | undefined;
+    const resolveAllowed = (allowed: unknown) => {
+        if (allowed === 'inherit') {
+            columnKeys = columnKeys || deriveColumnKeys(model);
+            return columnKeys;
+        }
+
+        return allowed;
+    };
+
+    const output : SchemaOptions = {
+        ...base,
+        name: base.name ?? buildModelSchemaName(model),
+        schemaMapping: { ...schemaMapping, ...base.schemaMapping },
+        relations: {
+            allowed: relationKeys,
+            ...relations,
+        },
+    };
+
+    if (fields) {
+        output.fields = { ...fields, allowed: resolveAllowed(fields.allowed) } as SchemaOptions['fields'];
+    }
+
+    if (filters) {
+        output.filters = { ...filters, allowed: resolveAllowed(filters.allowed) } as SchemaOptions['filters'];
+    }
+
+    if (sort) {
+        output.sort = { ...sort, allowed: resolveAllowed(sort.allowed) } as SchemaOptions['sort'];
+    }
+
+    if (pagination) {
+        output.pagination = pagination;
+    }
+
+    return output;
+}
+
+/**
+ * Define a schema for one model of a prisma datamodel
+ * (`Prisma.dmmf.datamodel`, or any object of the same shape).
+ *
+ * ```typescript
+ * const schema = defineSchemaWithModel<User>(Prisma.dmmf.datamodel, 'User', {
+ *     fields: { allowed: 'inherit' },
+ *     filters: { allowed: ['id', 'name'] },
+ * });
+ * ```
+ */
+export function defineSchemaWithModel<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+>(
+    datamodel: Datamodel,
+    model: string,
+    options?: ModelSchemaOptions<RECORD>,
+) : Schema<RECORD> {
+    return defineSchema(buildSchemaOptions(
+        resolveModel(datamodel, model),
+        options,
+    ) as SchemaOptions<RECORD>);
+}
+
+/**
+ * Register one derived schema per model of the datamodel, named by
+ * the lower-camel model name. Hand-written schemas already present in
+ * the registry take precedence; per-model options are keyed by the
+ * derived name.
+ */
+export function defineSchemaRegistryWithDatamodel(
+    datamodel: Datamodel,
+    options: SchemaRegistryWithDatamodelOptions = {},
+) : SchemaRegistry {
+    const registry = options.registry || new SchemaRegistry();
+    const schemasOptions = options.schemas || {};
+
+    const names = new Set<string>();
+    for (const model of datamodel.models) {
+        const name = buildModelSchemaName(model);
+        if (names.has(name)) {
+            throw new Error(`The derived schema name "${name}" is not unique across the datamodel.`);
+        }
+
+        names.add(name);
+
+        // an already registered schema (e.g. hand-written) takes precedence.
+        if (registry.get(name)) {
+            if (schemasOptions[name]) {
+                throw new Error(`The schemas option key "${name}" cannot be applied, since the schema is already registered.`);
+            }
+
+            continue;
+        }
+
+        registry.add(defineSchemaWithModel(datamodel, model.name, schemasOptions[name]));
+    }
+
+    for (const name of Object.keys(schemasOptions)) {
+        if (!names.has(name)) {
+            throw new Error(`The schemas option key "${name}" does not match any model of the datamodel.`);
+        }
+    }
+
+    return registry;
+}

--- a/packages/prisma/src/schema/module.ts
+++ b/packages/prisma/src/schema/module.ts
@@ -17,7 +17,13 @@ import {
     defineSchema,
 } from '@rapiq/core';
 import { camelCase } from 'change-case';
-import type { Datamodel, DatamodelModel } from '../metadata';
+import type {
+    Datamodel,
+    DatamodelInput,
+    DatamodelModel,
+    ModelInput,
+} from '../metadata';
+import { normalizeDatamodel, resolveModelName } from '../metadata';
 import type {
     ModelSchemaOptions,
     SchemaRegistryWithDatamodelOptions,
@@ -142,12 +148,12 @@ function buildSchemaOptions(
 export function defineSchemaWithModel<
     RECORD extends ObjectLiteral = ObjectLiteral,
 >(
-    datamodel: Datamodel,
-    model: string,
+    datamodel: DatamodelInput,
+    model: ModelInput,
     options?: ModelSchemaOptions<RECORD>,
 ) : Schema<RECORD> {
     return defineSchema(buildSchemaOptions(
-        resolveModel(datamodel, model),
+        resolveModel(normalizeDatamodel(datamodel), resolveModelName(model)),
         options,
     ) as SchemaOptions<RECORD>);
 }
@@ -159,9 +165,10 @@ export function defineSchemaWithModel<
  * derived name.
  */
 export function defineSchemaRegistryWithDatamodel(
-    datamodel: Datamodel,
+    input: DatamodelInput,
     options: SchemaRegistryWithDatamodelOptions = {},
 ) : SchemaRegistry {
+    const datamodel = normalizeDatamodel(input);
     const registry = options.registry || new SchemaRegistry();
     const schemasOptions = options.schemas || {};
 

--- a/packages/prisma/src/schema/types.ts
+++ b/packages/prisma/src/schema/types.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    BaseSchemaOptions,
+    FieldsOptions,
+    FiltersOptions,
+    ObjectLiteral,
+    PaginationOptions,
+    RelationsOptions,
+    SchemaRegistry,
+    SortOptions,
+} from '@rapiq/core';
+
+/**
+ * Marks an `allowed` list to be inherited from the model's scalar and
+ * enum field names (relation fields excluded).
+ */
+export type InheritSentinel = 'inherit';
+
+type WithDerivableAllowed<OPTIONS extends { allowed?: unknown }> = Omit<OPTIONS, 'allowed'> & {
+    allowed?: NonNullable<OPTIONS['allowed']> | InheritSentinel,
+};
+
+export type ModelSchemaOptions<
+    RECORD extends ObjectLiteral = ObjectLiteral,
+> = BaseSchemaOptions & {
+    fields?: WithDerivableAllowed<FieldsOptions<RECORD>>,
+    filters?: WithDerivableAllowed<FiltersOptions<RECORD>>,
+    sort?: WithDerivableAllowed<SortOptions<RECORD>>,
+    relations?: RelationsOptions<RECORD>,
+    pagination?: PaginationOptions,
+};
+
+/**
+ * Per-model options, keyed by the derived schema name (the
+ * lower-camel model name).
+ */
+export type ModelSchemasOptions = Record<string, ModelSchemaOptions<any>>;
+
+export type SchemaRegistryWithDatamodelOptions = {
+    schemas?: ModelSchemasOptions,
+
+    /**
+     * Registry to extend instead of creating a new one. Schemas
+     * already registered under a derived name take precedence; the
+     * model is skipped.
+     */
+    registry?: SchemaRegistry,
+};

--- a/packages/prisma/test/unit/acceptance.spec.ts
+++ b/packages/prisma/test/unit/acceptance.spec.ts
@@ -14,9 +14,10 @@ import {
     eq, 
 } from '@rapiq/core';
 import type { Args } from '../../src';
-import { PrismaAdapter } from '../../src';
+import { PrismaAdapter, defineSchemaRegistryWithDatamodel } from '../../src';
 import { selectRows } from '../data/evaluate';
 import { createAdapterOptions, createRegistry } from '../data/schema';
+import { datamodel } from '../data/datamodel';
 import type { User } from '../data/type';
 
 const records : User[] = [
@@ -79,6 +80,48 @@ function createUserRepository(schema?: Schema<User>) {
         },
     };
 }
+
+describe('acceptance: derived registry to prisma arguments', () => {
+    it('should decode against a derived schema and serialize', () => {
+        // shape from the datamodel, authorization explicit per model.
+        const registry = defineSchemaRegistryWithDatamodel(datamodel, {
+            schemas: {
+                user: {
+                    fields: { default: ['id', 'first_name'] },
+                    filters: { allowed: ['age', 'realm.name'] },
+                    sort: { allowed: ['age'] },
+                },
+                realm: {
+                    fields: { allowed: 'inherit' },
+                    filters: { allowed: ['name'] },
+                },
+            },
+        });
+
+        const codec = createURLCodec(registry);
+        const adapter = new PrismaAdapter(createAdapterOptions());
+
+        const query = codec.decode(
+            'filter[age]=18&filter[realm.name]=master&include=realm&sort=-age',
+            { schema: 'user' },
+        );
+
+        const { args } = adapter.execute(query!);
+
+        expect(args.where).toEqual({
+            AND: [
+                { age: { equals: 18 } },
+                { realm: { is: { name: { equals: 'master', mode: 'insensitive' } } } },
+            ],
+        });
+        expect(args.select).toEqual({
+            id: true, 
+            first_name: true, 
+            realm: true, 
+        });
+        expect(args.orderBy).toEqual([{ age: 'desc' }]);
+    });
+});
 
 describe('acceptance: request query to prisma arguments', () => {
     const repository = createUserRepository();

--- a/packages/prisma/test/unit/client.spec.ts
+++ b/packages/prisma/test/unit/client.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    ErrorCode,
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    eq,
+} from '@rapiq/core';
+import {
+    PrismaAdapter,
+    assertSchemaMatchesModel,
+    defineMetadata,
+    defineSchemaRegistryWithDatamodel,
+    defineSchemaWithModel,
+    normalizeDatamodel,
+    resolveClientProvider,
+    resolveModelName,
+} from '../../src';
+import { datamodel } from '../data/datamodel';
+
+/**
+ * The runtime datamodel keys models by name and strips the name from
+ * the entries; a client instance carries it plus the active provider,
+ * and a model delegate points back at its client. Shapes verified
+ * against a real generated client by the engine suite; these specs
+ * pin the resolution logic itself.
+ */
+function createFakeClient(provider = 'postgresql') {
+    const models : Record<string, any> = {};
+    for (const model of datamodel.models) {
+        models[model.name] = { fields: model.fields };
+    }
+
+    const client : Record<string, any> = {
+        _runtimeDataModel: { models },
+        _activeProvider: provider,
+    };
+
+    client.user = {
+        $name: 'User',
+        $parent: client,
+        fields: { id: { modelName: 'User', name: 'id' } },
+        findMany: () => [],
+    };
+
+    return client;
+}
+
+describe('src/metadata/normalize.ts', () => {
+    it('should answer identically from every datamodel source', () => {
+        const client = createFakeClient();
+
+        const fromDatamodel = defineMetadata(datamodel, 'User');
+        const fromClient = defineMetadata(client, 'User');
+        const fromRuntime = defineMetadata(client._runtimeDataModel, 'User');
+
+        const paths = ['realm', 'items', 'first_name', 'address', 'realm.name', 'items.color'];
+
+        for (const path of paths) {
+            for (const metadata of [fromClient, fromRuntime]) {
+                expect([path, metadata.isRelation(path)]).toEqual([path, fromDatamodel.isRelation(path)]);
+                expect([path, metadata.isToMany(path)]).toEqual([path, fromDatamodel.isToMany(path)]);
+                expect([path, metadata.isNullable(path)]).toEqual([path, fromDatamodel.isNullable(path)]);
+                expect([path, metadata.isString(path)]).toEqual([path, fromDatamodel.isString(path)]);
+            }
+        }
+    });
+
+    it('should resolve a model name from a delegate', () => {
+        const client = createFakeClient();
+
+        expect(resolveModelName('User')).toEqual('User');
+        expect(resolveModelName(client.user)).toEqual('User');
+        expect(resolveModelName({ fields: { id: { modelName: 'User' } } })).toEqual('User');
+    });
+
+    it('should fail typed for a pruned datamodel', () => {
+        // edge/wasm builds strip cardinality and nullability.
+        const pruned = {
+            models: [{
+                name: 'User',
+                fields: [{
+                    name: 'id', 
+                    kind: 'scalar', 
+                    type: 'Int', 
+                }],
+            }],
+        };
+
+        expect(() => normalizeDatamodel(pruned as any)).toThrowError(
+            expect.objectContaining({ code: ErrorCode.SCHEMA_UNRESOLVABLE }),
+        );
+    });
+
+    it('should fail typed for an unrecognizable source', () => {
+        expect(() => normalizeDatamodel({} as any)).toThrowError(
+            expect.objectContaining({ code: ErrorCode.SCHEMA_UNRESOLVABLE }),
+        );
+    });
+});
+
+describe('src/schema (client sources)', () => {
+    it('should derive a registry straight from a client', () => {
+        const client = createFakeClient();
+
+        const registry = defineSchemaRegistryWithDatamodel(client, { schemas: { user: { filters: { allowed: ['id'] } } } });
+
+        expect(registry.get('user')?.filters.allowed).toEqual(['id']);
+        expect(registry.get('user')?.mapSchema('items')).toEqual('item');
+        expect(registry.get('realm')).toBeDefined();
+    });
+
+    it('should derive and assert from a delegate', () => {
+        const client = createFakeClient();
+
+        const schema = defineSchemaWithModel(client, client.user, { fields: { allowed: 'inherit' } });
+
+        expect(schema.name).toEqual('user');
+        expect(() => assertSchemaMatchesModel(schema, client, client.user)).not.toThrow();
+    });
+});
+
+describe('src/provider/module.ts (client)', () => {
+    it('should read the active provider off a client', () => {
+        expect(resolveClientProvider(createFakeClient('mysql'))).toEqual('mysql');
+        expect(resolveClientProvider({ _engineConfig: { activeProvider: 'sqlite' } })).toEqual('sqlite');
+    });
+
+    it('should fail typed when the provider is unreadable', () => {
+        expect(() => resolveClientProvider({})).toThrowError(
+            expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
+        );
+    });
+});
+
+describe('src/adapter/module.ts (client options)', () => {
+    const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('first_name', 'Peter')]) });
+
+    it('should bind everything from a model delegate', () => {
+        const client = createFakeClient();
+
+        const { args } = new PrismaAdapter({ model: client.user }).execute(query);
+
+        // provider postgresql (mode emitted), metadata bound (string column)
+        expect(args.where).toEqual({ first_name: { equals: 'Peter', mode: 'insensitive' } });
+    });
+
+    it('should bind from a client and a model name', () => {
+        const client = createFakeClient('mysql');
+
+        const { args } = new PrismaAdapter({ client, model: 'User' }).execute(query);
+
+        // the mysql collation compares case-insensitively on its own
+        expect(args.where).toEqual({ first_name: { equals: 'Peter' } });
+    });
+
+    it('should let explicit overrides win over derived values', () => {
+        const client = createFakeClient('postgresql');
+
+        const { args } = new PrismaAdapter({
+            model: client.user,
+            provider: 'sqlite',
+        }).execute(query);
+
+        expect(args.where).toEqual({ first_name: { equals: 'Peter' } });
+    });
+
+    it('should fail typed for a delegate without a client backref', () => {
+        expect(() => new PrismaAdapter({ model: { fields: { id: { modelName: 'User' } } } })).toThrowError(
+            expect.objectContaining({ code: ErrorCode.SCHEMA_UNRESOLVABLE }),
+        );
+    });
+});

--- a/packages/prisma/test/unit/engine.db.spec.ts
+++ b/packages/prisma/test/unit/engine.db.spec.ts
@@ -252,6 +252,35 @@ describe('engine parity (prisma vs memory)', () => {
         expect(rows).toHaveLength(4);
     });
 
+    it('should bind from a real model delegate', async () => {
+        // the one-argument form reads model name, datamodel and
+        // provider off the delegate's runtime backref; this pins those
+        // private internals against the real generated client.
+        const bound = new PrismaAdapter({ model: database.client.user });
+
+        const conditions : Condition[] = [
+            eq('address', 'Hogwarts'),
+            ne('items.title', 'book'),
+            not(and(eq('realm.name', 'master'), gte('age', 18))),
+        ];
+
+        for (const condition of conditions) {
+            const expected = adapter.execute(new Query({ filters: new FiltersNode(FilterCompoundOperator.AND, [condition]) })).args;
+
+            const derived = bound.execute(new Query({ filters: new FiltersNode(FilterCompoundOperator.AND, [condition]) })).args;
+
+            expect(derived).toEqual(expected);
+
+            const rows = await database.client.user.findMany({
+                where: derived.where,
+                select: { id: true },
+            });
+
+            expect(rows.map((row: any) => row.id).sort((a: number, b: number) => a - b))
+                .toEqual(memoryIds(condition));
+        }
+    });
+
     it('should keep the engine-free fixture datamodel faithful', () => {
         // the engine-free specs run against a hand-written datamodel;
         // if it drifts from the real one they prove nothing.

--- a/packages/prisma/test/unit/schema.spec.ts
+++ b/packages/prisma/test/unit/schema.spec.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    ErrorCode,
+    SchemaRegistry,
+    and,
+    defineSchema,
+    eq,
+} from '@rapiq/core';
+import {
+    assertSchemaMatchesModel,
+    defineSchemaRegistryWithDatamodel,
+    defineSchemaWithModel,
+} from '../../src';
+import { datamodel } from '../data/datamodel';
+import type { User } from '../data/type';
+
+describe('src/schema/module.ts', () => {
+    describe('defineSchemaWithModel', () => {
+        it('should derive name, relations and schema mapping', () => {
+            const schema = defineSchemaWithModel<User>(datamodel, 'User');
+
+            expect(schema.name).toEqual('user');
+            expect(schema.relations.allowed).toEqual(['realm', 'items']);
+            expect(schema.mapSchema('realm')).toEqual('realm');
+            expect(schema.mapSchema('items')).toEqual('item');
+        });
+
+        it('should inherit an allowed list from the model fields', () => {
+            const schema = defineSchemaWithModel<User>(datamodel, 'User', { fields: { allowed: 'inherit' } });
+
+            expect(schema.fields.allowed).toEqual([
+                'id', 
+                'first_name', 
+                'last_name', 
+                'email', 
+                'age', 
+                'address', 
+                'realm_id',
+            ]);
+        });
+
+        it('should keep an explicit allowed list untouched', () => {
+            const schema = defineSchemaWithModel<User>(datamodel, 'User', { filters: { allowed: ['id', 'first_name'] } });
+
+            expect(schema.filters.allowed).toEqual(['id', 'first_name']);
+        });
+
+        it('should allow nothing without per-parameter options', () => {
+            // derivation supplies shape, not authorization.
+            const schema = defineSchemaWithModel<User>(datamodel, 'User');
+
+            expect(schema.fields.allowed).toEqual([]);
+            expect(schema.filters.allowed).toEqual([]);
+        });
+
+        it('should let explicit base options win', () => {
+            const schema = defineSchemaWithModel<User>(datamodel, 'User', {
+                name: 'account',
+                schemaMapping: { realm: 'customRealm' },
+            });
+
+            expect(schema.name).toEqual('account');
+            expect(schema.mapSchema('realm')).toEqual('customRealm');
+            expect(schema.mapSchema('items')).toEqual('item');
+        });
+
+        it('should fail typed for a model outside the datamodel', () => {
+            expect(() => defineSchemaWithModel(datamodel, 'user')).toThrowError(
+                expect.objectContaining({ code: ErrorCode.SCHEMA_UNRESOLVABLE }),
+            );
+        });
+    });
+
+    describe('defineSchemaRegistryWithDatamodel', () => {
+        it('should register one schema per model', () => {
+            const registry = defineSchemaRegistryWithDatamodel(datamodel);
+
+            expect(registry.get('user')).toBeDefined();
+            expect(registry.get('realm')).toBeDefined();
+            expect(registry.get('item')).toBeDefined();
+        });
+
+        it('should apply per-model options keyed by derived name', () => {
+            const registry = defineSchemaRegistryWithDatamodel(datamodel, { schemas: { user: { filters: { allowed: ['id'] } } } });
+
+            expect(registry.get('user')?.filters.allowed).toEqual(['id']);
+        });
+
+        it('should keep a hand-written schema over the derived one', () => {
+            const registry = new SchemaRegistry();
+            registry.add(defineSchema<User>({
+                name: 'user',
+                filters: { allowed: ['first_name'] },
+            }));
+
+            defineSchemaRegistryWithDatamodel(datamodel, { registry });
+
+            expect(registry.get('user')?.filters.allowed).toEqual(['first_name']);
+            expect(registry.get('realm')).toBeDefined();
+        });
+
+        it('should reject options for an already registered schema', () => {
+            const registry = new SchemaRegistry();
+            registry.add(defineSchema<User>({ name: 'user' }));
+
+            expect(() => defineSchemaRegistryWithDatamodel(datamodel, {
+                registry,
+                schemas: { user: { filters: { allowed: ['id'] } } },
+            })).toThrowError(/already registered/);
+        });
+
+        it('should reject options that match no model', () => {
+            expect(() => defineSchemaRegistryWithDatamodel(datamodel, { schemas: { unknown: {} } })).toThrowError(/does not match any model/);
+        });
+    });
+});
+
+describe('src/schema/assert.ts', () => {
+    it('should accept a schema whose keys exist on the model', () => {
+        const schema = defineSchema<User>({
+            name: 'user',
+            fields: { default: ['id'], allowed: ['email'] },
+            filters: { allowed: ['first_name', 'realm.name'] },
+            sort: { allowed: ['age'] },
+            relations: { allowed: ['realm', 'items.realm'] },
+        });
+
+        expect(() => assertSchemaMatchesModel(schema, datamodel, 'User')).not.toThrow();
+    });
+
+    it('should collect every offending key', () => {
+        const schema = defineSchema<any>({
+            name: 'user',
+            fields: { default: ['identifier'] },
+            filters: { allowed: ['firstName', 'address'] },
+            sort: { allowed: ['renamed.name'] },
+            relations: { allowed: ['profile'] },
+        });
+
+        try {
+            assertSchemaMatchesModel(schema, datamodel, 'User');
+            expect.unreachable();
+        } catch (error: any) {
+            expect(error.code).toEqual(ErrorCode.SCHEMA_ENTITY_MISMATCH);
+            expect(error.model).toEqual('User');
+            expect([...error.keys].sort()).toEqual([
+                'firstName', 
+                'identifier', 
+                'profile', 
+                'renamed.name',
+            ]);
+        }
+    });
+
+    it('should validate a filters default condition tree', () => {
+        const schema = defineSchema<any>({
+            name: 'user',
+            filters: {
+                allowed: ['age'],
+                default: and(eq('age', 18), eq('missing', 1)),
+            },
+        });
+
+        expect(() => assertSchemaMatchesModel(schema, datamodel, 'User')).toThrowError(
+            expect.objectContaining({ keys: ['missing'] }),
+        );
+    });
+
+    it('should fail typed for a model outside the datamodel', () => {
+        const schema = defineSchema<User>({ name: 'user' });
+
+        expect(() => assertSchemaMatchesModel(schema, datamodel, 'Account')).toThrowError(
+            expect.objectContaining({ code: ErrorCode.SCHEMA_UNRESOLVABLE }),
+        );
+    });
+});


### PR DESCRIPTION
Stacked on #838. Two features: schema derivation from a datamodel, and client-bound adapter construction.

## Bind the adapter from a model delegate

```typescript
const adapter = new PrismaAdapter({ model: prisma.user });
```

One argument. The model name, the datamodel (relations, cardinality, nullability, column types) and the active provider are read off the client the delegate belongs to, through its runtime backref. `{ client: prisma, model: 'User' }` works with a plain name, `provider`/`metadata` remain overridable, and the fully explicit `{ provider, metadata }` form stays as the private-API-free path.

Honesty note: the reads use private but long-stable client internals (`_runtimeDataModel`, `_activeProvider`, the delegate `$name`/`$parent` markers; Prisma has no public reflection API, prisma/prisma#19392). Guarded accordingly:

- every read fails typed instead of guessing (unresolvable client, unreadable provider),
- pruned edge/wasm runtime datamodels (no cardinality/nullability) are rejected typed with the hand-written datamodel as the documented escape hatch,
- the engine suite pins the shapes against a **real generated client**: the delegate-bound adapter must produce byte-identical arguments to the datamodel-bound one and select the same records through the engine, and the shapes are verified to survive `$extends`.

## Schema derivation

```typescript
const registry = defineSchemaRegistryWithDatamodel(prisma, {
    schemas: {
        user: {
            fields: { allowed: 'inherit' },       // the model's field names
            filters: { allowed: ['id', 'name'] }, // authorization stays yours
        },
    },
});
```

Mirrors `@rapiq/typeorm`'s entity derivation contract: derivation supplies *shape* (schema name, relation allow-list, `schemaMapping`), authorization stays explicit, hand-written schemas take precedence, and name collisions or unmatched option keys fail loudly. `assertSchemaMatchesModel` turns schema/model drift into a boot-time `SchemaModelMismatchError` carrying every offending key. All entry points accept a client instance, a runtime datamodel or a DMMF datamodel.

## Testing

33 new specs (client resolution, derivation, assert) plus engine-backed checks against the real generated client on SQLite and PostgreSQL. Acceptance test runs a derived registry through the full pipeline: wire input -> URL codec (relation traversal via derived `schemaMapping`) -> adapter -> args object.

## Notes

- `change-case` added as a dependency (same as `@rapiq/typeorm`, for the derived names).
- Docs lead with the delegate-bound form; the explicit form is documented as the stable path with the private-API caveat spelled out.
- Still deferred: scalar-list operators, `_count` ordering.
