### PR TITLE
feat(prisma): run queries through the bound model and merge args

### DIFF
--- a/packages/docs/guide/executing-queries.md
+++ b/packages/docs/guide/executing-queries.md
@@ -37,18 +37,16 @@ const [entities, total] = await queryBuilder.getManyAndCount();
 Prisma takes an argument object rather than a builder, so the adapter is a pure serializer that returns the object and touches nothing:
 
 ```typescript
-import { PrismaAdapter, defineMetadata } from '@rapiq/prisma';
+import { PrismaAdapter } from '@rapiq/prisma';
 
-const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
-    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
-});
+const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({ model: prisma.user });
 
 const { args, pagination } = adapter.execute(query);
 
 const users = await prisma.user.findMany(args);
 ```
 
-A model-bound adapter can also run the request in one call, rows plus the pre-pagination total:
+Because this adapter is model-bound, it can also run the request in one call, rows plus the pre-pagination total:
 
 ```typescript
 const { data, total, pagination } = await adapter.apply(query, {

--- a/packages/docs/guide/executing-queries.md
+++ b/packages/docs/guide/executing-queries.md
@@ -46,12 +46,13 @@ const { args, pagination } = adapter.execute(query);
 const users = await prisma.user.findMany(args);
 ```
 
-Because this adapter is model-bound, it can also run the request in one call, rows plus the pre-pagination total:
+Because this adapter is model-bound, it can also run the request itself:
 
 ```typescript
-const { data, total, pagination } = await adapter.apply(query, {
+const rows = await adapter.findMany(query, {
     base: { where: { realm_id } },  // an application-owned scope, conjoined
 });
+const total = await adapter.count(query);  // pre-pagination, for the meta block
 ```
 
 Unlike the builder-bound adapters, one `PrismaAdapter` instance is stateless and safely shared across requests. The [package page](/packages/prisma) covers the provider presets (`mode: 'insensitive'` support) and how negation is rendered exactly despite Prisma's three-valued `NOT`.

--- a/packages/docs/guide/executing-queries.md
+++ b/packages/docs/guide/executing-queries.md
@@ -48,7 +48,15 @@ const { args, pagination } = adapter.execute(query);
 const users = await prisma.user.findMany(args);
 ```
 
-An application-owned predicate is preserved the same way, by passing it as the baseline: `execute(query, { base: { where: { realm_id } } })` conjoins the client's filters with your scope. Unlike the builder-bound adapters, one `PrismaAdapter` instance is stateless and safely shared across requests. The [package page](/packages/prisma) covers the provider presets (`mode: 'insensitive'` support) and how negation is rendered exactly despite Prisma's three-valued `NOT`.
+A model-bound adapter can also run the request in one call, rows plus the pre-pagination total:
+
+```typescript
+const { data, total, pagination } = await adapter.apply(query, {
+    base: { where: { realm_id } },  // an application-owned scope, conjoined
+});
+```
+
+Unlike the builder-bound adapters, one `PrismaAdapter` instance is stateless and safely shared across requests. The [package page](/packages/prisma) covers the provider presets (`mode: 'insensitive'` support) and how negation is rendered exactly despite Prisma's three-valued `NOT`.
 
 ## Raw SQL
 

--- a/packages/docs/packages/prisma.md
+++ b/packages/docs/packages/prisma.md
@@ -35,13 +35,11 @@ Because the adapter produces a value instead of writing into a builder, it is **
 A model-bound adapter can also run what it serialized, the counterpart of the typeorm adapter applying its state to the bound query builder:
 
 ```typescript
-const { data, total, pagination } = await adapter.apply(query);
-// or individually:
 const rows = await adapter.findMany(query);
 const total = await adapter.count(query);
 ```
 
-`apply` returns rows, the pre-pagination total and the applied pagination in one call, shaped like [@rapiq/memory](/packages/memory)'s `applyQuery`; `count` sees the query's filters (and any baseline `where`) but never the page window. On an adapter constructed with explicit `{ provider, metadata }` the runners raise a typed error, since there is nothing to run against; `execute()` stays the pure serializer either way.
+`count` sees the query's filters (and any baseline `where`) but never the page window: the pre-pagination total a response meta block reports. The two compose however your endpoint needs them; there is deliberately no bundled rows-plus-total call, because it would hide a second query and, without a transaction, could pair mutually inconsistent results. On an adapter constructed with explicit `{ provider, metadata }` the runners reject with a typed error, since there is nothing to run against; `execute()` stays the pure serializer either way.
 
 ## Merging arguments
 

--- a/packages/docs/packages/prisma.md
+++ b/packages/docs/packages/prisma.md
@@ -53,7 +53,7 @@ import { mergeArgs } from '@rapiq/prisma';
 const args = mergeArgs(baseline, produced);
 ```
 
-`where` conditions are conjoined (`AND`), an overriding `include` joins a baseline `select` instead of replacing it (a caller-owned projection is never widened), `orderBy`/`take`/`skip` follow the override, and unknown keys (`cursor`, `distinct`, ...) pass through. The adapter's `execute(query, { base })` is exactly this merge applied to what the query produced.
+`where` conditions are conjoined (`AND`), an overriding `include` joins a baseline `select` instead of replacing it (a caller-owned projection is never widened), `orderBy`/`take`/`skip` follow the override, and unknown keys (`cursor`, `distinct`, ...) pass through. The adapter's `execute(query, { base })` is this merge applied to what the query produced, with one exception: an unsatisfiable condition (e.g. `in([])`) keeps its root-level `{ OR: [] }` form beside the baseline instead of being conjoined, because prisma strips empty groups below the root.
 
 ## Model metadata
 

--- a/packages/docs/packages/prisma.md
+++ b/packages/docs/packages/prisma.md
@@ -30,6 +30,31 @@ const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({ /* … */ });
 
 Because the adapter produces a value instead of writing into a builder, it is **stateless**: construct one instance per model and share it across requests. To combine several queries, compose them *before* serializing with [`mergeQueries`](/guide/merging-queries) or `query.filters.and(...)`; the adapter deliberately has no accumulation API.
 
+## Running the query
+
+A model-bound adapter can also run what it serialized, the counterpart of the typeorm adapter applying its state to the bound query builder:
+
+```typescript
+const { data, total, pagination } = await adapter.apply(query);
+// or individually:
+const rows = await adapter.findMany(query);
+const total = await adapter.count(query);
+```
+
+`apply` returns rows, the pre-pagination total and the applied pagination in one call, shaped like [@rapiq/memory](/packages/memory)'s `applyQuery`; `count` sees the query's filters (and any baseline `where`) but never the page window. On an adapter constructed with explicit `{ provider, metadata }` the runners raise a typed error, since there is nothing to run against; `execute()` stays the pure serializer either way.
+
+## Merging arguments
+
+Prisma ships no per-call args composition (`$extends` intercepts every call globally), so the merge rules the adapter applies to its `base` option are exported as a standalone helper:
+
+```typescript
+import { mergeArgs } from '@rapiq/prisma';
+
+const args = mergeArgs(baseline, produced);
+```
+
+`where` conditions are conjoined (`AND`), an overriding `include` joins a baseline `select` instead of replacing it (a caller-owned projection is never widened), `orderBy`/`take`/`skip` follow the override, and unknown keys (`cursor`, `distinct`, ...) pass through. The adapter's `execute(query, { base })` is exactly this merge applied to what the query produced.
+
 ## Model metadata
 
 The adapter needs four facts about your model that a `Query` cannot carry, and each one changes what a *valid* Prisma filter looks like:

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -66,10 +66,10 @@ npm install @rapiq/core @rapiq/prisma
 
 ## Running the query
 
-A model-bound adapter can run what it serialized: `apply` returns `{ data, total, pagination }` in one call (rows plus the pre-pagination total), `findMany` and `count` run individually, and every runner accepts the same `base` option. `execute()` stays the pure serializer.
+A model-bound adapter can run what it serialized: `findMany` pipes the arguments into the delegate, `count` reports the pre-pagination total, and both accept the same `base` option. `execute()` stays the pure serializer.
 
 ```typescript
-const { data, total, pagination } = await adapter.apply(query, {
+const rows = await adapter.findMany(query, {
     base: { where: { realm_id: realmId } },
 });
 ```

--- a/packages/prisma/README.md
+++ b/packages/prisma/README.md
@@ -64,6 +64,18 @@ npm install @rapiq/core @rapiq/prisma
 
 `pagination` is echoed back from `execute()` as the limit/offset actually applied, ready for a response `meta` block.
 
+## Running the query
+
+A model-bound adapter can run what it serialized: `apply` returns `{ data, total, pagination }` in one call (rows plus the pre-pagination total), `findMany` and `count` run individually, and every runner accepts the same `base` option. `execute()` stays the pure serializer.
+
+```typescript
+const { data, total, pagination } = await adapter.apply(query, {
+    base: { where: { realm_id: realmId } },
+});
+```
+
+The merge rules behind `base` are exported as `mergeArgs(base, override)` for use outside the adapter; prisma itself ships no per-call args composition.
+
 ## Model binding
 
 A model delegate binds everything: the model name, the datamodel and the active provider are read off its client (private but long-stable internals, pinned against real generated clients by the engine suite; every read fails typed rather than guessing). The private-API-free alternative supplies the same facts explicitly:

--- a/packages/prisma/src/adapter/index.ts
+++ b/packages/prisma/src/adapter/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './fields';
+export * from './merge';
 export * from './module';
 export * from './relations';
 export * from './sort';

--- a/packages/prisma/src/adapter/merge.ts
+++ b/packages/prisma/src/adapter/merge.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Args, Where } from './types';
+
+/**
+ * Merge two prisma argument objects, treating `override` as a
+ * NARROWING of `base` (prisma itself ships no args composition;
+ * `$extends` intercepts every call globally, per-call merging is left
+ * to the user):
+ *
+ * - `where` conditions are conjoined (`AND`), never substituted, so
+ *   an application-owned tenant or authorization predicate survives,
+ * - `select` and `include` stay mutually exclusive per prisma's
+ *   rules: an overriding `select` replaces the baseline selection,
+ *   while an overriding `include` JOINS a baseline `select` instead
+ *   of replacing it (widening a caller-owned projection would expose
+ *   columns the application chose to withhold),
+ * - `orderBy`, `take` and `skip` follow the override when present,
+ * - every other key (`cursor`, `distinct`, ...) passes through, the
+ *   override winning on collisions.
+ */
+export function mergeArgs<T extends Args = Args>(base: T, override: Args) : T {
+    const output = { ...base } as Args;
+
+    const {
+        where,
+        select,
+        include,
+        orderBy,
+        take,
+        skip,
+        ...rest
+    } = override;
+
+    Object.assign(output, rest);
+
+    if (where) {
+        output.where = base.where ?
+            { AND: [base.where, where] } as Where :
+            where;
+    }
+
+    if (select) {
+        output.select = select;
+        delete output.include;
+        delete (output as Record<string, unknown>).omit;
+    } else if (include) {
+        if (base.select) {
+            output.select = { ...base.select, ...include };
+            delete output.include;
+            delete (output as Record<string, unknown>).omit;
+        } else {
+            output.include = include;
+            delete output.select;
+        }
+    }
+
+    if (orderBy) {
+        output.orderBy = orderBy;
+    }
+
+    if (typeof take !== 'undefined') {
+        output.take = take;
+    }
+
+    if (typeof skip !== 'undefined') {
+        output.skip = skip;
+    }
+
+    return output as T;
+}

--- a/packages/prisma/src/adapter/module.ts
+++ b/packages/prisma/src/adapter/module.ts
@@ -8,20 +8,21 @@
 import type { IQuery, IQueryVisitor } from '@rapiq/core';
 import { AdapterError, ErrorCode } from '@rapiq/core';
 import type { IMetadata } from '../metadata';
-import { defineMetadata, resolveDelegateClient } from '../metadata';
+import { defineMetadata, resolveDelegateClient, resolveModelName } from '../metadata';
 import type { ProviderOptions } from '../provider';
 import { resolveClientProvider, resolveProviderOptions } from '../provider';
 import { buildSelection } from './fields';
+import { mergeArgs } from './merge';
 import { collectRelationPaths } from './relations';
 import { buildOrderBy } from './sort';
 import { WhereRenderer } from './where';
 import type {
+    ApplyOutput,
     Args,
     ExecuteOptions,
     PrismaAdapterClientOptions,
     PrismaAdapterOptions,
     PrismaAdapterOutput,
-    Where,
 } from './types';
 
 /**
@@ -53,6 +54,32 @@ function resolveClientOptions(options: PrismaAdapterClientOptions) : {
 }
 
 /**
+ * The delegate to run against: the model itself when one was passed,
+ * otherwise the client property named after the model (prisma
+ * lowercases exactly the first letter: `RoleDetail` becomes
+ * `client.roleDetail`).
+ */
+function resolveDelegate(options: PrismaAdapterClientOptions, client?: object) : Record<string, any> | undefined {
+    if (typeof options.model === 'object' && options.model !== null) {
+        return options.model as Record<string, any>;
+    }
+
+    if (!client) {
+        return undefined;
+    }
+
+    const name = resolveModelName(options.model);
+    const property = name.charAt(0).toLowerCase() + name.slice(1);
+    const delegate = (client as Record<string, any>)[property];
+
+    if (delegate && typeof delegate.findMany === 'function') {
+        return delegate;
+    }
+
+    return undefined;
+}
+
+/**
  * Serializes a parsed query into a prisma `findMany` argument object.
  *
  * A pure serializer: `execute` maps a value to a value, holds no
@@ -79,6 +106,8 @@ export class PrismaAdapter<
 
     protected options : PrismaAdapterOptions;
 
+    protected model : Record<string, any> | undefined;
+
     constructor(options: PrismaAdapterOptions) {
         this.options = options;
 
@@ -88,6 +117,11 @@ export class PrismaAdapter<
             this.renderer = new WhereRenderer(
                 resolved.metadata,
                 resolved.provider,
+            );
+
+            this.model = resolveDelegate(
+                options,
+                options.client ?? resolveDelegateClient(options.model),
             );
 
             return;
@@ -106,27 +140,26 @@ export class PrismaAdapter<
         options: ExecuteOptions<ARGS> = {},
     ) : PrismaAdapterOutput<ARGS> {
         const base = options.base as Args | undefined;
-        const args = { ...(base || {}) } as Args;
 
         const filters = this.renderer.build(
             query.filters,
             options.filters || this.options.filters || {},
         );
 
-        const where = this.buildWhere(filters, base?.where);
-        if (where) {
-            args.where = where;
+        const produced : Args = {};
+
+        if (!filters.impossible && filters.where) {
+            produced.where = filters.where;
         }
 
-        this.applySelection(
-            args,
+        Object.assign(
+            produced,
             buildSelection(query.fields, collectRelationPaths(query.relations)),
-            base,
         );
 
         const orderBy = buildOrderBy(query.sorts);
         if (orderBy.length > 0) {
-            args.orderBy = orderBy;
+            produced.orderBy = orderBy;
         }
 
         // a query without pagination leaves caller-owned take/skip
@@ -135,11 +168,24 @@ export class PrismaAdapter<
         const { limit, offset } = query.pagination;
 
         if (typeof limit !== 'undefined') {
-            args.take = limit;
+            produced.take = limit;
         }
 
         if (typeof offset !== 'undefined') {
-            args.skip = offset;
+            produced.skip = offset;
+        }
+
+        const args = base ? mergeArgs(base, produced) : produced;
+
+        if (filters.impossible) {
+            // `{ OR: [] }` is prisma's `1 = 0`, but only at the ROOT;
+            // a nested empty group is stripped, so this cannot go
+            // through the generic where conjunction. Sibling operator
+            // keys are conjoined, so a caller-owned predicate rides
+            // along instead of being dropped.
+            args.where = base && base.where ?
+                { OR: [], AND: [base.where] } :
+                { OR: [] };
         }
 
         return {
@@ -154,69 +200,68 @@ export class PrismaAdapter<
 
     // -----------------------------------------------------------
 
-    protected buildWhere(
-        filters: { where?: Where, impossible: boolean },
-        base?: Where,
-    ) : Where | undefined {
-        if (filters.impossible) {
-            // `{ OR: [] }` is prisma's `1 = 0`, but only at the root;
-            // a nested empty group is stripped. Sibling operator keys
-            // are conjoined, so a caller-owned predicate rides along
-            // instead of being dropped.
-            return base ? { OR: [], AND: [base] } : { OR: [] };
-        }
+    /**
+     * Serialize and run in one step: `execute` piped into the bound
+     * model's `findMany`. Only available on a model-bound adapter,
+     * the counterpart of the typeorm adapter applying its state to
+     * the bound query builder.
+     */
+    findMany<T = Record<string, any>>(
+        query: IQuery,
+        options: ExecuteOptions<ARGS> = {},
+    ) : Promise<T[]> {
+        const { args } = this.execute(query, options);
 
-        const { where } = filters;
-
-        if (!where) {
-            return base;
-        }
-
-        if (!base) {
-            return where;
-        }
-
-        // rapiq filters narrow the query; they never replace an
-        // application-owned tenant or authorization predicate.
-        return { AND: [base, where] };
+        return this.delegate().findMany(args);
     }
 
     /**
-     * Prisma rejects `select` next to `include` (and next to `omit`)
-     * on the same level, so exactly one of them survives.
-     *
-     * A baseline `select` is a deliberate projection restriction and
-     * is therefore never dropped: relations the query hydrates join
-     * it instead. Widening a caller-owned projection would expose
-     * columns the application chose to withhold.
+     * Records matching the query's filters (and the baseline `where`),
+     * BEFORE pagination: the total a response meta block reports.
      */
-    protected applySelection(
-        args: Args,
-        selection: { select?: Record<string, any>, include?: Record<string, any> },
-        base?: Args,
-    ) : void {
-        if (selection.select) {
-            args.select = selection.select;
-            delete args.include;
-            delete (args as Record<string, unknown>).omit;
+    count(
+        query: IQuery,
+        options: ExecuteOptions<ARGS> = {},
+    ) : Promise<number> {
+        const { args } = this.execute(query, options);
 
-            return;
+        return this.delegate().count(args.where ? { where: args.where } : {});
+    }
+
+    /**
+     * The whole request in one call: rows and the pre-pagination
+     * total, shaped like `@rapiq/memory`'s `applyQuery`.
+     */
+    async apply<T = Record<string, any>>(
+        query: IQuery,
+        options: ExecuteOptions<ARGS> = {},
+    ) : Promise<ApplyOutput<T>> {
+        const { args, pagination } = this.execute(query, options);
+
+        const model = this.delegate();
+
+        const [data, total] = await Promise.all([
+            model.findMany(args),
+            model.count(args.where ? { where: args.where } : {}),
+        ]);
+
+        return {
+            data, 
+            total, 
+            pagination, 
+        };
+    }
+
+    protected delegate() : Record<string, any> {
+        if (!this.model) {
+            throw new AdapterError({
+                message: 'The adapter is not bound to a model; ' +
+                    'construct it with `{ model }` to run queries.',
+                code: ErrorCode.FEATURE_UNSUPPORTED,
+            });
         }
 
-        if (!selection.include) {
-            return;
-        }
-
-        if (base && base.select) {
-            args.select = { ...base.select, ...selection.include };
-            delete args.include;
-            delete (args as Record<string, unknown>).omit;
-
-            return;
-        }
-
-        args.include = selection.include;
-        delete args.select;
+        return this.model;
     }
 }
 

--- a/packages/prisma/src/adapter/module.ts
+++ b/packages/prisma/src/adapter/module.ts
@@ -17,7 +17,6 @@ import { collectRelationPaths } from './relations';
 import { buildOrderBy } from './sort';
 import { WhereRenderer } from './where';
 import type {
-    ApplyOutput,
     Args,
     ExecuteOptions,
     PrismaAdapterClientOptions,
@@ -231,30 +230,6 @@ export class PrismaAdapter<
         const { args } = this.execute(query, options);
 
         return this.delegate().count(args.where ? { where: args.where } : {});
-    }
-
-    /**
-     * The whole request in one call: rows and the pre-pagination
-     * total, shaped like `@rapiq/memory`'s `applyQuery`.
-     */
-    async apply<T = Record<string, any>>(
-        query: IQuery,
-        options: ExecuteOptions<ARGS> = {},
-    ) : Promise<ApplyOutput<T>> {
-        const { args, pagination } = this.execute(query, options);
-
-        const model = this.delegate();
-
-        const [data, total] = await Promise.all([
-            model.findMany(args),
-            model.count(args.where ? { where: args.where } : {}),
-        ]);
-
-        return {
-            data, 
-            total, 
-            pagination, 
-        };
     }
 
     protected delegate() : Record<string, any> {

--- a/packages/prisma/src/adapter/module.ts
+++ b/packages/prisma/src/adapter/module.ts
@@ -61,7 +61,12 @@ function resolveClientOptions(options: PrismaAdapterClientOptions) : {
  */
 function resolveDelegate(options: PrismaAdapterClientOptions, client?: object) : Record<string, any> | undefined {
     if (typeof options.model === 'object' && options.model !== null) {
-        return options.model as Record<string, any>;
+        const delegate = options.model as Record<string, any>;
+
+        // a delegate that cannot run is not a binding: leaving it
+        // unbound keeps the runners' typed error instead of a raw
+        // TypeError from inside findMany.
+        return typeof delegate.findMany === 'function' ? delegate : undefined;
     }
 
     if (!client) {
@@ -206,7 +211,7 @@ export class PrismaAdapter<
      * the counterpart of the typeorm adapter applying its state to
      * the bound query builder.
      */
-    findMany<T = Record<string, any>>(
+    async findMany<T = Record<string, any>>(
         query: IQuery,
         options: ExecuteOptions<ARGS> = {},
     ) : Promise<T[]> {
@@ -219,7 +224,7 @@ export class PrismaAdapter<
      * Records matching the query's filters (and the baseline `where`),
      * BEFORE pagination: the total a response meta block reports.
      */
-    count(
+    async count(
         query: IQuery,
         options: ExecuteOptions<ARGS> = {},
     ) : Promise<number> {

--- a/packages/prisma/src/adapter/types.ts
+++ b/packages/prisma/src/adapter/types.ts
@@ -112,20 +112,6 @@ export type ExecuteOptions<ARGS extends Args = Args> = {
     filters?: FiltersAdapterOptions,
 };
 
-/**
- * Output of {@link PrismaAdapter.apply}: the rows, the
- * pre-pagination total and the applied pagination, shaped like
- * `@rapiq/memory`'s `applyQuery`.
- */
-export type ApplyOutput<T = Record<string, any>> = {
-    data: T[],
-    total: number,
-    pagination: {
-        limit: number | undefined,
-        offset: number | undefined,
-    },
-};
-
 export type PrismaAdapterOutput<ARGS extends Args = Args> = {
     /**
      * The argument object to hand to `prisma.<model>.findMany()`.

--- a/packages/prisma/src/adapter/types.ts
+++ b/packages/prisma/src/adapter/types.ts
@@ -112,6 +112,20 @@ export type ExecuteOptions<ARGS extends Args = Args> = {
     filters?: FiltersAdapterOptions,
 };
 
+/**
+ * Output of {@link PrismaAdapter.apply}: the rows, the
+ * pre-pagination total and the applied pagination, shaped like
+ * `@rapiq/memory`'s `applyQuery`.
+ */
+export type ApplyOutput<T = Record<string, any>> = {
+    data: T[],
+    total: number,
+    pagination: {
+        limit: number | undefined,
+        offset: number | undefined,
+    },
+};
+
 export type PrismaAdapterOutput<ARGS extends Args = Args> = {
     /**
      * The argument object to hand to `prisma.<model>.findMany()`.

--- a/packages/prisma/test/unit/engine.db.spec.ts
+++ b/packages/prisma/test/unit/engine.db.spec.ts
@@ -288,16 +288,21 @@ describe('engine parity (prisma vs memory)', () => {
     it('should run the whole request through the bound model', async () => {
         const bound = new PrismaAdapter({ model: database.client.user });
 
-        const output = await bound.apply(new Query({
+        const request = new Query({
             filters: new FiltersNode(FilterCompoundOperator.AND, [gte('age', 21)]),
             sorts: new Sorts([new Sort('id', SortDirection.ASC)]),
             pagination: new Pagination(2, 0),
-        }));
+        });
+
+        // the rows-plus-total composition a list endpoint runs
+        const [data, total] = await Promise.all([
+            bound.findMany(request),
+            bound.count(request),
+        ]);
 
         // ages: 18, 60, 33, 21 -> matched ids [2, 3, 4], page of 2
-        expect(output.data.map((row: any) => row.id)).toEqual([2, 3]);
-        expect(output.total).toEqual(3);
-        expect(output.pagination).toEqual({ limit: 2, offset: 0 });
+        expect(data.map((row: any) => row.id)).toEqual([2, 3]);
+        expect(total).toEqual(3);
     });
 
     it('should conjoin a baseline where when running', async () => {

--- a/packages/prisma/test/unit/engine.db.spec.ts
+++ b/packages/prisma/test/unit/engine.db.spec.ts
@@ -9,7 +9,11 @@ import type { Condition, Filter, Filters } from '@rapiq/core';
 import {
     FilterCompoundOperator,
     Filters as FiltersNode,
+    Pagination,
     Query,
+    Sort,
+    SortDirection,
+    Sorts,
     and,
     contains,
     elemMatch,
@@ -279,6 +283,33 @@ describe('engine parity (prisma vs memory)', () => {
             expect(rows.map((row: any) => row.id).sort((a: number, b: number) => a - b))
                 .toEqual(memoryIds(condition));
         }
+    });
+
+    it('should run the whole request through the bound model', async () => {
+        const bound = new PrismaAdapter({ model: database.client.user });
+
+        const output = await bound.apply(new Query({
+            filters: new FiltersNode(FilterCompoundOperator.AND, [gte('age', 21)]),
+            sorts: new Sorts([new Sort('id', SortDirection.ASC)]),
+            pagination: new Pagination(2, 0),
+        }));
+
+        // ages: 18, 60, 33, 21 -> matched ids [2, 3, 4], page of 2
+        expect(output.data.map((row: any) => row.id)).toEqual([2, 3]);
+        expect(output.total).toEqual(3);
+        expect(output.pagination).toEqual({ limit: 2, offset: 0 });
+    });
+
+    it('should conjoin a baseline where when running', async () => {
+        const bound = new PrismaAdapter({ model: database.client.user });
+
+        const rows = await bound.findMany(new Query({
+            filters: new FiltersNode(FilterCompoundOperator.AND, [gte('age', 21)]),
+            sorts: new Sorts([new Sort('id', SortDirection.ASC)]),
+        }), { base: { where: { address: { not: null } } } });
+
+        // of ids [2, 3, 4], only 3 has an address
+        expect(rows.map((row: any) => row.id)).toEqual([3]);
     });
 
     it('should keep the engine-free fixture datamodel faithful', () => {

--- a/packages/prisma/test/unit/run.spec.ts
+++ b/packages/prisma/test/unit/run.spec.ts
@@ -83,27 +83,12 @@ describe('src/adapter/module.ts (runners)', () => {
         expect(calls.count).toEqual([{ where: { age: { gte: 18 } } }]);
     });
 
-    it('should apply rows, total and pagination together', async () => {
-        const { client, calls } = createRecordingClient();
-
-        const output = await new PrismaAdapter({ model: client.user }).apply(query);
-
-        expect(output).toEqual({
-            data: [{ id: 1 }],
-            total: 7,
-            pagination: { limit: 10, offset: 20 },
-        });
-
-        // the count sees the where, never the page window
-        expect(calls.count).toEqual([{ where: { age: { gte: 18 } } }]);
-        expect(calls.findMany[0].take).toEqual(10);
-    });
-
     it('should conjoin a baseline where into every runner', async () => {
         const { client, calls } = createRecordingClient();
         const adapter = new PrismaAdapter({ model: client.user });
 
-        await adapter.apply(query, { base: { where: { realm_id: 1 } } });
+        await adapter.findMany(query, { base: { where: { realm_id: 1 } } });
+        await adapter.count(query, { base: { where: { realm_id: 1 } } });
 
         expect(calls.findMany[0].where).toEqual({ AND: [{ realm_id: 1 }, { age: { gte: 18 } }] });
         expect(calls.count[0].where).toEqual({ AND: [{ realm_id: 1 }, { age: { gte: 18 } }] });
@@ -129,9 +114,6 @@ describe('src/adapter/module.ts (runners)', () => {
             code: ErrorCode.FEATURE_UNSUPPORTED,
         });
         await expect(adapter.count(query)).rejects.toMatchObject({
-            code: ErrorCode.FEATURE_UNSUPPORTED,
-        });
-        await expect(adapter.apply(query)).rejects.toMatchObject({
             code: ErrorCode.FEATURE_UNSUPPORTED,
         });
     });

--- a/packages/prisma/test/unit/run.spec.ts
+++ b/packages/prisma/test/unit/run.spec.ts
@@ -117,15 +117,42 @@ describe('src/adapter/module.ts (runners)', () => {
         expect(calls.findMany).toHaveLength(1);
     });
 
-    it('should fail typed on an unbound adapter', () => {
+    it('should reject typed on an unbound adapter', async () => {
         const adapter = new PrismaAdapter({
             provider: 'postgresql',
             metadata: defineMetadata(datamodel, 'User'),
         });
 
-        expect(() => adapter.findMany(query)).toThrowError(
-            expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
-        );
+        // rejections, never synchronous throws: every runner returns a
+        // promise, so a .catch() must observe the failure.
+        await expect(adapter.findMany(query)).rejects.toMatchObject({
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
+        await expect(adapter.count(query)).rejects.toMatchObject({
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
+        await expect(adapter.apply(query)).rejects.toMatchObject({
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
+    });
+
+    it('should reject typed for a model object that cannot run', async () => {
+        const { client } = createRecordingClient();
+
+        // metadata and provider resolve through the backref, but an
+        // object without findMany is not a runnable binding.
+        const adapter = new PrismaAdapter({
+            model: {
+                $name: 'User',
+                $parent: client,
+                fields: { id: { modelName: 'User', name: 'id' } },
+            },
+        });
+
+        expect(adapter.execute(query).args.where).toBeDefined();
+        await expect(adapter.findMany(query)).rejects.toMatchObject({
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
     });
 });
 

--- a/packages/prisma/test/unit/run.spec.ts
+++ b/packages/prisma/test/unit/run.spec.ts
@@ -110,12 +110,8 @@ describe('src/adapter/module.ts (runners)', () => {
 
         // rejections, never synchronous throws: every runner returns a
         // promise, so a .catch() must observe the failure.
-        await expect(adapter.findMany(query)).rejects.toMatchObject({
-            code: ErrorCode.FEATURE_UNSUPPORTED,
-        });
-        await expect(adapter.count(query)).rejects.toMatchObject({
-            code: ErrorCode.FEATURE_UNSUPPORTED,
-        });
+        await expect(adapter.findMany(query)).rejects.toMatchObject({ code: ErrorCode.FEATURE_UNSUPPORTED });
+        await expect(adapter.count(query)).rejects.toMatchObject({ code: ErrorCode.FEATURE_UNSUPPORTED });
     });
 
     it('should reject typed for a model object that cannot run', async () => {
@@ -132,9 +128,7 @@ describe('src/adapter/module.ts (runners)', () => {
         });
 
         expect(adapter.execute(query).args.where).toBeDefined();
-        await expect(adapter.findMany(query)).rejects.toMatchObject({
-            code: ErrorCode.FEATURE_UNSUPPORTED,
-        });
+        await expect(adapter.findMany(query)).rejects.toMatchObject({ code: ErrorCode.FEATURE_UNSUPPORTED });
     });
 });
 

--- a/packages/prisma/test/unit/run.spec.ts
+++ b/packages/prisma/test/unit/run.spec.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    ErrorCode,
+    FilterCompoundOperator,
+    Filters,
+    Pagination,
+    Query,
+    Sort,
+    SortDirection,
+    Sorts,
+    gte,
+} from '@rapiq/core';
+import { PrismaAdapter, defineMetadata, mergeArgs } from '../../src';
+import { datamodel } from '../data/datamodel';
+
+/**
+ * A recording delegate: answers like a prisma model and captures the
+ * argument objects it was called with.
+ */
+function createRecordingClient() {
+    const models : Record<string, any> = {};
+    for (const model of datamodel.models) {
+        models[model.name] = { fields: model.fields };
+    }
+
+    const calls : { findMany: any[], count: any[] } = { findMany: [], count: [] };
+
+    const client : Record<string, any> = {
+        _runtimeDataModel: { models },
+        _activeProvider: 'postgresql',
+    };
+
+    client.user = {
+        $name: 'User',
+        $parent: client,
+        fields: { id: { modelName: 'User', name: 'id' } },
+        findMany: (args: any) => {
+            calls.findMany.push(args);
+            return Promise.resolve([{ id: 1 }]);
+        },
+        count: (args: any) => {
+            calls.count.push(args);
+            return Promise.resolve(7);
+        },
+    };
+
+    return { client, calls };
+}
+
+const query = new Query({
+    filters: new Filters(FilterCompoundOperator.AND, [gte('age', 18)]),
+    sorts: new Sorts([new Sort('age', SortDirection.DESC)]),
+    pagination: new Pagination(10, 20),
+});
+
+describe('src/adapter/module.ts (runners)', () => {
+    it('should run findMany with the serialized arguments', async () => {
+        const { client, calls } = createRecordingClient();
+
+        const rows = await new PrismaAdapter({ model: client.user }).findMany(query);
+
+        expect(rows).toEqual([{ id: 1 }]);
+        expect(calls.findMany).toEqual([{
+            where: { age: { gte: 18 } },
+            orderBy: [{ age: 'desc' }],
+            take: 10,
+            skip: 20,
+        }]);
+    });
+
+    it('should count without pagination or selection', async () => {
+        const { client, calls } = createRecordingClient();
+
+        const total = await new PrismaAdapter({ model: client.user }).count(query);
+
+        expect(total).toEqual(7);
+        expect(calls.count).toEqual([{ where: { age: { gte: 18 } } }]);
+    });
+
+    it('should apply rows, total and pagination together', async () => {
+        const { client, calls } = createRecordingClient();
+
+        const output = await new PrismaAdapter({ model: client.user }).apply(query);
+
+        expect(output).toEqual({
+            data: [{ id: 1 }],
+            total: 7,
+            pagination: { limit: 10, offset: 20 },
+        });
+
+        // the count sees the where, never the page window
+        expect(calls.count).toEqual([{ where: { age: { gte: 18 } } }]);
+        expect(calls.findMany[0].take).toEqual(10);
+    });
+
+    it('should conjoin a baseline where into every runner', async () => {
+        const { client, calls } = createRecordingClient();
+        const adapter = new PrismaAdapter({ model: client.user });
+
+        await adapter.apply(query, { base: { where: { realm_id: 1 } } });
+
+        expect(calls.findMany[0].where).toEqual({ AND: [{ realm_id: 1 }, { age: { gte: 18 } }] });
+        expect(calls.count[0].where).toEqual({ AND: [{ realm_id: 1 }, { age: { gte: 18 } }] });
+    });
+
+    it('should resolve the delegate from a client and a model name', async () => {
+        const { client, calls } = createRecordingClient();
+
+        await new PrismaAdapter({ client, model: 'User' }).findMany(query);
+
+        expect(calls.findMany).toHaveLength(1);
+    });
+
+    it('should fail typed on an unbound adapter', () => {
+        const adapter = new PrismaAdapter({
+            provider: 'postgresql',
+            metadata: defineMetadata(datamodel, 'User'),
+        });
+
+        expect(() => adapter.findMany(query)).toThrowError(
+            expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
+        );
+    });
+});
+
+describe('src/adapter/merge.ts', () => {
+    it('should conjoin where conditions', () => {
+        expect(mergeArgs(
+            { where: { realm_id: 1 } },
+            { where: { age: { gte: 18 } } },
+        )).toEqual({ where: { AND: [{ realm_id: 1 }, { age: { gte: 18 } }] } });
+    });
+
+    it('should keep a one-sided where as it is', () => {
+        expect(mergeArgs({ where: { realm_id: 1 } }, {})).toEqual({ where: { realm_id: 1 } });
+        expect(mergeArgs({}, { where: { realm_id: 1 } })).toEqual({ where: { realm_id: 1 } });
+    });
+
+    it('should replace the selection with an overriding select', () => {
+        expect(mergeArgs(
+            { include: { realm: true } },
+            { select: { id: true } },
+        )).toEqual({ select: { id: true } });
+    });
+
+    it('should join an overriding include into a baseline select', () => {
+        // widening a caller-owned projection would expose columns the
+        // application chose to withhold.
+        expect(mergeArgs(
+            { select: { id: true, first_name: true } },
+            { include: { realm: true } },
+        )).toEqual({
+            select: {
+                id: true, 
+                first_name: true, 
+                realm: true, 
+            }, 
+        });
+    });
+
+    it('should set an include when no baseline select restricts', () => {
+        expect(mergeArgs({}, { include: { realm: true } })).toEqual({ include: { realm: true } });
+    });
+
+    it('should let pagination and order overrides win', () => {
+        expect(mergeArgs(
+            { take: 5, orderBy: [{ id: 'asc' }] },
+            {
+                take: 10, 
+                skip: 2, 
+                orderBy: [{ age: 'desc' }], 
+            },
+        )).toEqual({
+            take: 10,
+            skip: 2,
+            orderBy: [{ age: 'desc' }],
+        });
+    });
+
+    it('should pass unknown keys through', () => {
+        expect(mergeArgs(
+            { cursor: { id: 5 }, distinct: ['email'] } as any,
+            { where: { age: { gte: 18 } } },
+        )).toEqual({
+            cursor: { id: 5 },
+            distinct: ['email'],
+            where: { age: { gte: 18 } },
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to #845, closing the gap against the typeorm adapter: a model-bound `PrismaAdapter` can now run what it serialized, and the args-merge rules become a public helper.

## Runners

```typescript
const adapter = new PrismaAdapter({ model: prisma.user });

const rows = await adapter.findMany(query, {
    base: { where: { realm_id: realmId } },
});
const total = await adapter.count(query);  // pre-pagination, for the meta block
```

- `findMany(query, options)`: `execute()` piped into the delegate.
- `count(query, options)`: the pre-pagination total (sees the `where`, including any baseline, never the page window).

There is deliberately no bundled rows-plus-total call: it would hide a second query on every request and, without a transaction, could pair mutually inconsistent results. The two primitives compose, and prisma's `$transaction` remains available when the pair must be consistent.

`execute()` stays the pure serializer; on an adapter constructed with explicit `{ provider, metadata }` the runners reject with a typed error, since there is nothing to run against. Runner failures are always promise rejections, never synchronous throws, and an object passed as `model` without a callable `findMany` does not bind.

## `mergeArgs`

Prisma ships no per-call args composition (`$extends` intercepts every call globally), so the merge the adapter always applied to its `base` option is now exported:

```typescript
import { mergeArgs } from '@rapiq/prisma';

const args = mergeArgs(baseline, produced);
```

`where` conditions are conjoined (`AND`), an overriding `include` joins a baseline `select` instead of replacing it (a caller-owned projection is never widened), `orderBy`/`take`/`skip` follow the override, and unknown keys (`cursor`, `distinct`, ...) pass through. `execute(query, { base })` is this merge applied to what the query produced, with the impossible-condition root form (`{ OR: [] }`) as the one special case, since a nested empty group would be stripped by prisma.

## Testing

Recording-delegate unit tests (argument shapes per runner, baseline conjunction, typed rejections on unbound or non-runnable bindings) and `mergeArgs` semantics, plus engine-backed runs against the real client, including the rows-plus-total composition and a baseline `where` conjunction.
