### PR TITLE
feat(core): add schema describe() serialization API

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -54,7 +54,7 @@ Parsed queries are immutable-ish node objects (`Query`, `Filters`, `Filter`, `Fi
 
 ### 2. Schema as server-side allow-list
 
-A `Schema<RECORD>` declares what a client *may* request per parameter (`allowed`, `default`, `mapping`, `schemaMapping`). Parsers consult it during parsing and either drop or throw on disallowed input (`throwOnFailure`). The `SchemaRegistry` stores schemas by name so relation traversal (`schemaMapping: { items: 'item' }`) resolves nested records. `schema.describe({ parameters? })` serializes the declared constraints into a JSON-safe `SchemaDescription` (each sub-schema contributes its own `describe()`; the relation→schema target map is composed on `Schema` via `mapSchema`) — absent key = never declared, `[]` = explicitly nothing; dynamic validate hooks and the filters `default` condition are deliberately not represented.
+A `Schema<RECORD>` declares what a client *may* request per parameter (`allowed`, `default`, `mapping`, `schemaMapping`). Parsers consult it during parsing and either drop or throw on disallowed input (`throwOnFailure`). The `SchemaRegistry` stores schemas by name so relation traversal (`schemaMapping: { items: 'item' }`) resolves nested records. `schema.describe({ parameters? })` serializes the declared constraints into a JSON-safe, shape-NORMALIZED `SchemaDescription` (each sub-schema contributes its own `describe()`; the relation→schema target map is composed on `Schema` via `mapSchema`) — every covered parameter carries every constraint key: `null` = never declared, `[]` = explicitly nothing, `strict` normalized to effective `false`; dynamic validate hooks and the filters `default` condition are deliberately not represented.
 
 ### 3. Dialects as small option objects, not subclasses
 

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -54,7 +54,7 @@ Parsed queries are immutable-ish node objects (`Query`, `Filters`, `Filter`, `Fi
 
 ### 2. Schema as server-side allow-list
 
-A `Schema<RECORD>` declares what a client *may* request per parameter (`allowed`, `default`, `mapping`, `schemaMapping`). Parsers consult it during parsing and either drop or throw on disallowed input (`throwOnFailure`). The `SchemaRegistry` stores schemas by name so relation traversal (`schemaMapping: { items: 'item' }`) resolves nested records.
+A `Schema<RECORD>` declares what a client *may* request per parameter (`allowed`, `default`, `mapping`, `schemaMapping`). Parsers consult it during parsing and either drop or throw on disallowed input (`throwOnFailure`). The `SchemaRegistry` stores schemas by name so relation traversal (`schemaMapping: { items: 'item' }`) resolves nested records. `schema.describe({ parameters? })` serializes the declared constraints into a JSON-safe `SchemaDescription` (each sub-schema contributes its own `describe()`; the relation→schema target map is composed on `Schema` via `mapSchema`) — absent key = never declared, `[]` = explicitly nothing; dynamic validate hooks and the filters `default` condition are deliberately not represented.
 
 ### 3. Dialects as small option objects, not subclasses
 

--- a/packages/core/src/schema/module.ts
+++ b/packages/core/src/schema/module.ts
@@ -19,8 +19,11 @@ import {
     defineSortSchema,
 } from './parameter';
 import type {
+    SchemaDescribeOptions,
+    SchemaDescription,
     SchemaOptions,
 } from './types';
+import { Parameter } from '../constants';
 import type { ObjectLiteral } from '../types';
 import { BaseSchema } from './base';
 
@@ -74,6 +77,63 @@ export class Schema<
         }
 
         this.extendSchemasOptions();
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Serialize the declared constraints of every (selected)
+     * parameter into a JSON-safe {@link SchemaDescription}. The
+     * relation target map is composed here, since the schema
+     * mapping lives on this schema — an unmapped relation maps to
+     * itself, mirroring registry resolution.
+     */
+    describe(options: SchemaDescribeOptions = {}) : SchemaDescription {
+        const output : SchemaDescription = {};
+
+        if (typeof this.options.name !== 'undefined') {
+            output.name = this.options.name;
+        }
+
+        if (typeof this.options.strict !== 'undefined') {
+            output.strict = this.options.strict;
+        }
+
+        const parameters : string[] = options.parameters || Object.values(Parameter);
+
+        if (parameters.includes(Parameter.FIELDS)) {
+            output.fields = this.fields.describe();
+        }
+
+        if (parameters.includes(Parameter.FILTERS)) {
+            output.filters = this.filters.describe();
+        }
+
+        if (parameters.includes(Parameter.PAGINATION)) {
+            output.pagination = this.pagination.describe();
+        }
+
+        if (parameters.includes(Parameter.RELATIONS)) {
+            output.relations = this.relations.describe();
+
+            if (
+                output.relations.allowed &&
+                output.relations.allowed.length > 0
+            ) {
+                const schemas : Record<string, string> = {};
+                for (const relation of output.relations.allowed) {
+                    schemas[relation] = this.mapSchema(relation);
+                }
+
+                output.relations.schemas = schemas;
+            }
+        }
+
+        if (parameters.includes(Parameter.SORT)) {
+            output.sort = this.sort.describe();
+        }
+
+        return output;
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/module.ts
+++ b/packages/core/src/schema/module.ts
@@ -89,15 +89,10 @@ export class Schema<
      * itself, mirroring registry resolution.
      */
     describe(options: SchemaDescribeOptions = {}) : SchemaDescription {
-        const output : SchemaDescription = {};
-
-        if (typeof this.options.name !== 'undefined') {
-            output.name = this.options.name;
-        }
-
-        if (typeof this.options.strict !== 'undefined') {
-            output.strict = this.options.strict;
-        }
+        const output : SchemaDescription = {
+            name: this.options.name ?? null,
+            strict: this.options.strict ?? false,
+        };
 
         const parameters : string[] = options.parameters || Object.values(Parameter);
 
@@ -116,10 +111,7 @@ export class Schema<
         if (parameters.includes(Parameter.RELATIONS)) {
             output.relations = this.relations.describe();
 
-            if (
-                output.relations.allowed &&
-                output.relations.allowed.length > 0
-            ) {
+            if (output.relations.allowed) {
                 const schemas : Record<string, string> = {};
                 for (const relation of output.relations.allowed) {
                     schemas[relation] = this.mapSchema(relation);

--- a/packages/core/src/schema/parameter/fields/schema.ts
+++ b/packages/core/src/schema/parameter/fields/schema.ts
@@ -99,17 +99,10 @@ export class FieldsSchema<
      * consumer mutating the description never touches the schema.
      */
     describe() : FieldsSchemaDescription {
-        const output : FieldsSchemaDescription = {};
-
-        if (!this.defaultIsUndefined) {
-            output.default = [...this.default];
-        }
-
-        if (!this.allowedIsUndefined) {
-            output.allowed = [...this.allowed];
-        }
-
-        return output;
+        return {
+            default: this.defaultIsUndefined ? null : [...this.default],
+            allowed: this.allowedIsUndefined ? null : [...this.allowed],
+        };
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/parameter/fields/schema.ts
+++ b/packages/core/src/schema/parameter/fields/schema.ts
@@ -10,7 +10,7 @@ import type { FieldKeys, ObjectLiteral } from '../../../types';
 import {
     isPropertyNameValid,
 } from '../../../utils';
-import type { FieldsOptions } from './types';
+import type { FieldsOptions, FieldsSchemaDescription } from './types';
 import { BaseKeyValidatableSchema } from '../../key-validatable';
 
 export class FieldsSchema<
@@ -90,6 +90,26 @@ export class FieldsSchema<
 
     hasDefaults() {
         return !this.defaultIsUndefined && this.default.length > 0;
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Serialize the declared constraints. Arrays are cloned, so a
+     * consumer mutating the description never touches the schema.
+     */
+    describe() : FieldsSchemaDescription {
+        const output : FieldsSchemaDescription = {};
+
+        if (!this.defaultIsUndefined) {
+            output.default = [...this.default];
+        }
+
+        if (!this.allowedIsUndefined) {
+            output.allowed = [...this.allowed];
+        }
+
+        return output;
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/parameter/fields/types.ts
+++ b/packages/core/src/schema/parameter/fields/types.ts
@@ -36,3 +36,13 @@ export type FieldsOptions<
      */
     validateMany?: KeyValidatorMany<CONTEXT>,
 };
+
+/**
+ * JSON-serializable snapshot of the fields constraints a schema
+ * declares. An absent key was never declared (fallback semantics
+ * apply); an empty array is an explicit "nothing".
+ */
+export type FieldsSchemaDescription = {
+    default?: string[],
+    allowed?: string[],
+};

--- a/packages/core/src/schema/parameter/fields/types.ts
+++ b/packages/core/src/schema/parameter/fields/types.ts
@@ -39,10 +39,11 @@ export type FieldsOptions<
 
 /**
  * JSON-serializable snapshot of the fields constraints a schema
- * declares. An absent key was never declared (fallback semantics
- * apply); an empty array is an explicit "nothing".
+ * declares. The shape is uniform across schemas: a `null` constraint
+ * was never declared (fallback semantics apply); an empty array is an
+ * explicit "nothing".
  */
 export type FieldsSchemaDescription = {
-    default?: string[],
-    allowed?: string[],
+    default: string[] | null,
+    allowed: string[] | null,
 };

--- a/packages/core/src/schema/parameter/filters/schema.ts
+++ b/packages/core/src/schema/parameter/filters/schema.ts
@@ -9,6 +9,7 @@ import type { ICondition, IFilter } from '../../../parameter';
 import type { MaybeAsync, ObjectLiteral, SimpleKeys } from '../../../types';
 import type {
     FiltersOptions,
+    FiltersSchemaDescription,
 } from './types';
 import { BaseSchema } from '../../base';
 
@@ -54,6 +55,22 @@ export class FiltersSchema<
 
     hasDefaults() {
         return !this.defaultIsUndefined;
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Serialize the declared constraints. Arrays are cloned, so a
+     * consumer mutating the description never touches the schema.
+     */
+    describe() : FiltersSchemaDescription {
+        const output : FiltersSchemaDescription = {};
+
+        if (!this.allowedIsUndefined) {
+            output.allowed = [...this.allowed];
+        }
+
+        return output;
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/parameter/filters/schema.ts
+++ b/packages/core/src/schema/parameter/filters/schema.ts
@@ -64,13 +64,7 @@ export class FiltersSchema<
      * consumer mutating the description never touches the schema.
      */
     describe() : FiltersSchemaDescription {
-        const output : FiltersSchemaDescription = {};
-
-        if (!this.allowedIsUndefined) {
-            output.allowed = [...this.allowed];
-        }
-
-        return output;
+        return { allowed: this.allowedIsUndefined ? null : [...this.allowed] };
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/parameter/filters/types.ts
+++ b/packages/core/src/schema/parameter/filters/types.ts
@@ -46,3 +46,15 @@ export type FiltersOptions<
      */
     caseSensitive?: SimpleKeys<T>[],
 };
+
+/**
+ * JSON-serializable snapshot of the filter constraints a schema
+ * declares. Only the consumer-facing vocabulary is exposed — the
+ * `default` condition is a server-injected baseline, not something
+ * a client can send, so it is deliberately absent. An absent
+ * `allowed` was never declared (fallback semantics apply); an
+ * empty array is an explicit "nothing".
+ */
+export type FiltersSchemaDescription = {
+    allowed?: string[],
+};

--- a/packages/core/src/schema/parameter/filters/types.ts
+++ b/packages/core/src/schema/parameter/filters/types.ts
@@ -51,10 +51,11 @@ export type FiltersOptions<
  * JSON-serializable snapshot of the filter constraints a schema
  * declares. Only the consumer-facing vocabulary is exposed — the
  * `default` condition is a server-injected baseline, not something
- * a client can send, so it is deliberately absent. An absent
- * `allowed` was never declared (fallback semantics apply); an
- * empty array is an explicit "nothing".
+ * a client can send, so it is deliberately absent. The shape is
+ * uniform across schemas: a `null` allow-list was never declared
+ * (fallback semantics apply); an empty array is an explicit
+ * "nothing".
  */
 export type FiltersSchemaDescription = {
-    allowed?: string[],
+    allowed: string[] | null,
 };

--- a/packages/core/src/schema/parameter/pagination/schema.ts
+++ b/packages/core/src/schema/parameter/pagination/schema.ts
@@ -19,12 +19,6 @@ export class PaginationSchema extends BaseSchema<PaginationOptions> {
      * Serialize the declared constraints.
      */
     describe() : PaginationSchemaDescription {
-        const output : PaginationSchemaDescription = {};
-
-        if (typeof this.options.maxLimit !== 'undefined') {
-            output.maxLimit = this.options.maxLimit;
-        }
-
-        return output;
+        return { maxLimit: this.options.maxLimit ?? null };
     }
 }

--- a/packages/core/src/schema/parameter/pagination/schema.ts
+++ b/packages/core/src/schema/parameter/pagination/schema.ts
@@ -5,11 +5,26 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PaginationOptions } from './types';
+import type { PaginationOptions, PaginationSchemaDescription } from './types';
 import { BaseSchema } from '../../base';
 
 export class PaginationSchema extends BaseSchema<PaginationOptions> {
     get maxLimit() {
         return this.options.maxLimit;
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Serialize the declared constraints.
+     */
+    describe() : PaginationSchemaDescription {
+        const output : PaginationSchemaDescription = {};
+
+        if (typeof this.options.maxLimit !== 'undefined') {
+            output.maxLimit = this.options.maxLimit;
+        }
+
+        return output;
     }
 }

--- a/packages/core/src/schema/parameter/pagination/types.ts
+++ b/packages/core/src/schema/parameter/pagination/types.ts
@@ -13,8 +13,9 @@ export type PaginationOptions = BaseSchemaOptions & {
 
 /**
  * JSON-serializable snapshot of the pagination constraints a schema
- * declares. An absent `maxLimit` means no cap was declared.
+ * declares. The shape is uniform across schemas: a `null` `maxLimit`
+ * means no cap was declared.
  */
 export type PaginationSchemaDescription = {
-    maxLimit?: number,
+    maxLimit: number | null,
 };

--- a/packages/core/src/schema/parameter/pagination/types.ts
+++ b/packages/core/src/schema/parameter/pagination/types.ts
@@ -10,3 +10,11 @@ import type { BaseSchemaOptions } from '../../types';
 export type PaginationOptions = BaseSchemaOptions & {
     maxLimit?: number
 };
+
+/**
+ * JSON-serializable snapshot of the pagination constraints a schema
+ * declares. An absent `maxLimit` means no cap was declared.
+ */
+export type PaginationSchemaDescription = {
+    maxLimit?: number,
+};

--- a/packages/core/src/schema/parameter/relations/schema.ts
+++ b/packages/core/src/schema/parameter/relations/schema.ts
@@ -35,12 +35,11 @@ export class RelationsSchema<
      * since the schema mapping lives on the parent schema.
      */
     describe() : RelationsSchemaDescription {
-        const output : RelationsSchemaDescription = {};
-
-        if (typeof this.options.allowed !== 'undefined') {
-            output.allowed = [...this.options.allowed];
-        }
-
-        return output;
+        return {
+            allowed: typeof this.options.allowed === 'undefined' ?
+                null :
+                [...this.options.allowed],
+            schemas: null,
+        };
     }
 }

--- a/packages/core/src/schema/parameter/relations/schema.ts
+++ b/packages/core/src/schema/parameter/relations/schema.ts
@@ -8,7 +8,7 @@
 import { Parameter } from '../../../constants';
 import type { ObjectLiteral } from '../../../types';
 import { BaseKeyValidatableSchema } from '../../key-validatable';
-import type { RelationsOptions } from './types';
+import type { RelationsOptions, RelationsSchemaDescription } from './types';
 
 export class RelationsSchema<
     T extends ObjectLiteral = ObjectLiteral,
@@ -24,5 +24,23 @@ export class RelationsSchema<
 
     get mapping() {
         return this.options.mapping || {};
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Serialize the declared constraints. The array is cloned, so a
+     * consumer mutating the description never touches the schema.
+     * The `schemas` target map is composed by {@link Schema.describe},
+     * since the schema mapping lives on the parent schema.
+     */
+    describe() : RelationsSchemaDescription {
+        const output : RelationsSchemaDescription = {};
+
+        if (typeof this.options.allowed !== 'undefined') {
+            output.allowed = [...this.options.allowed];
+        }
+
+        return output;
     }
 }

--- a/packages/core/src/schema/parameter/relations/types.ts
+++ b/packages/core/src/schema/parameter/relations/types.ts
@@ -47,10 +47,12 @@ export type RelationsOptions<
  * parent `schemaMapping`; an unmapped relation maps to itself,
  * mirroring registry resolution) — nested capabilities are looked up
  * on that schema's own description instead of being expanded inline.
- * An absent `allowed` was never declared (fallback semantics apply);
- * an empty array is an explicit "nothing".
+ * The shape is uniform across schemas: a `null` allow-list was never
+ * declared (fallback semantics apply; the targets cannot be
+ * enumerated then, so `schemas` is `null` alongside it), an empty
+ * array is an explicit "nothing" (with an empty `schemas` record).
  */
 export type RelationsSchemaDescription = {
-    allowed?: string[],
-    schemas?: Record<string, string>,
+    allowed: string[] | null,
+    schemas: Record<string, string> | null,
 };

--- a/packages/core/src/schema/parameter/relations/types.ts
+++ b/packages/core/src/schema/parameter/relations/types.ts
@@ -39,3 +39,18 @@ export type RelationsOptions<
      */
     validateMany?: KeyValidatorMany<CONTEXT>,
 };
+
+/**
+ * JSON-serializable snapshot of the relation constraints a schema
+ * declares. `schemas` maps each allowed relation to the name of the
+ * schema governing it (composed by {@link Schema.describe} via the
+ * parent `schemaMapping`; an unmapped relation maps to itself,
+ * mirroring registry resolution) — nested capabilities are looked up
+ * on that schema's own description instead of being expanded inline.
+ * An absent `allowed` was never declared (fallback semantics apply);
+ * an empty array is an explicit "nothing".
+ */
+export type RelationsSchemaDescription = {
+    allowed?: string[],
+    schemas?: Record<string, string>,
+};

--- a/packages/core/src/schema/parameter/sort/schema.ts
+++ b/packages/core/src/schema/parameter/sort/schema.ts
@@ -9,6 +9,7 @@ import { Parameter } from '../../../constants';
 import type { ObjectLiteral } from '../../../types';
 import type {
     SortOptions,
+    SortSchemaDescription,
 } from './types';
 import { BaseKeyValidatableSchema } from '../../key-validatable';
 
@@ -46,6 +47,30 @@ export class SortSchema<
 
     get mapping() : Record<string, string> | undefined {
         return this.options.mapping;
+    }
+
+    // ---------------------------------------------------------
+
+    /**
+     * Serialize the declared constraints. Arrays and records are
+     * cloned, so a consumer mutating the description never touches
+     * the schema. An allow-list derived from `default` keys (see
+     * {@link SortSchema.buildAllowed}) serializes like a declared one.
+     */
+    describe() : SortSchemaDescription {
+        const output : SortSchemaDescription = {};
+
+        if (!this.allowedIsUndefined) {
+            output.allowed = this.allowed.map(
+                (el) => (Array.isArray(el) ? [...el] : el),
+            ) as string[] | string[][];
+        }
+
+        if (!this.defaultIsUndefined) {
+            output.default = { ...this.default };
+        }
+
+        return output;
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/parameter/sort/schema.ts
+++ b/packages/core/src/schema/parameter/sort/schema.ts
@@ -58,19 +58,14 @@ export class SortSchema<
      * {@link SortSchema.buildAllowed}) serializes like a declared one.
      */
     describe() : SortSchemaDescription {
-        const output : SortSchemaDescription = {};
-
-        if (!this.allowedIsUndefined) {
-            output.allowed = this.allowed.map(
-                (el) => (Array.isArray(el) ? [...el] : el),
-            ) as string[] | string[][];
-        }
-
-        if (!this.defaultIsUndefined) {
-            output.default = { ...this.default };
-        }
-
-        return output;
+        return {
+            allowed: this.allowedIsUndefined ?
+                null :
+                this.allowed.map(
+                    (el) => (Array.isArray(el) ? [...el] : el),
+                ) as string[] | string[][],
+            default: this.defaultIsUndefined ? null : { ...this.default },
+        };
     }
 
     // ---------------------------------------------------------

--- a/packages/core/src/schema/parameter/sort/types.ts
+++ b/packages/core/src/schema/parameter/sort/types.ts
@@ -41,3 +41,14 @@ export type SortOptions<
      */
     validateMany?: KeyValidatorMany<CONTEXT>,
 };
+
+/**
+ * JSON-serializable snapshot of the sort constraints a schema
+ * declares. `allowed` may hold tuple groups (keys only usable
+ * together, in order). An absent key was never declared (fallback
+ * semantics apply); an empty array is an explicit "nothing".
+ */
+export type SortSchemaDescription = {
+    allowed?: string[] | string[][],
+    default?: Record<string, `${SortDirection}`>,
+};

--- a/packages/core/src/schema/parameter/sort/types.ts
+++ b/packages/core/src/schema/parameter/sort/types.ts
@@ -45,10 +45,11 @@ export type SortOptions<
 /**
  * JSON-serializable snapshot of the sort constraints a schema
  * declares. `allowed` may hold tuple groups (keys only usable
- * together, in order). An absent key was never declared (fallback
- * semantics apply); an empty array is an explicit "nothing".
+ * together, in order). The shape is uniform across schemas: a `null`
+ * constraint was never declared (fallback semantics apply); an empty
+ * array is an explicit "nothing".
  */
 export type SortSchemaDescription = {
-    allowed?: string[] | string[][],
-    default?: Record<string, `${SortDirection}`>,
+    allowed: string[] | string[][] | null,
+    default: Record<string, `${SortDirection}`> | null,
 };

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -189,10 +189,11 @@ export type SchemaDescribeOptions = {
  * the introspection surface an API can hand to its consumers so the
  * queryable vocabulary is discoverable without reading server code.
  *
- * Reading rules, uniform across parameters:
+ * The shape is NORMALIZED so every schema describes identically:
  * - a parameter key is present iff the description covers that
- *   parameter ({@link SchemaDescribeOptions.parameters});
- * - within a parameter, an absent constraint was never declared
+ *   parameter ({@link SchemaDescribeOptions.parameters}; all of them
+ *   by default), and always carries every constraint key;
+ * - within a parameter, a `null` constraint was never declared
  *   (fallback semantics apply — by default the syntactic property-name
  *   check, under {@link BaseSchemaOptions.strict} a full reject);
  * - an empty array is an explicit "nothing allowed".
@@ -206,8 +207,8 @@ export type SchemaDescribeOptions = {
  * description is the static upper bound.
  */
 export type SchemaDescription = {
-    name?: string,
-    strict?: boolean,
+    name: string | null,
+    strict: boolean,
     fields?: FieldsSchemaDescription,
     filters?: FiltersSchemaDescription,
     pagination?: PaginationSchemaDescription,

--- a/packages/core/src/schema/types.ts
+++ b/packages/core/src/schema/types.ts
@@ -8,14 +8,19 @@
 import type {
     FieldsOptions,
     FieldsSchema,
+    FieldsSchemaDescription,
     FiltersOptions,
     FiltersSchema,
+    FiltersSchemaDescription,
     PaginationOptions,
-    PaginationSchema, 
+    PaginationSchema,
+    PaginationSchemaDescription,
     RelationsOptions,
     RelationsSchema,
+    RelationsSchemaDescription,
     SortOptions,
     SortSchema,
+    SortSchemaDescription,
 } from './parameter';
 import type { Parameter } from '../constants';
 import type { ICondition } from '../parameter';
@@ -165,3 +170,47 @@ export type SchemaOptions<
     RECORD extends ObjectLiteral = ObjectLiteral,
     CONTEXT = any,
 > = Partial<SchemaOptionsNormalized<RECORD, CONTEXT>>;
+
+/**
+ * Options for {@link Schema.describe}.
+ */
+export type SchemaDescribeOptions = {
+    /**
+     * Restrict the description to a subset of parameters, mirroring
+     * a parse/decode surface that only processes some of them (e.g.
+     * a single-record read handling `fields` and `relations` only).
+     * Defaults to every parameter.
+     */
+    parameters?: `${Parameter}`[],
+};
+
+/**
+ * JSON-serializable snapshot of the constraints a schema declares —
+ * the introspection surface an API can hand to its consumers so the
+ * queryable vocabulary is discoverable without reading server code.
+ *
+ * Reading rules, uniform across parameters:
+ * - a parameter key is present iff the description covers that
+ *   parameter ({@link SchemaDescribeOptions.parameters});
+ * - within a parameter, an absent constraint was never declared
+ *   (fallback semantics apply — by default the syntactic property-name
+ *   check, under {@link BaseSchemaOptions.strict} a full reject);
+ * - an empty array is an explicit "nothing allowed".
+ *
+ * Relation capabilities are not expanded inline: `relations.schemas`
+ * names the schema governing each relation, whose own description
+ * covers the dotted vocabulary reachable through it.
+ *
+ * Dynamic constraints (validate/validateMany hooks, e.g. per-actor
+ * authorization gates) are deliberately not represented — the
+ * description is the static upper bound.
+ */
+export type SchemaDescription = {
+    name?: string,
+    strict?: boolean,
+    fields?: FieldsSchemaDescription,
+    filters?: FiltersSchemaDescription,
+    pagination?: PaginationSchemaDescription,
+    relations?: RelationsSchemaDescription,
+    sort?: SortSchemaDescription,
+};

--- a/packages/core/test/unit/schema/describe.spec.ts
+++ b/packages/core/test/unit/schema/describe.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Parameter,
+    defineSchema,
+} from '../../../src';
+import type { User } from '../../data/type';
+
+describe('src/schema/**/describe', () => {
+    it('should serialize every declared constraint', () => {
+        const schema = defineSchema<User>({
+            name: 'user',
+            fields: {
+                default: ['id', 'name'],
+                allowed: ['email'],
+            },
+            filters: { allowed: ['id', 'name'] },
+            relations: { allowed: ['realm', 'items'] },
+            sort: {
+                allowed: ['id', 'name'],
+                default: { name: 'DESC' },
+            },
+            pagination: { maxLimit: 50 },
+            schemaMapping: { items: 'item' },
+        });
+
+        expect(schema.describe()).toEqual({
+            name: 'user',
+            fields: {
+                default: ['id', 'name'],
+                allowed: ['email'],
+            },
+            filters: { allowed: ['id', 'name'] },
+            pagination: { maxLimit: 50 },
+            relations: {
+                allowed: ['realm', 'items'],
+                schemas: {
+                    realm: 'realm',
+                    items: 'item',
+                },
+            },
+            sort: {
+                allowed: ['id', 'name'],
+                default: { name: 'DESC' },
+            },
+        });
+    });
+
+    it('should omit undeclared constraints instead of normalizing them', () => {
+        const schema = defineSchema<User>({});
+
+        expect(schema.describe()).toEqual({
+            fields: {},
+            filters: {},
+            pagination: {},
+            relations: {},
+            sort: {},
+        });
+    });
+
+    it('should keep an explicitly empty allow-list distinguishable from an undeclared one', () => {
+        const schema = defineSchema<User>({
+            fields: { allowed: [] },
+            relations: { allowed: [] },
+        });
+
+        const output = schema.describe();
+
+        expect(output.fields).toEqual({ allowed: [] });
+        expect(output.relations).toEqual({ allowed: [] });
+        expect(output.filters).toEqual({});
+    });
+
+    it('should restrict the description to the selected parameters', () => {
+        const schema = defineSchema<User>({
+            name: 'user',
+            fields: { allowed: ['id', 'name'] },
+            filters: { allowed: ['id'] },
+            relations: { allowed: ['realm'] },
+            sort: { allowed: ['id'] },
+            pagination: { maxLimit: 50 },
+        });
+
+        expect(schema.describe({ parameters: [Parameter.FIELDS, Parameter.RELATIONS] })).toEqual({
+            name: 'user',
+            fields: { allowed: ['id', 'name'] },
+            relations: {
+                allowed: ['realm'],
+                schemas: { realm: 'realm' },
+            },
+        });
+    });
+
+    it('should serialize a sort allow-list derived from default keys', () => {
+        const schema = defineSchema<User>({ sort: { default: { name: 'DESC' } } });
+
+        expect(schema.describe().sort).toEqual({
+            allowed: ['name'],
+            default: { name: 'DESC' },
+        });
+    });
+
+    it('should clone sort tuple groups', () => {
+        const schema = defineSchema<User>({ sort: { allowed: [['realm.id', 'id'], ['name']] } });
+
+        const output = schema.describe();
+
+        expect(output.sort).toEqual({ allowed: [['realm.id', 'id'], ['name']] });
+
+        (output.sort!.allowed as string[][])[0].push('mutated');
+        expect(schema.sort.allowed[0]).toEqual(['realm.id', 'id']);
+    });
+
+    it('should not expose internal state to description mutations', () => {
+        const schema = defineSchema<User>({
+            fields: { default: ['id'], allowed: ['email'] },
+            filters: { allowed: ['id'] },
+            relations: { allowed: ['realm'] },
+            sort: { default: { name: 'DESC' } },
+        });
+
+        const output = schema.describe();
+
+        output.fields!.default!.push('mutated');
+        output.fields!.allowed!.push('mutated');
+        output.filters!.allowed!.push('mutated');
+        output.relations!.allowed!.push('mutated');
+        output.sort!.default!.id = 'ASC';
+
+        expect(schema.fields.default).toEqual(['id']);
+        expect(schema.fields.allowed).toEqual(['email']);
+        expect(schema.filters.allowed).toEqual(['id']);
+        expect(schema.relations.allowed).toEqual(['realm']);
+        expect(schema.sort.default).toEqual({ name: 'DESC' });
+    });
+
+    it('should include the strict flag only when declared', () => {
+        expect(defineSchema<User>({}).describe().strict).toBeUndefined();
+        expect(defineSchema<User>({ strict: true }).describe().strict).toBe(true);
+    });
+
+    it('should survive a JSON round-trip unchanged', () => {
+        const schema = defineSchema<User>({
+            name: 'user',
+            fields: { default: ['id', 'name'], allowed: ['email'] },
+            filters: { allowed: ['id', 'name'] },
+            relations: { allowed: ['realm'] },
+            sort: { allowed: ['id'], default: { id: 'ASC' } },
+            pagination: { maxLimit: 50 },
+        });
+
+        const output = schema.describe();
+
+        expect(JSON.parse(JSON.stringify(output))).toEqual(output);
+    });
+});

--- a/packages/core/test/unit/schema/describe.spec.ts
+++ b/packages/core/test/unit/schema/describe.spec.ts
@@ -31,6 +31,7 @@ describe('src/schema/**/describe', () => {
 
         expect(schema.describe()).toEqual({
             name: 'user',
+            strict: false,
             fields: {
                 default: ['id', 'name'],
                 allowed: ['email'],
@@ -51,15 +52,17 @@ describe('src/schema/**/describe', () => {
         });
     });
 
-    it('should omit undeclared constraints instead of normalizing them', () => {
+    it('should keep the shape uniform: undeclared constraints serialize as null', () => {
         const schema = defineSchema<User>({});
 
         expect(schema.describe()).toEqual({
-            fields: {},
-            filters: {},
-            pagination: {},
-            relations: {},
-            sort: {},
+            name: null,
+            strict: false,
+            fields: { default: null, allowed: null },
+            filters: { allowed: null },
+            pagination: { maxLimit: null },
+            relations: { allowed: null, schemas: null },
+            sort: { allowed: null, default: null },
         });
     });
 
@@ -71,9 +74,9 @@ describe('src/schema/**/describe', () => {
 
         const output = schema.describe();
 
-        expect(output.fields).toEqual({ allowed: [] });
-        expect(output.relations).toEqual({ allowed: [] });
-        expect(output.filters).toEqual({});
+        expect(output.fields).toEqual({ default: null, allowed: [] });
+        expect(output.relations).toEqual({ allowed: [], schemas: {} });
+        expect(output.filters).toEqual({ allowed: null });
     });
 
     it('should restrict the description to the selected parameters', () => {
@@ -88,7 +91,8 @@ describe('src/schema/**/describe', () => {
 
         expect(schema.describe({ parameters: [Parameter.FIELDS, Parameter.RELATIONS] })).toEqual({
             name: 'user',
-            fields: { allowed: ['id', 'name'] },
+            strict: false,
+            fields: { default: null, allowed: ['id', 'name'] },
             relations: {
                 allowed: ['realm'],
                 schemas: { realm: 'realm' },
@@ -110,7 +114,7 @@ describe('src/schema/**/describe', () => {
 
         const output = schema.describe();
 
-        expect(output.sort).toEqual({ allowed: [['realm.id', 'id'], ['name']] });
+        expect(output.sort).toEqual({ allowed: [['realm.id', 'id'], ['name']], default: null });
 
         (output.sort!.allowed as string[][])[0].push('mutated');
         expect(schema.sort.allowed[0]).toEqual(['realm.id', 'id']);
@@ -139,8 +143,8 @@ describe('src/schema/**/describe', () => {
         expect(schema.sort.default).toEqual({ name: 'DESC' });
     });
 
-    it('should include the strict flag only when declared', () => {
-        expect(defineSchema<User>({}).describe().strict).toBeUndefined();
+    it('should normalize the strict flag to its effective default', () => {
+        expect(defineSchema<User>({}).describe().strict).toBe(false);
         expect(defineSchema<User>({ strict: true }).describe().strict).toBe(true);
     });
 

--- a/packages/docs/guide/schemas.md
+++ b/packages/docs/guide/schemas.md
@@ -309,6 +309,7 @@ is discoverable without reading server code:
 userSchema.describe();
 // {
 //     name: 'user',
+//     strict: false,
 //     fields: { default: ['id', 'name'], allowed: ['email'] },
 //     filters: { allowed: ['id', 'name'] },
 //     pagination: { maxLimit: 50 },
@@ -316,19 +317,22 @@ userSchema.describe();
 //         allowed: ['realm', 'items'],
 //         schemas: { realm: 'realm', items: 'item' },
 //     },
-//     sort: { allowed: ['id', 'name'] },
+//     sort: { allowed: ['id', 'name'], default: null },
 // }
 ```
 
-Reading rules, uniform across parameters:
+The shape is **normalized** — every schema describes identically, so
+consumers can rely on a stable structure:
 
 - a parameter key is present iff the description covers that parameter —
   pass `parameters` to mirror a surface that only processes some of them
   (e.g. a single-record read handling `fields` and `relations` only):
-  `schema.describe({ parameters: [Parameter.FIELDS, Parameter.RELATIONS] })`;
-- within a parameter, an **absent** constraint was never declared, so the
+  `schema.describe({ parameters: [Parameter.FIELDS, Parameter.RELATIONS] })`.
+  A covered parameter always carries every constraint key;
+- within a parameter, a **`null`** constraint was never declared, so the
   fallback semantics apply (syntactic property-name check, or a full
-  reject under [strict mode](#strict-mode));
+  reject under [strict mode](#strict-mode) — `strict` is normalized to
+  its effective default, `false`);
 - an **empty array** is an explicit "nothing allowed".
 
 Relation capabilities are not expanded inline: `relations.schemas` names

--- a/packages/docs/guide/schemas.md
+++ b/packages/docs/guide/schemas.md
@@ -298,6 +298,51 @@ const query = parser.parse(input, { schema: 'user' });
 
 With the mapping above, input like `fields: { realm: ['name'] }` or `filters: { 'realm.name': 'master' }` is validated against the **realm** schema's allow-lists — each relation owner decides what may be requested of it.
 
+## Describing a schema
+
+`schema.describe()` serializes the declared constraints into a JSON-safe
+`SchemaDescription` — the introspection surface an API can return to its
+consumers (e.g. under a response `meta` key), so the queryable vocabulary
+is discoverable without reading server code:
+
+```typescript
+userSchema.describe();
+// {
+//     name: 'user',
+//     fields: { default: ['id', 'name'], allowed: ['email'] },
+//     filters: { allowed: ['id', 'name'] },
+//     pagination: { maxLimit: 50 },
+//     relations: {
+//         allowed: ['realm', 'items'],
+//         schemas: { realm: 'realm', items: 'item' },
+//     },
+//     sort: { allowed: ['id', 'name'] },
+// }
+```
+
+Reading rules, uniform across parameters:
+
+- a parameter key is present iff the description covers that parameter —
+  pass `parameters` to mirror a surface that only processes some of them
+  (e.g. a single-record read handling `fields` and `relations` only):
+  `schema.describe({ parameters: [Parameter.FIELDS, Parameter.RELATIONS] })`;
+- within a parameter, an **absent** constraint was never declared, so the
+  fallback semantics apply (syntactic property-name check, or a full
+  reject under [strict mode](#strict-mode));
+- an **empty array** is an explicit "nothing allowed".
+
+Relation capabilities are not expanded inline: `relations.schemas` names
+the schema governing each relation (via `schemaMapping`; an unmapped
+relation maps to itself, mirroring registry resolution) — nested
+vocabulary is looked up on that schema's own description.
+
+Deliberately absent from the output: the filters `default` condition (a
+server-injected baseline, not client vocabulary) and the dynamic
+`validate`/`validateMany` hooks (e.g. per-actor authorization gates) —
+the description is the **static upper bound** of what a client may send,
+not a per-request effective view. Arrays are cloned, so mutating a
+description never touches the schema.
+
 ## Failure behavior: drop vs. throw
 
 By default, parsers **drop** what the schema doesn't allow — the query still parses, minus the offending parts. That is the forgiving mode: old clients sending a removed field keep working.


### PR DESCRIPTION
## What

`schema.describe({ parameters? })` serializes a schema's declared constraints into a JSON-safe, **shape-normalized** `SchemaDescription` — every schema describes identically, so consumers can rely on a stable structure:

```typescript
userSchema.describe();
// {
//     name: 'user',
//     strict: false,
//     fields: { default: ['id', 'name'], allowed: ['email'] },
//     filters: { allowed: ['id', 'name'] },
//     pagination: { maxLimit: 50 },
//     relations: { allowed: ['realm', 'items'], schemas: { realm: 'realm', items: 'item' } },
//     sort: { allowed: ['id', 'name'], default: null },
// }
```

- Each sub-schema contributes its own `describe()` (`FieldsSchemaDescription`, `FiltersSchemaDescription`, `SortSchemaDescription`, `RelationsSchemaDescription`, `PaginationSchemaDescription`); the relation → schema target map is composed on `Schema` via `mapSchema` (an unmapped relation maps to itself, mirroring registry resolution).
- **Normalized shape**: every covered parameter carries every constraint key. `null` = never declared (fallback semantics apply — syntactic check, or full reject under `strict`); `[]` = an explicit "nothing allowed". This preserves the `allowedIsUndefined` distinction that plain property reads flatten. `name` serializes as `string | null`, `strict` as its effective boolean default, and `relations.schemas` mirrors the allowed tri-state (`null` when undeclared, `{}` when explicitly empty).
- `parameters` restricts the output to a subset, mirroring surfaces that only process some parameters (e.g. a single-record read handling `fields` + `relations` only).
- Deliberately **not** represented: the filters `default` condition (server-injected baseline, not client vocabulary) and `validate`/`validateMany` hooks (per-request dynamic gates) — the description is the static upper bound.
- Arrays/records are cloned; the output survives a JSON round-trip unchanged.

## Why

authup/authup#1649: an API consumer has no way to discover which filter/field/sort/relation keys a collection or record endpoint accepts without reading server source. authup returns this description under the response `meta` key of its entity endpoints (authup/authup#3332). Since the allow-list normalization semantics live here (`*IsUndefined` flags, raw-vs-normalized getters, `schemaMapping` being `protected`), the serializer belongs in `@rapiq/core` rather than being hand-rolled downstream.

## Notes

- Docs: new "Describing a schema" section in `guide/schemas.md`.
- Needs a `2.0.0-beta.11` release for authup to consume.