### PR TITLE
feat: add drizzle adapter (@rapiq/adapter-drizzle)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -30,7 +30,7 @@ The `Query` AST is an **intermediate representation (IR)**. Every package plays 
 
 1. **Define & interact** — client-side construction (plan 012): `defineQuery<RECORD>(QueryBuildInput)` + per-parameter `define*` fragment factories desugar typed input (scalars → `eq`, bare arrays → `in` with `null` legal, `$`-operator objects, condition-helper trees) straight to the AST — schema-free, no parsing. Condition helpers (`parameter/filters/helpers/`, one per `FilterFieldOperator`; `in` → `inArray` since `in` is reserved) build `Filter`/`Filters` nodes directly. Queries compose immutably via `mergeQueries` (left-priority; fields/relations/sorts keyed by name, pagination per-property) and the `Filters` combinators: `merge()` = per-field replace, flat root-AND only (typed `MergeError`, `ErrorCode.FILTERS_NOT_FLAT`); `and()`/`or()` = wrap & inject (server scoping — injected conditions can't be displaced by later merges). `$and`/`$or` object keys stay reserved for the mongo parser dialect (`@rapiq/parser-mongo`). `QueryBuilder` was removed — `defineQuery` replaces it.
 2. **Parse to IR** — parsers transform *dialect* input (a spec for how parameters are written: "simple" object shapes, "expression" strings) into the IR, validated against a `Schema`. The `filters.validate` hook runs on every resolved/coerced leaf and may synchronously or asynchronously accept it, replace it with any `ICondition` (leaf or compound, issue #840 — per-leaf policy residuals like `and(<leaf>, <scope>)` stay attached to the leaf; the simple URL dialect then throws its usual typed `FEATURE_UNSUPPORTED` on encode, and the non-flat result refuses later `merge()`s by design) or reject it, all without flattening compound structure. `parse()` keeps a strictly synchronous return type and throws `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER` on a Promise/thenable; `parseAsync()` awaits validators sequentially in tree order. Defaults apply if validation removes every leaf. Parsers are **transport-agnostic**: they read only the canonical `Parameter` keys (`fields`, `filters`, `pagination`, `relations`, `sort`) and know nothing about how the input crossed a process boundary.
-3. **Consume the IR** — either interpret/walk it directly (`@rapiq/adapter-sql`, `@rapiq/adapter-typeorm` via visitors; `@rapiq/adapter-memory` compiles it into plain functions to evaluate in-memory objects/arrays), or…
+3. **Consume the IR** — either interpret/walk it directly (`@rapiq/adapter-sql`, `@rapiq/adapter-typeorm` via visitors; `@rapiq/adapter-prisma`/`@rapiq/adapter-drizzle` serialize it into plain args/config objects; `@rapiq/adapter-memory` compiles it into plain functions to evaluate in-memory objects/arrays), or…
 4. **Transport the IR between application boundaries via a codec** — `@rapiq/codec-url` owns the complete HTTP URL wire format. The public `URLCodec` façade accepts a raw query string or a pre-parsed query object (Express `req.query`), maps wire names (`URLParameter`: `filter`, `page`, `include`, …) to canonical parameters and delegates to internal expression/simple strategies. Encoding writes stamped expression filters by default. Decoding dispatches stamped payloads and recognizes untagged expression strings or legacy simple bracket filters, so v2 follows a read-both/write-expression migration. App2 then works with the same IR.
 
 Codec rules settled during plan 007 (2026-07):
@@ -218,6 +218,32 @@ plan 024, do not re-litigate:
   widen an exact comparison).
 - **Unsupported by construction**: `regex`, `mod`, `size`, ITSELF, and `elemMatch` on a
   to-one relation raise a typed `AdapterError`, never approximated.
+
+`@rapiq/adapter-drizzle`: second pure IR **serializer** (plan 026), targeting drizzle-orm v1's
+relational-queries v2 object config (`{ where, columns, with, orderBy, limit, offset }` for
+`db.query.<table>.findMany()`); `drizzle-orm` is a devDependency only. Reuses the settled
+prisma pipeline (`planCondition` → core `distributeNegation` → same-element factoring →
+leaf-literal table) with drizzle spellings settled by engine measurement (2026-08-02):
+
+- A relation-filter object is ONE correlated `EXISTS` scope, so same-path conjuncts factor
+  into a single nested object; presence is `{ rel: true }`, absence `NOT: { rel: true }`
+  (the only emitted `NOT`: EXISTS is two-valued). `isNull`/`isNotNull` exist in the object
+  language, so complement null arms need no CASE analogue.
+- An empty `OR: []` group is STRIPPED by drizzle (matches everything), so an impossible
+  root is expressed as `limit: 0`, never `{ OR: [] }` (prisma's trick would silently
+  invert there).
+- Case folding has no `mode` flag: the pg preset lowers the foldable families to
+  `ilike`/`notIlike` with adapter-escaped operands (no wildcard veto needed — unlike
+  prisma, the adapter builds the pattern), `in` decomposes into per-string `ilike` arms;
+  mysql is collation-CI, sqlite `LIKE`-only (eq stays exact, documented). sqlite has no
+  default LIKE escape and the filter object no `ESCAPE` clause, so an anchored operand
+  carrying `%`/`_` fails typed there (`likeEscape` preset flag).
+- `metadata` + `provider` required (carried prisma rule); metadata is a hand-written
+  drizzle-vocabulary datamodel (`defineMetadata`), derivation from live
+  `defineRelations` handles is a follow-up. Relation-path `orderBy` is typed-unsupported
+  (undocumented in RQBv2; silent ignore beats nothing loud). The sqlite engine parity
+  matrix runs IN THE DEFAULT suite (in-memory better-sqlite3, no codegen); `test:db`
+  replays it on postgres where `ilike` exists.
 
 `@rapiq/adapter-memory`: compile-once functional visitors — the core visitor interfaces implemented with `R = compiled function` (`IFiltersVisitor<Predicate>`, `ISortsVisitor<Comparator>`, `IFieldsVisitor<Projector>`, `IPaginationVisitor<Slicer>`, `IQueryVisitor<CompiledQuery>`): `compileFilters(condition)` → `(input) => boolean`, `applyQuery(query, data)` → `{ data, total, pagination }`. The semantics contract (SQL parity for positive operators, complement law for negations — `ne`/`nin`/`not*` match null/missing —, same-element join-row binding for dotted paths over arrays) is settled in `.agents/plans/014-memory.md`; do not re-litigate decisions recorded there.
 

--- a/.agents/references/drizzle.md
+++ b/.agents/references/drizzle.md
@@ -1,0 +1,84 @@
+# Drizzle ORM
+
+Target of `@rapiq/adapter-drizzle` (plan 026). The adapter serializes the rapiq IR into a
+relational-queries v2 (RQBv2) `findMany` config object. RQBv2 ships with drizzle-orm v1
+(`1.0.0-rc.x`; npm `latest` is still the 0.45 line with the callback-based RQBv1).
+
+## Version landscape (checked 2026-08-02)
+
+| dist-tag | version | relational API |
+|---|---|---|
+| `latest` | 0.45.2 | RQBv1: `where: (table, { eq }) => ...` callback, table-bound operator functions |
+| `rc` | 1.0.0-rc.4 (2026-06-27) | RQBv2: object-based `where`, `defineRelations` |
+| `beta` | 1.0.0-beta.22 | superseded by the rc line |
+
+## RQBv2 findMany config (the adapter's output shape)
+
+```typescript
+db.query.users.findMany({
+    where: { /* filter object, see below */ },
+    columns: { id: true, name: true },        // or exclusion: { secret: false }
+    with: { posts: { columns: {...}, where: {...}, limit, offset } },
+    orderBy: { id: 'asc' },                    // or array form for multi-key ordering
+    limit: 10,
+    offset: 0,
+});
+```
+
+## Where filter vocabulary
+
+Root level and column level both accept `AND` / `OR` / `NOT`; root level additionally
+accepts `RAW: (table) => sql`.
+
+Column operators: `eq`, `ne`, `gt`, `gte`, `lt`, `lte`, `in`, `notIn`, `like`, `ilike`,
+`notLike`, `notIlike`, `isNull`, `isNotNull`, `arrayContains`, `arrayContained`,
+`arrayOverlaps`.
+
+```typescript
+where: {
+    age: { gte: 18 },
+    name: { ilike: 'jane%' },
+    OR: [{ status: 'active' }, { status: 'pending' }],
+    NOT: { role: 'admin' },
+    posts: { content: { like: 'M%' } },   // relation filter: ANY related record matches
+    comments: true,                        // relation existence test
+}
+```
+
+Relation filters are existential only (no some/every/none vocabulary as in prisma):
+a nested relation object matches records with at least one related record satisfying the
+interior; `NOT` around it yields the none form. All conditions inside one relation-filter
+object share a single scope (same related record), which is the same-element binding
+rapiq's contract requires.
+
+Corresponding code in this project:
+
+| drizzle concept | rapiq counterpart |
+|---|---|
+| column operators | `packages/adapter-drizzle/src/adapter/where.ts` leaf table (planned) |
+| relation filter object | one existential scope from the same-element factoring pass (mirrors `packages/adapter-prisma/src/adapter/where.ts`) |
+| `NOT: { rel: true }` | relation absence arm (prisma analogue: `NOT: { rel: { is: {} } }` / `none: {}`) |
+| `isNull` / `isNotNull` | null arms of `@rapiq/core` `distributeNegation` complements |
+| `columns` | fields pick set (`FieldOperator.INCLUDE`/`EXCLUDE`) |
+| `with` | relations + per-relation fieldset narrowing (issue #847) |
+
+## Behavioral notes / differences vs rapiq semantics
+
+- `ne`, `notLike`, `notIlike`, `notIn` render plain SQL and therefore exclude NULL rows;
+  rapiq's negations are exact null-inclusive complements, so complements need an
+  `isNull` OR-arm (nullability-gated), exactly like `@rapiq/adapter-prisma`.
+- `ilike` renders the pg `ILIKE` keyword: only valid on postgres. mysql compares
+  case-insensitively via its default `*_ci` collations with plain `like`; sqlite `LIKE`
+  is ASCII-case-insensitive. Mirrors the provider-preset reasoning of adapter-prisma and
+  the `caseFold` identity of adapter-sql presets.
+- LIKE pattern operands are built by the adapter, so `%`/`_`/`\` can be escaped by us
+  (default escape character on pg and mysql is backslash). Prisma could not do this
+  (operand passed verbatim), hence its wildcard veto; drizzle does not need the veto.
+- `orderBy` on a related table's column is not documented for the root query; RQBv1 did
+  not support it either.
+- No regex, mod or array-length operator (RAW is the only escape hatch).
+- `defineRelations(schema, (r) => ({...}))` replaces the v1 `relations()` helpers;
+  `from`/`to` replace `fields`/`references`; `through` covers many-to-many.
+
+Sources: https://rqbv2.drizzle-orm-fe.pages.dev/docs/rqb-v2 and
+https://rqbv2.drizzle-orm-fe.pages.dev/docs/relations-v1-v2 (rc docs site).

--- a/.agents/structure.md
+++ b/.agents/structure.md
@@ -14,6 +14,7 @@ npm-workspaces monorepo (`packages/*`) orchestrated by Nx. Every publishable pac
 | [@rapiq/adapter-sql](../packages/adapter-sql)                             | Library  | Dialect-agnostic SQL adapter + visitor; ships dialect presets (pg, mysql, sqlite, mssql, oracle) |
 | [@rapiq/adapter-typeorm](../packages/adapter-typeorm)                     | Library  | Adapter applying a parsed `Query` to a TypeORM `SelectQueryBuilder`         |
 | [@rapiq/adapter-prisma](../packages/adapter-prisma)                       | Library  | Adapter serializing a parsed `Query` into a Prisma `findMany` args object (pure value, no prisma dependency) |
+| [@rapiq/adapter-drizzle](../packages/adapter-drizzle)                     | Library  | Adapter serializing a parsed `Query` into a drizzle relational-queries v2 `findMany` config (pure value, no drizzle dependency) |
 | [@rapiq/adapter-memory](../packages/adapter-memory)                       | Library  | Evaluates a parsed `Query` against in-memory objects/arrays: visitors compile the AST into plain functions (predicate/comparator/projector/slicer) |
 | [@rapiq/docs](../packages/docs)                           | Docs app | VitePress documentation site (rapiq.tada5hi.net); private, not published    |
 
@@ -30,6 +31,7 @@ Layer 1 (depend on core):
   @rapiq/adapter-sql
   @rapiq/adapter-memory
   @rapiq/adapter-prisma
+  @rapiq/adapter-drizzle
 
 Layer 2:
   @rapiq/parser-expression   (core + parser-simple)
@@ -93,6 +95,11 @@ packages/adapter-prisma/src/
 ├── metadata/             # IMetadata + Metadata/defineMetadata over a prisma datamodel (DMMF-shaped)
 └── provider/             # per-connector capability presets (mode: 'insensitive' support)
 
+packages/adapter-drizzle/src/
+├── adapter/              # DrizzleAdapter + pure renderers (where/fields/sort/merge) for the RQBv2 findMany config
+├── metadata/             # IMetadata + defineMetadata over a hand-written drizzle-vocabulary datamodel
+└── provider/             # per-dialect capability presets (ilike availability, LIKE escape)
+
 packages/adapter-memory/src/
 ├── parameter/{fields,filters,pagination,relations,sorts}/  # visitors compiling AST nodes into functions
 ├── query/                # CompiledQuery (matches/apply, pagination echo)
@@ -134,5 +141,5 @@ Public API is controlled via the barrel `src/index.ts` of each package; anything
 - **What a client may request (allow-lists, defaults, mappings)** → `@rapiq/core` (`schema/`)
 - **Turning raw URL input into the AST** → `@rapiq/codec-url` (dispatch + decode through parser-simple/parser-expression)
 - **Turning the AST into URL transport format** → `@rapiq/codec-url` (expression-default encode; deprecated explicit simple encode)
-- **Turning the AST into backend queries** → `@rapiq/adapter-sql`, `@rapiq/adapter-typeorm`, `@rapiq/adapter-prisma`
+- **Turning the AST into backend queries** → `@rapiq/adapter-sql`, `@rapiq/adapter-typeorm`, `@rapiq/adapter-prisma`, `@rapiq/adapter-drizzle`
 - **Evaluating the AST against in-memory data** → `@rapiq/adapter-memory` (predicates/comparators/projectors compiled from the AST)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,6 +167,15 @@ jobs:
                 run: |
                     npm run test:db --workspace=packages/adapter-prisma
 
+            # @rapiq/adapter-drizzle runs its sqlite engine parity in the default
+            # `tests` job (in-memory, codegen-free); this step adds the postgres
+            # replay, the only dialect where `ilike` exists and the case
+            # contract can be measured. Under the mysql matrix entry the
+            # postgres specs skip themselves.
+            -   name: Run tests (drizzle)
+                run: |
+                    npm run test:db --workspace=packages/adapter-drizzle
+
 #    preview:
 #        name: Preview Package
 #        needs: [build]

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -7,5 +7,6 @@
     "packages/adapter-sql": "2.0.0-beta.13",
     "packages/adapter-typeorm": "2.0.0-beta.13",
     "packages/adapter-prisma": "2.0.0-beta.13",
+    "packages/adapter-drizzle": "2.0.0-beta.13",
     "packages/adapter-memory": "2.0.0-beta.13"
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Every REST list endpoint answers the same five questions: which **fields**, whic
 | **Build** <sub>calling application</sub> | `defineQuery<User>({ filters: { age: gte(18) }, sort: '-name' })`: typed input in, query AST out |
 | **Transport** <sub>wire</sub> | encoded as a self-described URL query string: `?codec=url-expression&filter=gte(age,'18')&sort=-name` |
 | **Validate** <sub>receiving application</sub> | decoded back into the same AST, checked against a `Schema`: allow-lists, defaults, mappings |
-| **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/adapter-sql`), to a TypeORM `SelectQueryBuilder` (`@rapiq/adapter-typeorm`) or as Prisma arguments (`@rapiq/adapter-prisma`) |
+| **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/adapter-sql`), to a TypeORM `SelectQueryBuilder` (`@rapiq/adapter-typeorm`), as Prisma arguments (`@rapiq/adapter-prisma`) or as a Drizzle relational query config (`@rapiq/adapter-drizzle`) |
 
 The two ends are just applications. A browser querying an API is the common case, but services compose the same way:
 an API gateway, for instance, validates an incoming query against its own schema, scopes it
@@ -229,6 +229,7 @@ export async function getUsers(req: Request, res: Response) {
 | [@rapiq/adapter-sql](packages/adapter-sql) | Dialect-agnostic SQL adapter (pg, mysql, sqlite, mssql & oracle presets) |
 | [@rapiq/adapter-typeorm](packages/adapter-typeorm) | Applies a parsed `Query` to a TypeORM `SelectQueryBuilder` |
 | [@rapiq/adapter-prisma](packages/adapter-prisma) | Serializes a parsed `Query` into a Prisma argument object |
+| [@rapiq/adapter-drizzle](packages/adapter-drizzle) | Serializes a parsed `Query` into a Drizzle relational query config |
 | [@rapiq/adapter-memory](packages/adapter-memory) | Evaluates a parsed `Query` against in-memory objects & arrays |
 
 ## Parameters

--- a/package-lock.json
+++ b/package-lock.json
@@ -1247,21 +1247,6 @@
                 "better-sqlite3": "^12.6.0"
             }
         },
-        "node_modules/@prisma/adapter-better-sqlite3/node_modules/better-sqlite3": {
-            "version": "12.11.1",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "prebuild-install": "^7.1.1"
-            },
-            "engines": {
-                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
-            }
-        },
         "node_modules/@prisma/adapter-pg": {
             "version": "7.9.0",
             "resolved": "https://registry.npmjs.org/@prisma/adapter-pg/-/adapter-pg-7.9.0.tgz",
@@ -1672,6 +1657,10 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/@rapiq/adapter-drizzle": {
+            "resolved": "packages/adapter-drizzle",
+            "link": true
         },
         "node_modules/@rapiq/adapter-memory": {
             "resolved": "packages/adapter-memory",
@@ -2967,6 +2956,16 @@
             "license": "MIT",
             "dependencies": {
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@types/better-sqlite3": {
+            "version": "7.6.13",
+            "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+            "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/chai": {
@@ -4693,6 +4692,21 @@
             "integrity": "sha512-oQhh0y1qo2/ZKdAAEvHZAqKKiHOFU5k/bW96fE2ScgQOVkJRiHwB+nOS1SgFsYqRlxMDWvefXi9Q3px7QvgNDw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/better-sqlite3": {
+            "version": "12.11.1",
+            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
+            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "dependencies": {
+                "bindings": "^1.5.0",
+                "prebuild-install": "^7.1.1"
+            },
+            "engines": {
+                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+            }
         },
         "node_modules/bindings": {
             "version": "1.5.0",
@@ -11854,6 +11868,221 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "packages/adapter-drizzle": {
+            "name": "@rapiq/adapter-drizzle",
+            "version": "2.0.0-beta.13",
+            "license": "MIT",
+            "devDependencies": {
+                "@rapiq/core": "^2.0.0-beta.13",
+                "@types/better-sqlite3": "^7.6.11",
+                "@types/pg": "^8.11.10",
+                "better-sqlite3": "^12.6.0",
+                "drizzle-orm": "1.0.0-rc.4",
+                "pg": "^8.13.0"
+            },
+            "peerDependencies": {
+                "@rapiq/core": "^2.0.0-beta.13"
+            }
+        },
+        "packages/adapter-drizzle/node_modules/drizzle-orm": {
+            "version": "1.0.0-rc.4",
+            "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-1.0.0-rc.4.tgz",
+            "integrity": "sha512-BT+pf+qoiYHqltoA88Jmf6ilGMXPlpfE0hEJKc2adRtMCAl25Swk/t5gXcWxZNAwdtf3F5gCd2FpeOyP/pT0Hw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peerDependencies": {
+                "@aws-sdk/client-rds-data": ">=3",
+                "@cloudflare/workers-types": ">=4",
+                "@effect/sql-d1": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-libsql": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-mysql2": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-pg": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-pglite": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-sqlite-bun": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-sqlite-do": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-sqlite-node": ">=4.0.0-beta.83 || >=4.0.0",
+                "@effect/sql-sqlite-wasm": ">=4.0.0-beta.83 || >=4.0.0",
+                "@electric-sql/pglite": ">=0.2.0",
+                "@libsql/client": ">=0.10.0",
+                "@libsql/client-wasm": ">=0.10.0",
+                "@neondatabase/serverless": ">=0.10.0",
+                "@op-engineering/op-sqlite": ">=2",
+                "@opentelemetry/api": "^1.4.1",
+                "@planetscale/database": ">=1.13",
+                "@sinclair/typebox": ">=0.34.8",
+                "@sqlitecloud/drivers": ">=1.0.653",
+                "@tidbcloud/serverless": "*",
+                "@tursodatabase/database": ">=0.6.0-pre.28 || >=0.6.0",
+                "@tursodatabase/database-common": ">=0.6.0-pre.28 || >=0.6.0",
+                "@tursodatabase/database-wasm": ">=0.6.0-pre.28 || >=0.6.0",
+                "@tursodatabase/serverless": ">=1.1.3",
+                "@tursodatabase/sync": ">=0.6.0-pre.28 || >=0.6.0",
+                "@types/better-sqlite3": "*",
+                "@types/mssql": "^9.1.4",
+                "@types/pg": "*",
+                "@types/sql.js": "*",
+                "@upstash/redis": ">=1.34.7",
+                "@vercel/postgres": ">=0.8.0",
+                "@xata.io/client": "*",
+                "arktype": ">=2.0.0",
+                "better-sqlite3": ">=9.3.0",
+                "bun-types": "*",
+                "effect": ">=4.0.0-beta.83 || >=4.0.0",
+                "expo-sqlite": ">=14.0.0",
+                "mssql": "^11.0.1",
+                "mysql2": ">=2",
+                "pg": ">=8",
+                "postgres": ">=3",
+                "sql.js": ">=1",
+                "sqlite3": ">=5",
+                "typebox": ">=1.0.0",
+                "valibot": ">=1.0.0-beta.7",
+                "zod": "^3.25.0 || ^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@aws-sdk/client-rds-data": {
+                    "optional": true
+                },
+                "@cloudflare/workers-types": {
+                    "optional": true
+                },
+                "@effect/sql-d1": {
+                    "optional": true
+                },
+                "@effect/sql-libsql": {
+                    "optional": true
+                },
+                "@effect/sql-mysql2": {
+                    "optional": true
+                },
+                "@effect/sql-pg": {
+                    "optional": true
+                },
+                "@effect/sql-pglite": {
+                    "optional": true
+                },
+                "@effect/sql-sqlite-bun": {
+                    "optional": true
+                },
+                "@effect/sql-sqlite-do": {
+                    "optional": true
+                },
+                "@effect/sql-sqlite-node": {
+                    "optional": true
+                },
+                "@effect/sql-sqlite-wasm": {
+                    "optional": true
+                },
+                "@electric-sql/pglite": {
+                    "optional": true
+                },
+                "@libsql/client": {
+                    "optional": true
+                },
+                "@libsql/client-wasm": {
+                    "optional": true
+                },
+                "@neondatabase/serverless": {
+                    "optional": true
+                },
+                "@op-engineering/op-sqlite": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@planetscale/database": {
+                    "optional": true
+                },
+                "@sinclair/typebox": {
+                    "optional": true
+                },
+                "@sqlitecloud/drivers": {
+                    "optional": true
+                },
+                "@tidbcloud/serverless": {
+                    "optional": true
+                },
+                "@tursodatabase/database": {
+                    "optional": true
+                },
+                "@tursodatabase/database-common": {
+                    "optional": true
+                },
+                "@tursodatabase/database-wasm": {
+                    "optional": true
+                },
+                "@tursodatabase/serverless": {
+                    "optional": true
+                },
+                "@tursodatabase/sync": {
+                    "optional": true
+                },
+                "@types/better-sqlite3": {
+                    "optional": true
+                },
+                "@types/mssql": {
+                    "optional": true
+                },
+                "@types/pg": {
+                    "optional": true
+                },
+                "@types/sql.js": {
+                    "optional": true
+                },
+                "@upstash/redis": {
+                    "optional": true
+                },
+                "@vercel/postgres": {
+                    "optional": true
+                },
+                "@xata.io/client": {
+                    "optional": true
+                },
+                "arktype": {
+                    "optional": true
+                },
+                "better-sqlite3": {
+                    "optional": true
+                },
+                "bun-types": {
+                    "optional": true
+                },
+                "effect": {
+                    "optional": true
+                },
+                "expo-sqlite": {
+                    "optional": true
+                },
+                "mssql": {
+                    "optional": true
+                },
+                "mysql2": {
+                    "optional": true
+                },
+                "pg": {
+                    "optional": true
+                },
+                "postgres": {
+                    "optional": true
+                },
+                "sql.js": {
+                    "optional": true
+                },
+                "sqlite3": {
+                    "optional": true
+                },
+                "typebox": {
+                    "optional": true
+                },
+                "valibot": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": true
+                }
+            }
+        },
         "packages/adapter-memory": {
             "name": "@rapiq/adapter-memory",
             "version": "2.0.0-beta.13",
@@ -12039,21 +12268,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "packages/adapter-typeorm/node_modules/better-sqlite3": {
-            "version": "12.11.1",
-            "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-            "integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "dependencies": {
-                "bindings": "^1.5.0",
-                "prebuild-install": "^7.1.1"
-            },
-            "engines": {
-                "node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
             }
         },
         "packages/adapter-typeorm/node_modules/cliui": {

--- a/packages/adapter-drizzle/LICENSE
+++ b/packages/adapter-drizzle/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021-2026 Peter Placzek
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/adapter-drizzle/README.md
+++ b/packages/adapter-drizzle/README.md
@@ -1,0 +1,118 @@
+<p align="center">
+  <a href="https://github.com/tada5hi/rapiq">
+    <img src="https://raw.githubusercontent.com/tada5hi/rapiq/master/.github/assets/logo.svg" alt="rapiq" width="100" height="100">
+  </a>
+</p>
+
+<h1 align="center">@rapiq/adapter-drizzle</h1>
+
+<p align="center">
+  <b>Turn a rapiq <code>Query</code> into a Drizzle relational query config.</b><br>
+  A pure serializer: nothing is mutated, no database is touched,<br>
+  and <code>drizzle-orm</code> is not a dependency.
+</p>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@rapiq/adapter-drizzle"><img src="https://img.shields.io/npm/v/@rapiq/adapter-drizzle/beta?color=%237c3aed&label=npm" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/@rapiq/adapter-drizzle"><img src="https://img.shields.io/npm/types/@rapiq/adapter-drizzle?color=%2306b6d4" alt="types"></a>
+  <a href="https://github.com/tada5hi/rapiq/blob/master/LICENSE"><img src="https://img.shields.io/npm/l/@rapiq/adapter-drizzle?color=blue" alt="License: MIT"></a>
+</p>
+
+<p align="center">
+  <a href="https://rapiq.tada5hi.net/packages/adapter-drizzle"><b>Documentation</b></a>
+  ·
+  <a href="https://github.com/tada5hi/rapiq">Monorepo</a>
+  ·
+  <a href="https://www.npmjs.com/package/@rapiq/adapter-drizzle">npm</a>
+</p>
+
+---
+
+Part of [**rapiq**](https://github.com/tada5hi/rapiq). Typed REST queries: *build, transport, validate, execute.*
+This adapter targets Drizzle's relational queries v2 API (drizzle-orm v1): `execute(query)` returns the plain config object you hand straight to `db.query.<table>.findMany()`.
+
+- 🧾 **Just a value**: `execute(query)` returns `{ config, pagination }`. Nothing is mutated, so the adapter is trivial to test, log, cache or post-process.
+- 🔗 **Zero coupling**: `drizzle-orm` is neither a runtime nor a peer dependency; it is a devDependency only, because the test suite runs the emitted configs through a real engine.
+- 🧮 **Exact semantics**: negation is the null-inclusive complement and conditions on one to-many path bind to the same element, exactly as in `@rapiq/adapter-sql`, `@rapiq/adapter-typeorm`, `@rapiq/adapter-prisma` and `@rapiq/adapter-memory`. Drizzle's three-valued `NOT` is never applied to a user condition.
+- 🔬 **Measured, not modelled**: the parity suite executes every condition through a real drizzle engine (in-memory SQLite by default, PostgreSQL in CI) and cross-checks it against `@rapiq/adapter-memory`.
+
+```typescript
+import { DrizzleAdapter, defineMetadata } from '@rapiq/adapter-drizzle';
+
+const adapter = new DrizzleAdapter({
+    provider: 'pg',
+    metadata: defineMetadata(datamodel, 'users'),
+});
+
+const { config, pagination } = adapter.execute(query);
+
+const users = await db.query.users.findMany(config);
+```
+
+## Installation
+
+```sh
+npm install @rapiq/core @rapiq/adapter-drizzle
+```
+
+Requires drizzle-orm v1 (relational queries v2) on the consuming side; the adapter itself imports nothing from it.
+
+## What a query becomes
+
+| Query parameter | findMany config key |
+|---|---|
+| `filters` | `where` |
+| `fields` | `columns` |
+| `relations` | `with`, narrowed by per-relation field picks |
+| `sort` | `orderBy` (key order carries the priority) |
+| `pagination` | `limit` / `offset` |
+
+`pagination` is echoed back from `execute()` as the limit/offset actually applied, ready for a response `meta` block.
+
+## Table metadata
+
+The adapter needs four facts about your tables that a `Query` cannot carry, and each one changes what a *correct* drizzle filter looks like:
+
+| fact | what it decides |
+|---|---|
+| is the path a relation? | a relation takes a nested filter object or a presence test, never a column operator |
+| is that relation to-many? | the shape of the empty-collection arm of a complement |
+| can the column hold `null`? | whether a complement carries its `isNull` arm |
+| does it hold strings? | only string columns fold case through `ilike` |
+
+Guessing any of them produces a wrong result set rather than graceful degradation, so `metadata` and `provider` are required. The datamodel is a plain object in drizzle's own vocabulary:
+
+```typescript
+const metadata = defineMetadata({
+    users: {
+        columns: {
+            id: { dataType: 'number', nullable: false },
+            name: 'string',
+        },
+        relations: {
+            items: { target: 'items', many: true },
+            realm: { target: 'realms', many: false },
+        },
+    },
+    items: { /* ... */ },
+    realms: { /* ... */ },
+}, 'users');
+```
+
+## Preserving an application-owned predicate
+
+Rapiq filters **narrow** a query, they never replace it. Pass a baseline config and the caller's conditions are conjoined with your tenant or authorization scope:
+
+```typescript
+const { config } = adapter.execute(query, {
+    base: { where: { realm_id: realmId } },
+});
+
+// where: { AND: [ { realm_id: ... }, { ...client filters } ] }
+```
+
+The merge rules behind `base` are exported as `mergeConfig(base, override)` for use outside the adapter.
+
+## License
+
+MIT

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -1,0 +1,74 @@
+{
+    "name": "@rapiq/adapter-drizzle",
+    "version": "2.0.0-beta.13",
+    "description": "A drizzle adapter for rapiq.",
+    "type": "module",
+    "main": "dist/index.mjs",
+    "types": "dist/index.d.mts",
+    "exports": {
+        "./package.json": "./package.json",
+        ".": {
+            "types": "./dist/index.d.mts",
+            "import": "./dist/index.mjs"
+        }
+    },
+    "files": [
+        "dist/"
+    ],
+    "devDependencies": {
+        "@rapiq/core": "^2.0.0-beta.13",
+        "@types/better-sqlite3": "^7.6.11",
+        "@types/pg": "^8.11.10",
+        "better-sqlite3": "^12.6.0",
+        "drizzle-orm": "1.0.0-rc.4",
+        "pg": "^8.13.0"
+    },
+    "peerDependencies": {
+        "@rapiq/core": "^2.0.0-beta.13"
+    },
+    "scripts": {
+        "build:types": "tsc --noEmit -p tsconfig.build.json",
+        "build:js": "tsdown",
+        "build": "npm run build:types && npm run build:js",
+        "test": "vitest --config test/vitest.config.ts --run",
+        "test:coverage": "vitest --config test/vitest.config.ts --run --coverage",
+        "test:db": "vitest --config test/vitest.db.config.ts --run",
+        "prepublishOnly": "npm run build"
+    },
+    "author": {
+        "name": "Peter Placzek",
+        "email": "contact@tada5hi.net",
+        "url": "https://github.com/tada5hi"
+    },
+    "license": "MIT",
+    "publishConfig": {
+        "access": "public",
+        "tag": "beta"
+    },
+    "keywords": [
+        "query",
+        "json",
+        "json-api",
+        "api",
+        "rest",
+        "api-utils",
+        "drizzle",
+        "drizzle-orm",
+        "include",
+        "pagination",
+        "sort",
+        "fields",
+        "filter",
+        "relations",
+        "typescript"
+    ],
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/Tada5hi/rapiq.git",
+        "directory": "packages/adapter-drizzle"
+    },
+    "bugs": {
+        "url": "https://github.com/Tada5hi/rapiq/issues"
+    },
+    "homepage": "https://github.com/Tada5hi/rapiq#readme"
+}

--- a/packages/adapter-drizzle/src/adapter/fields.ts
+++ b/packages/adapter-drizzle/src/adapter/fields.ts
@@ -12,6 +12,7 @@ import {
     isFilter,
     isFilters,
 } from '@rapiq/core';
+import type { IMetadata } from '../metadata';
 
 type SelectionNode = {
     /**
@@ -165,7 +166,11 @@ function materialize(node: SelectionNode) : true | Record<string, any> {
  * compose at every level. Excluded fields are simply not projected,
  * the resolution every other rapiq backend applies.
  */
-export function buildSelection(fields: IFields, relationPaths: string[]) : Selection {
+export function buildSelection(
+    fields: IFields,
+    relationPaths: string[],
+    metadata?: IMetadata,
+) : Selection {
     const root = createNode();
 
     for (const field of fields.value) {
@@ -222,6 +227,17 @@ export function buildSelection(fields: IFields, relationPaths: string[]) : Selec
             }
 
             const segments = [...prefix, ...operand.split('.')];
+
+            // an operand that addresses a RELATION (a presence test
+            // like exists('realm')) is not a column key in drizzle:
+            // it hydrates through `with` instead, which is what the
+            // post-fetch gate evaluation needs to see the value.
+            // Widening-only, so the #847 narrowing veto is untouched.
+            if (metadata && metadata.isRelation(segments.join('.')) === true) {
+                descend(root, segments).whole = true;
+                continue;
+            }
+
             const last = segments.pop() as string;
 
             const node = descend(root, segments);

--- a/packages/adapter-drizzle/src/adapter/fields.ts
+++ b/packages/adapter-drizzle/src/adapter/fields.ts
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition, IFields } from '@rapiq/core';
+import {
+    FieldOperator,
+    ITSELF,
+    isFilter,
+    isFilters,
+} from '@rapiq/core';
+
+type SelectionNode = {
+    /**
+     * Scalar field names picked at this level.
+     */
+    picks : Set<string>,
+
+    children : Map<string, SelectionNode>,
+
+    /**
+     * Gate-operand columns (`Field.condition` reads, rapiq#830) forced
+     * into the selection at this level. Selected like picks, but never
+     * counted for the include-narrowing veto (#847): behind a whole
+     * relation the hydration covers them anyway.
+     */
+    operands : Set<string>,
+
+    /**
+     * Explicitly requested through `relations`: hydrated as a whole
+     * record unless direct `<relation>.<field>` picks exist — those
+     * narrow it to the fieldset (#847), matching the
+     * `@rapiq/adapter-memory` projection contract.
+     */
+    whole : boolean,
+
+    /**
+     * A pick exists somewhere in this subtree, so the level is
+     * projected sparsely (`columns`) instead of wholly.
+     */
+    refined : boolean,
+};
+
+export type Selection = {
+    columns?: Record<string, boolean>,
+    with?: Record<string, any>,
+};
+
+function createNode() : SelectionNode {
+    return {
+        picks: new Set(),
+        children: new Map(),
+        operands: new Set(),
+        whole: false,
+        refined: false,
+    };
+}
+
+/**
+ * Collect the leaf fields a condition tree reads. An elemMatch leaf
+ * contributes its own field (the array column) and is never descended
+ * into: its interior operands are element-relative, not columns.
+ */
+function collectConditionFields(condition: ICondition, output: string[]) : void {
+    if (isFilters(condition)) {
+        for (const child of condition.value) {
+            collectConditionFields(child, output);
+        }
+
+        return;
+    }
+
+    if (isFilter(condition)) {
+        output.push(condition.field);
+    }
+}
+
+function descend(node: SelectionNode, segments: string[]) : SelectionNode {
+    let current = node;
+
+    for (const segment of segments) {
+        let child = current.children.get(segment);
+        if (!child) {
+            child = createNode();
+            current.children.set(segment, child);
+        }
+
+        current = child;
+    }
+
+    return current;
+}
+
+function buildColumns(node: SelectionNode) : Record<string, boolean> {
+    const columns : Record<string, boolean> = {};
+
+    node.picks.forEach((pick) => {
+        columns[pick] = true;
+    });
+
+    node.operands.forEach((operand) => {
+        columns[operand] = true;
+    });
+
+    return columns;
+}
+
+function materializeChildren(node: SelectionNode) : Record<string, any> {
+    const output : Record<string, any> = {};
+
+    node.children.forEach((child, name) => {
+        output[name] = materialize(child);
+    });
+
+    return output;
+}
+
+/**
+ * A pick of the property itself wins over a refinement of it:
+ * `fields: ['realm', 'realm.name']` hydrates the whole relation,
+ * matching the `@rapiq/adapter-memory` projection contract.
+ */
+function materialize(node: SelectionNode) : true | Record<string, any> {
+    const children = materializeChildren(node);
+    const hasChildren = Object.keys(children).length > 0;
+
+    // an explicitly included relation without direct picks is
+    // hydrated whole; deeper relations still have to be declared, and
+    // `with` alone keeps every scalar of the level alongside them.
+    // Direct picks narrow the include to the fieldset instead (#847).
+    if (node.whole && node.picks.size === 0) {
+        if (hasChildren) {
+            return { with: children };
+        }
+
+        return true;
+    }
+
+    if (node.picks.size > 0 || node.operands.size > 0 || hasChildren) {
+        // an empty `columns` object is deliberate: a level reached
+        // only to traverse deeper (or narrowed away entirely) keeps
+        // no scalar of its own, matching the sparse `select` the
+        // prisma adapter emits.
+        const output : Record<string, any> = { columns: buildColumns(node) };
+
+        if (hasChildren) {
+            output.with = children;
+        }
+
+        return output;
+    }
+
+    return true;
+}
+
+/**
+ * The `columns` / `with` fragment of the config object; empty when
+ * neither fields nor relations were requested.
+ *
+ * Unlike prisma's `select`/`include`, drizzle keeps scalar selection
+ * (`columns`) and relation hydration (`with`) in separate keys that
+ * compose at every level. Excluded fields are simply not projected,
+ * the resolution every other rapiq backend applies.
+ */
+export function buildSelection(fields: IFields, relationPaths: string[]) : Selection {
+    const root = createNode();
+
+    for (const field of fields.value) {
+        if (field.operator === FieldOperator.EXCLUDE) {
+            continue;
+        }
+
+        const segments = field.name.split('.');
+        const last = segments.pop() as string;
+
+        root.refined = true;
+
+        let current = root;
+        for (const segment of segments) {
+            let child = current.children.get(segment);
+            if (!child) {
+                child = createNode();
+                current.children.set(segment, child);
+            }
+
+            child.refined = true;
+            current = child;
+        }
+
+        current.picks.add(last);
+    }
+
+    // Force-project the leaf columns a field visibility gate reads
+    // (`Field.condition`, rapiq#830): the gate is enforced after the
+    // fetch against the rows this selection produces, and a missing
+    // operand would over-redact an eq-style gate and let a negated
+    // gate disclose. Operands ride as select-only entries — they never
+    // count as picks for the include-narrowing veto (#847), and a
+    // whole level covers them anyway.
+    for (const field of fields.value) {
+        if (!field.condition || field.operator === FieldOperator.EXCLUDE) {
+            continue;
+        }
+
+        // A gate is evaluated against the record its field is read
+        // from: a gate on `items.secret` has operands relative to the
+        // item record.
+        const prefix = field.name.split('.');
+        prefix.pop();
+
+        const operands : string[] = [];
+        collectConditionFields(field.condition, operands);
+
+        for (const operand of operands) {
+            // ITSELF addresses the record (or bound element) itself,
+            // never a projectable column.
+            if (operand === ITSELF) {
+                continue;
+            }
+
+            const segments = [...prefix, ...operand.split('.')];
+            const last = segments.pop() as string;
+
+            const node = descend(root, segments);
+            if (!node.picks.has(last)) {
+                node.operands.add(last);
+            }
+        }
+    }
+
+    for (const path of relationPaths) {
+        descend(root, path.split('.')).whole = true;
+    }
+
+    const children = materializeChildren(root);
+    const hasChildren = Object.keys(children).length > 0;
+
+    const output : Selection = {};
+
+    if (root.refined) {
+        // possibly `{}`: a fields parameter that picks only relation
+        // columns narrows the root to no scalars at all, exactly like
+        // the sparse root `select` of the prisma adapter. A root that
+        // was never refined projects whole, which covers any gate
+        // operands on it.
+        output.columns = buildColumns(root);
+    }
+
+    if (hasChildren) {
+        output.with = children;
+    }
+
+    return output;
+}

--- a/packages/adapter-drizzle/src/adapter/index.ts
+++ b/packages/adapter-drizzle/src/adapter/index.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './fields';
+export * from './merge';
+export * from './module';
+export * from './relations';
+export * from './sort';
+export * from './types';
+export * from './where';

--- a/packages/adapter-drizzle/src/adapter/merge.ts
+++ b/packages/adapter-drizzle/src/adapter/merge.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { FindManyConfig, Where } from './types';
+
+/**
+ * Merge two drizzle config objects, treating `override` as a
+ * NARROWING of `base`:
+ *
+ * - `where` conditions are conjoined (`AND`), never substituted, so
+ *   an application-owned tenant or authorization predicate survives,
+ * - an overriding `columns` replaces the baseline projection
+ *   (widening a caller-owned projection would expose columns the
+ *   application chose to withhold), while `with` entries JOIN the
+ *   baseline ones, the override winning per relation,
+ * - `orderBy`, `limit` and `offset` follow the override when present,
+ * - every other key (`extras`, ...) passes through, the override
+ *   winning on collisions.
+ */
+export function mergeConfig<T extends FindManyConfig = FindManyConfig>(
+    base: T,
+    override: FindManyConfig,
+) : T {
+    const output = { ...base } as FindManyConfig;
+
+    const {
+        where,
+        columns,
+        with: withEntries,
+        orderBy,
+        limit,
+        offset,
+        ...rest
+    } = override;
+
+    Object.assign(output, rest);
+
+    if (where) {
+        output.where = base.where ?
+            { AND: [base.where, where] } as Where :
+            where;
+    }
+
+    if (columns) {
+        output.columns = columns;
+    }
+
+    if (withEntries) {
+        output.with = base.with ?
+            { ...base.with, ...withEntries } :
+            withEntries;
+    }
+
+    if (orderBy) {
+        output.orderBy = orderBy;
+    }
+
+    if (typeof limit !== 'undefined') {
+        output.limit = limit;
+    }
+
+    if (typeof offset !== 'undefined') {
+        output.offset = offset;
+    }
+
+    return output as T;
+}

--- a/packages/adapter-drizzle/src/adapter/merge.ts
+++ b/packages/adapter-drizzle/src/adapter/merge.ts
@@ -8,14 +8,15 @@
 import type { FindManyConfig, Where } from './types';
 
 /**
- * Merge two drizzle config objects, treating `override` as a
- * NARROWING of `base`:
+ * Merge two drizzle config objects: `base` is the caller-owned
+ * baseline, `override` the query-derived config, and the override
+ * wins wherever the query produced a value:
  *
  * - `where` conditions are conjoined (`AND`), never substituted, so
  *   an application-owned tenant or authorization predicate survives,
- * - an overriding `columns` replaces the baseline projection
- *   (widening a caller-owned projection would expose columns the
- *   application chose to withhold), while `with` entries JOIN the
+ * - a produced `columns` REPLACES the baseline projection: the
+ *   query's selection passed the schema allow-lists, and a baseline
+ *   default must not widen it back. Produced `with` entries JOIN the
  *   baseline ones, the override winning per relation,
  * - `orderBy`, `limit` and `offset` follow the override when present,
  * - every other key (`extras`, ...) passes through, the override

--- a/packages/adapter-drizzle/src/adapter/module.ts
+++ b/packages/adapter-drizzle/src/adapter/module.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IQuery, IQueryVisitor } from '@rapiq/core';
+import { resolveProviderOptions } from '../provider';
+import { buildSelection } from './fields';
+import { mergeConfig } from './merge';
+import { collectRelationPaths } from './relations';
+import { buildOrderBy } from './sort';
+import { WhereRenderer } from './where';
+import type {
+    DrizzleAdapterOptions,
+    DrizzleAdapterOutput,
+    ExecuteOptions,
+    FindManyConfig,
+} from './types';
+
+/**
+ * Serializes a parsed query into a drizzle relational-queries v2
+ * `findMany` config object.
+ *
+ * A pure serializer: `execute` maps a value to a value, holds no
+ * per-call state, and one instance is safely shared across requests.
+ * Queries compose BEFORE serialization (`mergeQueries`,
+ * `query.filters.and(...)` in `@rapiq/core`), which is why there is
+ * no accumulation API. Nothing from drizzle is imported; bind the
+ * concrete config type to keep the call site checked:
+ *
+ * ```typescript
+ * const adapter = new DrizzleAdapter({
+ *     provider: 'pg',
+ *     metadata: defineMetadata(datamodel, 'users'),
+ * });
+ *
+ * const { config, pagination } = adapter.execute(query);
+ * const users = await db.query.users.findMany(config);
+ * ```
+ */
+export class DrizzleAdapter<
+    CONFIG extends FindManyConfig = FindManyConfig,
+> implements IQueryVisitor<DrizzleAdapterOutput<CONFIG>> {
+    protected renderer : WhereRenderer;
+
+    protected options : DrizzleAdapterOptions;
+
+    constructor(options: DrizzleAdapterOptions) {
+        this.options = options;
+
+        this.renderer = new WhereRenderer(
+            options.metadata,
+            resolveProviderOptions(options.provider),
+        );
+    }
+
+    // -----------------------------------------------------------
+
+    execute(
+        query: IQuery,
+        options: ExecuteOptions<CONFIG> = {},
+    ) : DrizzleAdapterOutput<CONFIG> {
+        const base = options.base as FindManyConfig | undefined;
+
+        const filters = this.renderer.build(
+            query.filters,
+            options.filters || this.options.filters || {},
+        );
+
+        const produced : FindManyConfig = {};
+
+        if (!filters.impossible && filters.where) {
+            produced.where = filters.where;
+        }
+
+        Object.assign(
+            produced,
+            buildSelection(query.fields, collectRelationPaths(query.relations)),
+        );
+
+        const orderBy = buildOrderBy(query.sorts);
+        if (Object.keys(orderBy).length > 0) {
+            produced.orderBy = orderBy;
+        }
+
+        // a query without pagination leaves caller-owned limit/offset
+        // untouched. Nullish (not falsy) checks: an explicit 0 is a
+        // value, not absence.
+        const { limit, offset } = query.pagination;
+
+        if (typeof limit !== 'undefined') {
+            produced.limit = limit;
+        }
+
+        if (typeof offset !== 'undefined') {
+            produced.offset = offset;
+        }
+
+        const config = base ? mergeConfig(base, produced) : produced;
+
+        if (filters.impossible) {
+            // the filter object has no dialect-free `1 = 0` literal
+            // (an empty group is stripped, not falsified), so an
+            // impossible root is expressed through the config instead:
+            // `limit: 0` returns no rows on every dialect, and a
+            // caller-owned baseline cannot widen an unsatisfiable
+            // condition.
+            config.limit = 0;
+        }
+
+        return {
+            config: config as CONFIG,
+            pagination: { limit, offset },
+        };
+    }
+
+    visitQuery(expr: IQuery) : DrizzleAdapterOutput<CONFIG> {
+        return this.execute(expr);
+    }
+}
+
+// -----------------------------------------------------------
+
+/**
+ * One-shot convenience over {@link DrizzleAdapter}.
+ */
+export function buildDrizzleConfig<CONFIG extends FindManyConfig = FindManyConfig>(
+    query: IQuery,
+    options: DrizzleAdapterOptions & ExecuteOptions<CONFIG>,
+) : DrizzleAdapterOutput<CONFIG> {
+    return new DrizzleAdapter<CONFIG>(options).execute(query, options);
+}

--- a/packages/adapter-drizzle/src/adapter/module.ts
+++ b/packages/adapter-drizzle/src/adapter/module.ts
@@ -77,7 +77,11 @@ export class DrizzleAdapter<
 
         Object.assign(
             produced,
-            buildSelection(query.fields, collectRelationPaths(query.relations)),
+            buildSelection(
+                query.fields,
+                collectRelationPaths(query.relations),
+                this.options.metadata,
+            ),
         );
 
         const orderBy = buildOrderBy(query.sorts);

--- a/packages/adapter-drizzle/src/adapter/relations.ts
+++ b/packages/adapter-drizzle/src/adapter/relations.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IRelations } from '@rapiq/core';
+
+/**
+ * Canonical relation paths a query hydrates, parents included and
+ * deduplicated, e.g. `['items', 'items.realm']`.
+ *
+ * Unlike the SQL backends there are no join aliases to derive:
+ * drizzle addresses relations positionally through nested `with`
+ * entries, so paths are all the selection needs.
+ */
+export function collectRelationPaths(relations: IRelations) : string[] {
+    const output : string[] = [];
+
+    for (const relation of relations.value) {
+        const segments = relation.name.split('.');
+
+        for (let i = 0; i < segments.length; i++) {
+            const current = segments.slice(0, i + 1).join('.');
+
+            if (!output.includes(current)) {
+                output.push(current);
+            }
+        }
+    }
+
+    return output;
+}

--- a/packages/adapter-drizzle/src/adapter/sort.ts
+++ b/packages/adapter-drizzle/src/adapter/sort.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ISorts } from '@rapiq/core';
+import { AdapterError, SortDirection } from '@rapiq/core';
+
+/**
+ * The `orderBy` argument as a single object whose key order carries
+ * the sort priority (drizzle iterates the object's own insertion
+ * order).
+ *
+ * The relational API orders the root query by its own columns only:
+ * a dotted relation path fails typed instead of being emitted as an
+ * undocumented shape drizzle might silently ignore. Duplicate keys
+ * keep their first occurrence, mirroring the keyed collapse of the
+ * SQL adapters.
+ */
+export function buildOrderBy(sorts: ISorts) : Record<string, 'asc' | 'desc'> {
+    const output : Record<string, 'asc' | 'desc'> = {};
+
+    for (const sort of sorts.value) {
+        if (sort.name.includes('.')) {
+            throw AdapterError.featureUnsupported('sort:relation');
+        }
+
+        if (typeof output[sort.name] !== 'undefined') {
+            continue;
+        }
+
+        output[sort.name] = sort.operator === SortDirection.DESC ? 'desc' : 'asc';
+    }
+
+    return output;
+}

--- a/packages/adapter-drizzle/src/adapter/sort.ts
+++ b/packages/adapter-drizzle/src/adapter/sort.ts
@@ -19,12 +19,25 @@ import { AdapterError, SortDirection } from '@rapiq/core';
  * keep their first occurrence, mirroring the keyed collapse of the
  * SQL adapters.
  */
+/**
+ * JavaScript enumerates canonical integer-like keys FIRST, so a sort
+ * name like `2024` would silently jump ahead of every other key and
+ * reorder the priority the object form encodes.
+ */
+const INTEGER_NAME = /^(?:0|[1-9]\d*)$/;
+
 export function buildOrderBy(sorts: ISorts) : Record<string, 'asc' | 'desc'> {
     const output : Record<string, 'asc' | 'desc'> = {};
 
     for (const sort of sorts.value) {
         if (sort.name.includes('.')) {
             throw AdapterError.featureUnsupported('sort:relation');
+        }
+
+        if (INTEGER_NAME.test(sort.name)) {
+            // insertion order cannot carry the priority of an
+            // integer-like key; failing typed beats a silent reorder.
+            throw AdapterError.featureUnsupported('sort:numeric-name');
         }
 
         if (typeof output[sort.name] !== 'undefined') {

--- a/packages/adapter-drizzle/src/adapter/types.ts
+++ b/packages/adapter-drizzle/src/adapter/types.ts
@@ -87,8 +87,11 @@ export type DrizzleAdapterOutput<CONFIG extends FindManyConfig = FindManyConfig>
     config: CONFIG,
 
     /**
-     * The pagination actually applied, e.g. for the response meta
-     * block.
+     * The pagination applied from the query (schema-clamped), e.g.
+     * for the response meta block. Deliberately echoes the query
+     * alone, matching the other adapters: a baseline `limit`/`offset`
+     * and the impossible-root `limit: 0` cap are config concerns, not
+     * something a meta block should report.
      */
     pagination: {
         limit: number | undefined,

--- a/packages/adapter-drizzle/src/adapter/types.ts
+++ b/packages/adapter-drizzle/src/adapter/types.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IMetadata } from '../metadata';
+import type { Provider, ProviderOptions } from '../provider';
+
+/**
+ * A drizzle relational `where` filter object: an untyped record by
+ * construction, since the adapter emits plain objects and never
+ * imports drizzle's generated types.
+ */
+export type Where = Record<string, any>;
+
+/**
+ * The subset of a relational `findMany` config object rapiq
+ * populates. Assignable to `db.query.<table>.findMany(...)`'s
+ * argument; bind the concrete config type through
+ * {@link DrizzleAdapter}'s type parameter to keep the call site
+ * checked.
+ */
+export type FindManyConfig = {
+    where?: Where,
+    columns?: Record<string, boolean>,
+    with?: Record<string, any>,
+    orderBy?: Record<string, 'asc' | 'desc'>,
+    limit?: number,
+    offset?: number,
+};
+
+// -----------------------------------------------------------
+
+export type FiltersAdapterOptions = {
+    /**
+     * Field keys whose equality comparisons (eq/ne/in/nin) stay
+     * case-sensitive instead of the case-insensitive default.
+     * Typically forwarded from a schema's `filters.caseSensitive`.
+     */
+    caseSensitive?: string[] | boolean,
+};
+
+export type DrizzleAdapterOptions = {
+    /**
+     * Dialect the emitted config will execute against, or an explicit
+     * capability preset. Decides whether `ilike` may be emitted and
+     * whether LIKE operands can be escaped; a wrong answer breaks
+     * case-insensitive filters, so there is no default to guess.
+     */
+    provider: `${Provider}` | ProviderOptions,
+
+    /**
+     * Table metadata: which paths are relations, which of those are
+     * to-many, which columns can hold null and which hold strings.
+     * Build it with `defineMetadata()`.
+     *
+     * Required: the adapter is bound to one table anyway, and every
+     * one of these facts changes what a correct drizzle filter looks
+     * like. Guessing them produces wrong result sets, not graceful
+     * degradation.
+     */
+    metadata: IMetadata,
+
+    filters?: FiltersAdapterOptions,
+};
+
+// -----------------------------------------------------------
+
+export type ExecuteOptions<CONFIG extends FindManyConfig = FindManyConfig> = {
+    /**
+     * Application-owned baseline config, e.g. a tenant or
+     * authorization scope. The rapiq `where` is **conjoined** with
+     * `base.where`, never substituted for it; every other baseline
+     * key survives unless the query produces one itself.
+     */
+    base?: CONFIG,
+
+    filters?: FiltersAdapterOptions,
+};
+
+export type DrizzleAdapterOutput<CONFIG extends FindManyConfig = FindManyConfig> = {
+    /**
+     * The config object to hand to `db.query.<table>.findMany()`.
+     */
+    config: CONFIG,
+
+    /**
+     * The pagination actually applied, e.g. for the response meta
+     * block.
+     */
+    pagination: {
+        limit: number | undefined,
+        offset: number | undefined,
+    },
+};

--- a/packages/adapter-drizzle/src/adapter/where.ts
+++ b/packages/adapter-drizzle/src/adapter/where.ts
@@ -1,0 +1,900 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    ComparePlan,
+    ConditionPlan,
+    ElemMatchPlan,
+    ICondition,
+    MatchPlan,
+    NullCheckPlan,
+    OneOfPlan,
+} from '@rapiq/core';
+import {
+    AdapterError,
+    ITSELF,
+    distributeNegation,
+    planCondition,
+} from '@rapiq/core';
+import type { IMetadata } from '../metadata';
+import type { ProviderOptions } from '../provider';
+import type { FiltersAdapterOptions, Where } from './types';
+
+/**
+ * A folded verdict short-circuits rendering: `in([])` matches
+ * nothing, `nin([])` matches everything. Constants never reach the
+ * emitted object; an impossible root is reported through the
+ * `impossible` flag instead.
+ */
+type Result = Where | boolean;
+
+type Context = {
+    metadata: IMetadata,
+    provider: ProviderOptions,
+
+    /**
+     * Absolute path prefix of the current quantifier scope, for
+     * metadata lookups.
+     */
+    base: string,
+
+    /**
+     * Leaf fields inside a factored scope still carry their original
+     * dotted path; this prefix is removed before rendering.
+     */
+    strip: string,
+};
+
+type Atom = {
+    plan: ConditionPlan,
+    key: string,
+};
+
+/**
+ * Ceiling on the number of conjuncts a mixed tree may expand to while
+ * factoring quantifiers. Wire filters are tiny; a tree that exceeds
+ * this is adversarial, and failing typed beats a silent semantic
+ * downgrade.
+ */
+const EXPANSION_LIMIT = 64;
+
+const LIKE_SPECIAL = /[\\%_]/g;
+
+const LIKE_WILDCARD = /[%_]/;
+
+/**
+ * Escape `%`, `_` and the escape character itself so a LIKE operand
+ * matches literally. postgres and mysql treat a backslash as the
+ * default escape character; the object filter accepts no `ESCAPE`
+ * clause, so dialects without that default (sqlite) cannot escape at
+ * all and fail typed on wildcard-carrying operands instead.
+ */
+function escapeLike(text: string) : string {
+    return text.replace(LIKE_SPECIAL, (match) => `\\${match}`);
+}
+
+// -----------------------------------------------------------
+
+function join(base: string, path: string) : string {
+    if (!base) {
+        return path;
+    }
+
+    return path ? `${base}.${path}` : base;
+}
+
+function andCombine(results: Result[]) : Result {
+    const parts : Where[] = [];
+
+    for (const result of results) {
+        if (result === false) {
+            return false;
+        }
+
+        if (result !== true) {
+            parts.push(result);
+        }
+    }
+
+    if (parts.length === 0) {
+        return true;
+    }
+
+    if (parts.length === 1) {
+        return parts[0] as Where;
+    }
+
+    return { AND: parts };
+}
+
+function orCombine(results: Result[]) : Result {
+    const parts : Where[] = [];
+
+    for (const result of results) {
+        if (result === true) {
+            return true;
+        }
+
+        if (result !== false) {
+            parts.push(result);
+        }
+    }
+
+    if (parts.length === 0) {
+        return false;
+    }
+
+    if (parts.length === 1) {
+        return parts[0] as Where;
+    }
+
+    return { OR: parts };
+}
+
+// -----------------------------------------------------------
+
+/**
+ * Renders a condition tree into a drizzle relational `where` object,
+ * preserving the cross-backend semantics contract:
+ *
+ * - negation is eliminated up front by the core `distributeNegation`
+ *   transform, so this renderer only ever sees leaves in their final
+ *   (possibly complemented) form; drizzle's three-valued `NOT` is
+ *   never applied to a user condition (the one emitted `NOT` negates
+ *   a relation presence test, which is two-valued by construction),
+ * - relation traversal quantifies existentially with the quantifier
+ *   outermost, exactly like a left join evaluated per row
+ *   (`@rapiq/adapter-sql`) or a binding enumeration
+ *   (`@rapiq/adapter-memory`),
+ * - conditions sharing a to-many path within a conjunction bind to
+ *   the SAME element: they are factored into ONE relation-filter
+ *   object, drizzle's single existential scope (mixed trees are
+ *   expanded to reach that form; `∃` distributes over OR, so
+ *   disjunctions need no factoring),
+ * - an empty collection contributes exactly one all-null binding
+ *   (the left join's null row): every quantifier gains a
+ *   `NOT: { relation: true }` absence arm precisely when its interior
+ *   holds at that binding, and every to-one hop an absence arm under
+ *   the same rule.
+ */
+export class WhereRenderer {
+    protected metadata : IMetadata;
+
+    protected provider : ProviderOptions;
+
+    constructor(metadata: IMetadata, provider: ProviderOptions) {
+        this.metadata = metadata;
+        this.provider = provider;
+    }
+
+    // -----------------------------------------------------------
+
+    build(condition: ICondition, options: FiltersAdapterOptions = {}) : {
+        where?: Where,
+        impossible: boolean,
+    } {
+        const plan = planCondition(condition, { caseSensitive: options.caseSensitive });
+        if (!plan) {
+            return { impossible: false };
+        }
+
+        const result = this.render(distributeNegation(plan), {
+            metadata: this.metadata,
+            provider: this.provider,
+            base: '',
+            strip: '',
+        });
+
+        if (result === true) {
+            return { impossible: false };
+        }
+
+        if (result === false) {
+            return { impossible: true };
+        }
+
+        return { where: result, impossible: false };
+    }
+
+    // -----------------------------------------------------------
+
+    protected render(plan: ConditionPlan, ctx: Context) : Result {
+        switch (plan.kind) {
+            case 'constant': {
+                return plan.verdict;
+            }
+            case 'compound': {
+                if (plan.negated) {
+                    // a residual wrapper only ever encloses kinds
+                    // without a complement form; rendering the child
+                    // raises the matching typed error.
+                    return this.render(plan.children[0] as ConditionPlan, ctx);
+                }
+
+                if (plan.operator === 'or') {
+                    // ∃ distributes over OR, so disjuncts never share
+                    // a binding and render independently.
+                    return orCombine(plan.children.map((child) => this.render(child, ctx)));
+                }
+
+                return this.renderAnd(plan.children, ctx);
+            }
+            case 'elem-match': {
+                return this.renderElemMatch(plan, ctx);
+            }
+            default: {
+                return this.renderLeaf(plan, ctx);
+            }
+        }
+    }
+
+    /**
+     * A conjunction is where bindings are shared: conditions on one
+     * to-many path must land in one relation-filter scope. Children
+     * mixing quantifier keys are expanded to disjunctive form first,
+     * so each conjunct groups cleanly.
+     */
+    protected renderAnd(children: ConditionPlan[], ctx: Context) : Result {
+        const flattened : ConditionPlan[] = [];
+        for (const child of children) {
+            if (child.kind === 'compound' && !child.negated && child.operator === 'and') {
+                flattened.push(...child.children);
+            } else {
+                flattened.push(child);
+            }
+        }
+
+        const pure : Atom[] = [];
+        const mixed : ConditionPlan[] = [];
+
+        for (const child of flattened) {
+            const keys = this.keysOf(child, ctx);
+
+            if (keys.size <= 1) {
+                pure.push({ plan: child, key: keys.values().next().value ?? '' });
+            } else {
+                mixed.push(child);
+            }
+        }
+
+        if (mixed.length === 0) {
+            return this.renderConjunct(pure, ctx);
+        }
+
+        // a mixed child shares a binding with a sibling only through a
+        // non-root key that occurs elsewhere too; otherwise it factors
+        // internally on its own.
+        const shared = mixed.some((child) => {
+            const keys = this.keysOf(child, ctx);
+
+            for (const key of keys) {
+                if (!key) {
+                    continue;
+                }
+
+                const elsewhere = pure.some((atom) => atom.key === key) ||
+                    mixed.some((other) => other !== child && this.keysOf(other, ctx).has(key));
+
+                if (elsewhere) {
+                    return true;
+                }
+            }
+
+            return false;
+        });
+
+        if (!shared) {
+            return andCombine([
+                this.renderConjunct(pure, ctx),
+                ...mixed.map((child) => this.render(child, ctx)),
+            ]);
+        }
+
+        const conjuncts = this.expand(flattened, ctx);
+
+        return orCombine(conjuncts.map((conjunct) => this.renderConjunct(conjunct, ctx)));
+    }
+
+    /**
+     * Disjunctive expansion of a conjunction whose children cross
+     * quantifier scopes: the standard identity
+     * `a ∧ (b ∨ c) = (a ∧ b) ∨ (a ∧ c)`, applied only as far as
+     * needed: subtrees confined to a single key stay opaque atoms.
+     */
+    protected expand(children: ConditionPlan[], ctx: Context) : Atom[][] {
+        let conjuncts : Atom[][] = [[]];
+
+        for (const child of children) {
+            const branches = this.branchesOf(child, ctx);
+
+            const next : Atom[][] = [];
+            for (const conjunct of conjuncts) {
+                for (const branch of branches) {
+                    next.push([...conjunct, ...branch]);
+                }
+            }
+
+            if (next.length > EXPANSION_LIMIT) {
+                throw AdapterError.featureUnsupported('filters:complexity');
+            }
+
+            conjuncts = next;
+        }
+
+        return conjuncts;
+    }
+
+    protected branchesOf(plan: ConditionPlan, ctx: Context) : Atom[][] {
+        const keys = this.keysOf(plan, ctx);
+
+        if (keys.size <= 1) {
+            return [[{ plan, key: keys.values().next().value ?? '' }]];
+        }
+
+        // only compounds can mix keys
+        const compound = plan as Extract<ConditionPlan, { kind: 'compound' }>;
+
+        if (compound.operator === 'or') {
+            const output : Atom[][] = [];
+            for (const child of compound.children) {
+                output.push(...this.branchesOf(child, ctx));
+            }
+
+            return output;
+        }
+
+        let conjuncts : Atom[][] = [[]];
+        for (const child of compound.children) {
+            const branches = this.branchesOf(child, ctx);
+
+            const next : Atom[][] = [];
+            for (const conjunct of conjuncts) {
+                for (const branch of branches) {
+                    next.push([...conjunct, ...branch]);
+                }
+            }
+
+            if (next.length > EXPANSION_LIMIT) {
+                throw AdapterError.featureUnsupported('filters:complexity');
+            }
+
+            conjuncts = next;
+        }
+
+        return conjuncts;
+    }
+
+    protected renderConjunct(atoms: Atom[], ctx: Context) : Result {
+        const parts : Result[] = [];
+        const groups = new Map<string, ConditionPlan[]>();
+
+        for (const atom of atoms) {
+            if (!atom.key) {
+                parts.push(this.render(atom.plan, ctx));
+                continue;
+            }
+
+            const group = groups.get(atom.key) ?? [];
+            group.push(atom.plan);
+            groups.set(atom.key, group);
+        }
+
+        groups.forEach((plans, key) => {
+            parts.push(this.factor(key, plans, ctx));
+        });
+
+        return andCombine(parts);
+    }
+
+    /**
+     * One relation-filter object for every plan sharing the
+     * quantifier path: drizzle evaluates all conditions of the object
+     * against the same related record, which is the same-element
+     * binding of a left join, where each join row is tested against
+     * ALL conditions at once.
+     */
+    protected factor(path: string, plans: ConditionPlan[], ctx: Context) : Result {
+        const segments = path.split('.');
+        const name = segments.pop() as string;
+
+        const scoped : Context = {
+            ...ctx,
+            base: join(ctx.base, path),
+            strip: `${ctx.strip}${path}.`,
+        };
+
+        const interior = andCombine(plans.map((plan) => this.render(plan, scoped)));
+        const matchesNull = plans.every((plan) => this.evalAtNull(plan));
+
+        let node : Result;
+        if (interior === false) {
+            node = false;
+        } else {
+            node = { [name]: interior === true ? true : interior };
+        }
+
+        if (matchesNull) {
+            // the empty collection: its left join contributes exactly
+            // one all-null row, and the interior holds there.
+            node = orCombine([node, { NOT: { [name]: true } }]);
+        }
+
+        return this.wrapToOne(segments, node, matchesNull, ctx);
+    }
+
+    /**
+     * Wrap leading to-one segments, adding the absence arm when the
+     * interior holds at a null binding: an absent relation is the
+     * same all-null row a left join produces.
+     */
+    protected wrapToOne(
+        segments: string[],
+        node: Result,
+        matchesNull: boolean,
+        _ctx: Context,
+    ) : Result {
+        let current = node;
+
+        for (let i = segments.length - 1; i >= 0; i--) {
+            const name = segments[i] as string;
+
+            let branch : Result;
+            if (current === false) {
+                branch = false;
+            } else {
+                branch = { [name]: current === true ? true : current };
+            }
+
+            if (matchesNull) {
+                current = orCombine([branch, { NOT: { [name]: true } }]);
+            } else {
+                current = branch;
+            }
+        }
+
+        return current;
+    }
+
+    // -----------------------------------------------------------
+
+    protected renderElemMatch(plan: ElemMatchPlan, ctx: Context) : Result {
+        const relative = this.stripField(plan.field, ctx);
+        const absolute = join(ctx.base, relative);
+
+        const segments = relative.split('.');
+        const name = segments.pop() as string;
+
+        // walk any to-many prefix through the ordinary factoring path
+        const key = this.keyOfPath(relative, ctx);
+        if (key && key !== relative) {
+            return this.factor(key, [plan], ctx);
+        }
+
+        // elemMatch quantifies over the records of a to-many
+        // relation; a to-one relation has no elements, and drizzle
+        // offers no per-element filter for scalar arrays.
+        if (this.metadata.isRelation(absolute) !== true || this.metadata.isToMany(absolute) === false) {
+            throw AdapterError.featureUnsupported('filters:elemMatch');
+        }
+
+        const scoped : Context = {
+            ...ctx,
+            base: absolute,
+            strip: '',
+        };
+
+        const interior = this.render(plan.condition, scoped);
+        const matchesNull = this.evalAtNull(plan);
+
+        let node : Result;
+        if (interior === false) {
+            node = false;
+        } else {
+            node = { [name]: interior === true ? true : interior };
+        }
+
+        if (matchesNull) {
+            node = orCombine([node, { NOT: { [name]: true } }]);
+        }
+
+        return this.wrapToOne(segments, node, matchesNull, ctx);
+    }
+
+    protected renderLeaf(plan: ConditionPlan, ctx: Context) : Result {
+        const leaf = plan as Exclude<ConditionPlan, { kind: 'compound' | 'constant' | 'elem-match' }>;
+        const relative = this.stripField(leaf.field, ctx);
+        const absolute = join(ctx.base, relative);
+
+        // a null check on the relation itself addresses the value as
+        // a whole, not its elements.
+        if (leaf.kind === 'null-check' && this.metadata.isRelation(absolute)) {
+            if (this.metadata.isToMany(absolute)) {
+                // a collection is always present: possibly empty,
+                // never absent, matching @rapiq/adapter-memory.
+                return leaf.negated;
+            }
+
+            const present = this.presence(relative);
+
+            return leaf.negated ? present : { NOT: present as Where };
+        }
+
+        const key = this.keyOfPath(relative, ctx);
+        if (key) {
+            return this.factor(key, [leaf], ctx);
+        }
+
+        const segments = relative.split('.');
+        const name = segments.pop() as string;
+
+        if (name === ITSELF) {
+            // the bound element itself is not a column; drizzle has
+            // no scalar-array element filter to address it with.
+            throw AdapterError.featureUnsupported('filters:itself');
+        }
+
+        return this.wrapToOne(
+            segments,
+            this.renderLiteral(leaf, name, absolute),
+            this.evalAtNull(leaf),
+            ctx,
+        );
+    }
+
+    /**
+     * "The relation path exists": every hop as a plain presence test
+     * (`{ relation: true }`), two-valued by construction and
+     * therefore safe under `NOT`.
+     */
+    protected presence(path: string) : Result {
+        const segments = path.split('.');
+
+        let node : Result = true;
+
+        for (let i = segments.length - 1; i >= 0; i--) {
+            const name = segments[i] as string;
+
+            node = { [name]: node === true ? true : node };
+        }
+
+        return node;
+    }
+
+    // -----------------------------------------------------------
+
+    protected renderLiteral(
+        plan: Exclude<ConditionPlan, { kind: 'compound' | 'constant' | 'elem-match' }>,
+        name: string,
+        absolute: string,
+    ) : Result {
+        switch (plan.kind) {
+            case 'null-check': {
+                return this.renderNullCheck(plan, name, absolute);
+            }
+            case 'compare': {
+                return this.renderCompare(plan, name, absolute);
+            }
+            case 'one-of': {
+                return this.renderOneOf(plan, name, absolute);
+            }
+            case 'match': {
+                return this.renderMatch(plan, name, absolute);
+            }
+            default: {
+                // mod, size: no drizzle filter operator exists.
+                throw AdapterError.featureUnsupported(`filters:${plan.kind}`);
+            }
+        }
+    }
+
+    protected renderNullCheck(plan: NullCheckPlan, name: string, absolute: string) : Result {
+        // a column that cannot hold null decides the check.
+        if (this.metadata.isNullable(absolute) === false) {
+            return plan.negated;
+        }
+
+        return plan.negated ?
+            { [name]: { isNotNull: true } } :
+            { [name]: { isNull: true } };
+    }
+
+    protected renderCompare(plan: ComparePlan, name: string, absolute: string) : Result {
+        if (plan.op !== 'eq') {
+            // ordering never carries negation after distribution: its
+            // complement became the dual operator or a null check.
+            return { [name]: { [plan.op]: plan.value } };
+        }
+
+        // an insensitive equality lowers to ILIKE with a fully
+        // escaped operand: exact comparison, no wildcard semantics
+        // (unlike prisma, the operand is built here, so no veto is
+        // needed).
+        const fold = this.foldable(absolute, plan.caseFold) && typeof plan.value === 'string';
+
+        if (plan.negated) {
+            const negative = fold ?
+                { [name]: { notIlike: escapeLike(plan.value as string) } } :
+                { [name]: { ne: plan.value } };
+
+            return this.orNull(name, negative, absolute);
+        }
+
+        return fold ?
+            { [name]: { ilike: escapeLike(plan.value as string) } } :
+            { [name]: { eq: plan.value } };
+    }
+
+    /**
+     * The in/nin four-case contract: a null member also matches the
+     * absence of a value, and the negated form is the exact
+     * complement; drizzle's `in`/`notIn` accept no null member and
+     * skip null rows on their own.
+     */
+    protected renderOneOf(plan: OneOfPlan, name: string, absolute: string) : Result {
+        const fold = this.foldable(absolute, plan.caseFold) &&
+            plan.values.some((value) => typeof value === 'string');
+
+        let positive : Where;
+        let negative : Where;
+
+        if (fold) {
+            // no ILIKE-capable `in` exists: string members become
+            // individual (escaped, wildcard-free) ILIKE arms, other
+            // members keep the exact membership test.
+            const strings : string[] = [];
+            const others : unknown[] = [];
+
+            for (const value of plan.values) {
+                if (typeof value === 'string') {
+                    strings.push(value);
+                } else {
+                    others.push(value);
+                }
+            }
+
+            const positives : Where[] = strings.map(
+                (value) => ({ [name]: { ilike: escapeLike(value) } }),
+            );
+            const negatives : Where[] = strings.map(
+                (value) => ({ [name]: { notIlike: escapeLike(value) } }),
+            );
+
+            if (others.length > 0) {
+                positives.push({ [name]: { in: others } });
+                negatives.push({ [name]: { notIn: others } });
+            }
+
+            positive = orCombine(positives) as Where;
+            negative = andCombine(negatives) as Where;
+        } else {
+            positive = { [name]: { in: plan.values } };
+            negative = { [name]: { notIn: plan.values } };
+        }
+
+        if (plan.includesNull) {
+            if (plan.negated) {
+                return this.andNotNull(name, negative, absolute);
+            }
+
+            if (this.metadata.isNullable(absolute) === false) {
+                // the null member is dead on a required column.
+                return positive;
+            }
+
+            return { OR: [positive, { [name]: { isNull: true } }] };
+        }
+
+        if (plan.negated) {
+            return this.orNull(name, negative, absolute);
+        }
+
+        return positive;
+    }
+
+    protected renderMatch(plan: MatchPlan, name: string, absolute: string) : Result {
+        if (plan.pattern.mode === 'regex') {
+            // the relational filter object exposes no regular
+            // expression operator; the anchored operators map onto
+            // LIKE patterns instead.
+            throw AdapterError.featureUnsupported('filters:regex');
+        }
+
+        const pattern = this.likePattern(plan.pattern.mode, plan.pattern.text);
+        const fold = this.foldable(absolute, plan.ignoreCase);
+
+        if (plan.negated) {
+            const operator = fold ? 'notIlike' : 'notLike';
+
+            return this.orNull(name, { [name]: { [operator]: pattern } }, absolute);
+        }
+
+        const operator = fold ? 'ilike' : 'like';
+
+        return { [name]: { [operator]: pattern } };
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * Whether the plan holds at the all-null binding an empty
+     * collection (or absent to-one relation) contributes; decides the
+     * absence arms. Deliberately independent of column nullability: a
+     * left join produces null for non-nullable columns too.
+     */
+    protected evalAtNull(plan: ConditionPlan) : boolean {
+        switch (plan.kind) {
+            case 'constant': {
+                return plan.verdict;
+            }
+            case 'compound': {
+                if (plan.negated) {
+                    return false;
+                }
+
+                if (plan.operator === 'or') {
+                    return plan.children.some((child) => this.evalAtNull(child));
+                }
+
+                return plan.children.every((child) => this.evalAtNull(child));
+            }
+            case 'null-check': {
+                return !plan.negated;
+            }
+            case 'compare': {
+                return plan.op === 'eq' && plan.negated;
+            }
+            case 'one-of': {
+                return plan.negated ? !plan.includesNull : plan.includesNull;
+            }
+            case 'match': {
+                return plan.negated;
+            }
+            case 'elem-match': {
+                // a null collection contributes one null binding of
+                // its own, matching @rapiq/adapter-memory.
+                return this.evalAtNull(plan.condition);
+            }
+            default: {
+                return false;
+            }
+        }
+    }
+
+    /**
+     * Quantifier key of a leaf path, the prefix up to and including
+     * the first to-many segment, or the empty string for paths that
+     * traverse none. Leaves sharing a key share a binding.
+     */
+    protected keyOfPath(relative: string, ctx: Context) : string {
+        const segments = relative.split('.');
+
+        // the final segment is the addressed value, not a hop:
+        // except when the leaf addresses through it (dotted).
+        for (let i = 0; i < segments.length - 1; i++) {
+            const prefix = segments.slice(0, i + 1).join('.');
+
+            if (this.metadata.isToMany(join(ctx.base, prefix))) {
+                return prefix;
+            }
+        }
+
+        return '';
+    }
+
+    protected keysOf(plan: ConditionPlan, ctx: Context) : Set<string> {
+        switch (plan.kind) {
+            case 'compound': {
+                const output = new Set<string>();
+
+                for (const child of plan.children) {
+                    this.keysOf(child, ctx).forEach((key) => output.add(key));
+                }
+
+                return output;
+            }
+            case 'constant': {
+                return new Set();
+            }
+            case 'elem-match': {
+                // an elemMatch opens its own quantifier scope and
+                // never shares a binding, so it behaves like a root
+                // atom unless its own path traverses a to-many first.
+                const key = this.keyOfPath(this.stripField(plan.field, ctx), ctx);
+
+                return new Set([key && key !== this.stripField(plan.field, ctx) ? key : '']);
+            }
+            default: {
+                const leaf = plan as Extract<ConditionPlan, { field: string }>;
+
+                if (
+                    plan.kind === 'null-check' &&
+                    this.metadata.isRelation(join(ctx.base, this.stripField(leaf.field, ctx)))
+                ) {
+                    // addresses the relation value itself, no binding
+                    return new Set(['']);
+                }
+
+                return new Set([this.keyOfPath(this.stripField(leaf.field, ctx), ctx)]);
+            }
+        }
+    }
+
+    protected stripField(field: string, ctx: Context) : string {
+        if (ctx.strip && field.startsWith(ctx.strip)) {
+            return field.slice(ctx.strip.length);
+        }
+
+        return field;
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * The case-fold policy verdict from the core lowering, narrowed
+     * by the capability vetoes: the dialect must render `ILIKE` and
+     * the column must hold strings.
+     */
+    protected foldable(absolute: string, caseFold: boolean) : boolean {
+        if (!caseFold || !this.provider.caseInsensitiveLike) {
+            return false;
+        }
+
+        return this.metadata.isString(absolute) !== false;
+    }
+
+    /**
+     * The anchored-operator wildcard pattern. Dialects without a
+     * default LIKE escape character (sqlite) cannot match a literal
+     * `%`/`_`: typed failure instead of a silently widened match.
+     */
+    protected likePattern(mode: 'starts' | 'ends' | 'contains', text: string) : string {
+        let body : string;
+
+        if (this.provider.likeEscape) {
+            body = escapeLike(text);
+        } else {
+            if (LIKE_WILDCARD.test(text)) {
+                throw AdapterError.featureUnsupported('filters:like-wildcard');
+            }
+
+            body = text;
+        }
+
+        switch (mode) {
+            case 'starts': {
+                return `${body}%`;
+            }
+            case 'ends': {
+                return `%${body}`;
+            }
+            default: {
+                return `%${body}%`;
+            }
+        }
+    }
+
+    /**
+     * The null arm that makes a negated leaf the exact complement of
+     * its positive twin, dropped when the column provably never holds
+     * null.
+     */
+    protected orNull(name: string, where: Where, absolute: string) : Where {
+        if (this.metadata.isNullable(absolute) === false) {
+            return where;
+        }
+
+        return { OR: [where, { [name]: { isNull: true } }] };
+    }
+
+    protected andNotNull(name: string, where: Where, absolute: string) : Where {
+        if (this.metadata.isNullable(absolute) === false) {
+            return where;
+        }
+
+        return { AND: [where, { [name]: { isNotNull: true } }] };
+    }
+}

--- a/packages/adapter-drizzle/src/adapter/where.ts
+++ b/packages/adapter-drizzle/src/adapter/where.ts
@@ -211,8 +211,17 @@ export class WhereRenderer {
                 if (plan.negated) {
                     // a residual wrapper only ever encloses kinds
                     // without a complement form; rendering the child
-                    // raises the matching typed error.
-                    return this.render(plan.children[0] as ConditionPlan, ctx);
+                    // raises the matching typed error. Any other kind
+                    // here means the distribution invariant broke:
+                    // failing typed beats silently emitting the
+                    // positive (inverted) form.
+                    const child = plan.children[0] as ConditionPlan;
+
+                    if (child.kind !== 'mod' && child.kind !== 'size') {
+                        throw AdapterError.featureUnsupported('filters:negation');
+                    }
+
+                    return this.render(child, ctx);
                 }
 
                 if (plan.operator === 'or') {
@@ -605,7 +614,13 @@ export class WhereRenderer {
     protected renderCompare(plan: ComparePlan, name: string, absolute: string) : Result {
         if (plan.op !== 'eq') {
             // ordering never carries negation after distribution: its
-            // complement became the dual operator or a null check.
+            // complement became the dual operator or a null check. An
+            // unnoticed break of that invariant must fail typed, not
+            // emit the positive (inverted) form.
+            if (plan.negated) {
+                throw AdapterError.featureUnsupported('filters:negation');
+            }
+
             return { [name]: { [plan.op]: plan.value } };
         }
 

--- a/packages/adapter-drizzle/src/index.ts
+++ b/packages/adapter-drizzle/src/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './adapter';
+export * from './metadata';
+export * from './provider';

--- a/packages/adapter-drizzle/src/metadata/index.ts
+++ b/packages/adapter-drizzle/src/metadata/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';
+export * from './types';

--- a/packages/adapter-drizzle/src/metadata/module.ts
+++ b/packages/adapter-drizzle/src/metadata/module.ts
@@ -102,15 +102,23 @@ export class Metadata implements IMetadata {
                 return undefined;
             }
 
+            // own-property lookups: the segment originates from a
+            // wire filter key, and an inherited name (`constructor`,
+            // `toString`, ...) must answer "unknown", not resolve to
+            // an Object.prototype member.
             const segment = segments[i] as string;
-            const relation = table.relations?.[segment];
+            const relation = table.relations && Object.hasOwn(table.relations, segment) ?
+                table.relations[segment] :
+                undefined;
 
             if (i === segments.length - 1) {
                 if (relation) {
                     return { kind: 'relation', relation };
                 }
 
-                const column = table.columns?.[segment];
+                const column = table.columns && Object.hasOwn(table.columns, segment) ?
+                    table.columns[segment] :
+                    undefined;
                 if (typeof column === 'undefined') {
                     return undefined;
                 }

--- a/packages/adapter-drizzle/src/metadata/module.ts
+++ b/packages/adapter-drizzle/src/metadata/module.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError, ErrorCode } from '@rapiq/core';
+import type {
+    Datamodel,
+    DatamodelColumn,
+    DatamodelRelation,
+    DatamodelTable,
+    IMetadata,
+} from './types';
+
+const STRING_TYPE = 'string';
+
+type Resolved =    | { kind: 'column', column: DatamodelColumn } |
+    { kind: 'relation', relation: DatamodelRelation };
+
+/**
+ * Answers the adapter's metadata questions from a hand-written
+ * datamodel by walking dotted paths segment by segment. Unknown
+ * segments answer `undefined`, never a guess.
+ */
+export class Metadata implements IMetadata {
+    protected tables : Datamodel;
+
+    protected root : string;
+
+    constructor(datamodel: Datamodel, table: string) {
+        this.tables = datamodel;
+        this.root = table;
+
+        // a misspelled root would answer "unknown" to every question
+        // and silently degrade the adapter to its defaults.
+        if (!datamodel[table]) {
+            throw new AdapterError({
+                message: `The table "${table}" is not part of the datamodel.`,
+                code: ErrorCode.SCHEMA_UNRESOLVABLE,
+            });
+        }
+    }
+
+    // -----------------------------------------------------------
+
+    isRelation(path: string) : boolean | undefined {
+        const resolved = this.resolve(path);
+        if (!resolved) {
+            return undefined;
+        }
+
+        return resolved.kind === 'relation';
+    }
+
+    isToMany(path: string) : boolean | undefined {
+        const resolved = this.resolve(path);
+        if (!resolved || resolved.kind !== 'relation') {
+            return undefined;
+        }
+
+        return resolved.relation.many;
+    }
+
+    isString(path: string) : boolean | undefined {
+        const resolved = this.resolve(path);
+        if (!resolved || resolved.kind !== 'column') {
+            return undefined;
+        }
+
+        if (typeof resolved.column.dataType === 'undefined') {
+            return undefined;
+        }
+
+        return resolved.column.dataType === STRING_TYPE;
+    }
+
+    isNullable(path: string) : boolean | undefined {
+        const resolved = this.resolve(path);
+        if (!resolved || resolved.kind !== 'column') {
+            return undefined;
+        }
+
+        return resolved.column.nullable;
+    }
+
+    // -----------------------------------------------------------
+
+    /**
+     * Resolve a dotted path to its column or relation descriptor:
+     * every segment but the last must be a relation, and each hop
+     * switches to the related table.
+     */
+    protected resolve(path: string) : Resolved | undefined {
+        const segments = path.split('.');
+
+        let table : DatamodelTable | undefined = this.tables[this.root];
+
+        for (let i = 0; i < segments.length; i++) {
+            if (!table) {
+                return undefined;
+            }
+
+            const segment = segments[i] as string;
+            const relation = table.relations?.[segment];
+
+            if (i === segments.length - 1) {
+                if (relation) {
+                    return { kind: 'relation', relation };
+                }
+
+                const column = table.columns?.[segment];
+                if (typeof column === 'undefined') {
+                    return undefined;
+                }
+
+                return {
+                    kind: 'column',
+                    column: typeof column === 'string' ? { dataType: column } : column,
+                };
+            }
+
+            if (!relation) {
+                return undefined;
+            }
+
+            table = this.tables[relation.target];
+        }
+
+        return undefined;
+    }
+}
+
+/**
+ * Bind a datamodel to the table a query targets.
+ *
+ * ```typescript
+ * const metadata = defineMetadata({
+ *     users: {
+ *         columns: {
+ *             id: { dataType: 'number', nullable: false },
+ *             name: 'string',
+ *         },
+ *         relations: {
+ *             items: { target: 'items', many: true },
+ *             realm: { target: 'realms', many: false },
+ *         },
+ *     },
+ *     items: { ... },
+ *     realms: { ... },
+ * }, 'users');
+ * ```
+ */
+export function defineMetadata(datamodel: Datamodel, table: string) : Metadata {
+    return new Metadata(datamodel, table);
+}

--- a/packages/adapter-drizzle/src/metadata/types.ts
+++ b/packages/adapter-drizzle/src/metadata/types.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Column facts, in drizzle's own vocabulary: `dataType` matches a
+ * drizzle column's `dataType` (`'string'`, `'number'`, `'boolean'`,
+ * `'date'`, ...), `nullable` is the inverse of `notNull`. Both may
+ * stay undeclared: the adapter treats them as unknown, never as a
+ * guess. A bare data-type string is accepted as shorthand.
+ */
+export type DatamodelColumn = {
+    dataType?: string,
+    nullable?: boolean,
+};
+
+export type DatamodelColumnInput = DatamodelColumn | string;
+
+/**
+ * Relation facts: the key of the related table inside the datamodel
+ * and the cardinality (`many: true` for a `r.many` relation).
+ */
+export type DatamodelRelation = {
+    target: string,
+    many: boolean,
+};
+
+export type DatamodelTable = {
+    columns?: Record<string, DatamodelColumnInput>,
+    relations?: Record<string, DatamodelRelation>,
+};
+
+/**
+ * A hand-written description of the tables a query can traverse,
+ * keyed the way `defineRelations` keys them. Declared locally so this
+ * package never imports from `drizzle-orm`.
+ */
+export type Datamodel = Record<string, DatamodelTable>;
+
+/**
+ * What the adapter needs to know about the targeted table. Every
+ * question may answer `undefined` for "unknown": the adapter then
+ * falls back to its documented default instead of guessing silently.
+ */
+export interface IMetadata {
+    /**
+     * Whether the addressed path is a relation rather than a column.
+     * A relation accepts a nested filter object or a presence test,
+     * so a null check on one must be expressed as presence, not as a
+     * null comparison.
+     */
+    isRelation(path: string): boolean | undefined;
+
+    /**
+     * Whether the relation addressed by a dotted path is to-many
+     * rather than to-one: decides the shape of the absence arm.
+     */
+    isToMany(path: string): boolean | undefined;
+
+    /**
+     * Whether the field addressed by a dotted path holds strings and
+     * may therefore participate in case-insensitive comparison. The
+     * capability veto on the fold policy: the direct analogue of the
+     * `@rapiq/adapter-typeorm` column-type check.
+     */
+    isString(path: string): boolean | undefined;
+
+    /**
+     * Whether the field addressed by a dotted path can hold null.
+     *
+     * Load-bearing: the null-inclusive complement of a negated
+     * operator adds an `isNull` arm; known non-nullable columns drop
+     * it, semantically identical, since no null can exist there.
+     */
+    isNullable(path: string): boolean | undefined;
+}

--- a/packages/adapter-drizzle/src/provider/constants.ts
+++ b/packages/adapter-drizzle/src/provider/constants.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ProviderOptions } from './types';
+
+/**
+ * Database dialects drizzle can execute a relational query against.
+ */
+export enum Provider {
+    PG = 'pg',
+    MYSQL = 'mysql',
+    SQLITE = 'sqlite',
+}
+
+/**
+ * Capability preset per dialect: the drizzle counterpart of the
+ * `@rapiq/adapter-sql` dialect presets.
+ *
+ * `ilike` exists on postgres only. mysql compares case-insensitively
+ * under its default `*_ci` collations, so plain operators already
+ * satisfy the case contract. sqlite folds ASCII case in `LIKE` but
+ * not in `=`: a documented limitation rather than a silent
+ * divergence, mirroring `@rapiq/adapter-prisma`'s sqlite row.
+ *
+ * `likeEscape`: postgres and mysql escape `%`/`_` with a backslash by
+ * default; sqlite's `LIKE` has no default escape character and the
+ * relational filter object offers no `ESCAPE` clause.
+ */
+export const PROVIDERS : Record<`${Provider}`, ProviderOptions> = {
+    [Provider.PG]: { caseInsensitiveLike: true, likeEscape: true },
+    [Provider.MYSQL]: { caseInsensitiveLike: false, likeEscape: true },
+    [Provider.SQLITE]: { caseInsensitiveLike: false, likeEscape: false },
+};

--- a/packages/adapter-drizzle/src/provider/index.ts
+++ b/packages/adapter-drizzle/src/provider/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './constants';
+export * from './module';
+export * from './types';

--- a/packages/adapter-drizzle/src/provider/module.ts
+++ b/packages/adapter-drizzle/src/provider/module.ts
@@ -25,7 +25,14 @@ const ALIASES : Record<string, `${Provider}`> = {
 export function resolveProvider(name: string) : ProviderOptions | undefined {
     const normalized = name.toLowerCase();
 
-    return PROVIDERS[ALIASES[normalized] ?? normalized as `${Provider}`];
+    // own-property lookups: an inherited name like `valueOf` must
+    // answer "unknown" instead of resolving to an Object.prototype
+    // member that then poses as a preset.
+    const key = Object.hasOwn(ALIASES, normalized) ?
+        ALIASES[normalized] as `${Provider}` :
+        normalized as `${Provider}`;
+
+    return Object.hasOwn(PROVIDERS, key) ? PROVIDERS[key] : undefined;
 }
 
 /**

--- a/packages/adapter-drizzle/src/provider/module.ts
+++ b/packages/adapter-drizzle/src/provider/module.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError, ErrorCode } from '@rapiq/core';
+import { PROVIDERS, Provider } from './constants';
+import type { ProviderOptions } from './types';
+
+const ALIASES : Record<string, `${Provider}`> = {
+    postgres: Provider.PG,
+    postgresql: Provider.PG,
+    mysql2: Provider.MYSQL,
+    'better-sqlite3': Provider.SQLITE,
+    'libsql': Provider.SQLITE,
+    turso: Provider.SQLITE,
+};
+
+/**
+ * Resolve a dialect name (or a common driver name) to its capability
+ * preset.
+ */
+export function resolveProvider(name: string) : ProviderOptions | undefined {
+    const normalized = name.toLowerCase();
+
+    return PROVIDERS[ALIASES[normalized] ?? normalized as `${Provider}`];
+}
+
+/**
+ * Resolve the `provider` option. An unknown name must never fall
+ * back to a preset: silently treating a typo as postgres would emit
+ * `ilike` filters the real dialect rejects.
+ */
+export function resolveProviderOptions(
+    input: `${Provider}` | string | ProviderOptions,
+) : ProviderOptions {
+    if (typeof input === 'string') {
+        const options = resolveProvider(input);
+        if (options) {
+            return options;
+        }
+
+        throw new AdapterError({
+            message: `The drizzle dialect "${input}" is unknown.`,
+            code: ErrorCode.FEATURE_UNSUPPORTED,
+        });
+    }
+
+    return input;
+}

--- a/packages/adapter-drizzle/src/provider/types.ts
+++ b/packages/adapter-drizzle/src/provider/types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type ProviderOptions = {
+    /**
+     * Whether the connector renders `ilike`/`notIlike` (the postgres
+     * `ILIKE` keyword). The rapiq case contract (eq/ne/in/nin and the
+     * anchored operators compare case-insensitively by default) is
+     * expressed through those operators where they exist.
+     *
+     * Connectors whose default collation already compares
+     * case-insensitively (mysql) or whose `LIKE` is ASCII-folding
+     * (sqlite) set this to `false`: exactly like the identity
+     * `caseFold` of the `@rapiq/adapter-sql` mysql dialect.
+     */
+    caseInsensitiveLike: boolean,
+
+    /**
+     * Whether the connector's `LIKE` treats a backslash as the
+     * default escape character. Drizzle's object filters accept no
+     * `ESCAPE` clause, so on a connector without a default escape
+     * (sqlite) a pattern operand containing `%` or `_` cannot be
+     * matched literally: the adapter fails typed instead of silently
+     * widening the match.
+     */
+    likeEscape: boolean,
+};

--- a/packages/adapter-drizzle/test/data/datamodel.ts
+++ b/packages/adapter-drizzle/test/data/datamodel.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Datamodel } from '../../src';
+
+/**
+ * Keyed the way `defineRelations` keys the query namespace; column
+ * facts in drizzle's own vocabulary (`dataType`, `nullable`).
+ */
+export const datamodel : Datamodel = {
+    users: {
+        columns: {
+            id: { dataType: 'number', nullable: false },
+            first_name: { dataType: 'string', nullable: false },
+            last_name: { dataType: 'string', nullable: false },
+            email: { dataType: 'string', nullable: false },
+            age: { dataType: 'number', nullable: false },
+            address: { dataType: 'string', nullable: true },
+            realm_id: { dataType: 'number', nullable: true },
+        },
+        relations: {
+            realm: { target: 'realms', many: false },
+            items: { target: 'items', many: true },
+        },
+    },
+    realms: {
+        columns: {
+            id: { dataType: 'number', nullable: false },
+            name: { dataType: 'string', nullable: false },
+            description: { dataType: 'string', nullable: true },
+        },
+    },
+    items: {
+        columns: {
+            id: { dataType: 'number', nullable: false },
+            title: { dataType: 'string', nullable: false },
+            color: { dataType: 'string', nullable: true },
+        },
+    },
+};

--- a/packages/adapter-drizzle/test/data/engine.ts
+++ b/packages/adapter-drizzle/test/data/engine.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import Database from 'better-sqlite3';
+import { defineRelations } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import type { User } from './type';
+
+export const realms = sqliteTable('realms', {
+    id: integer('id').primaryKey(),
+    name: text('name').notNull(),
+    description: text('description'),
+});
+
+export const users = sqliteTable('users', {
+    id: integer('id').primaryKey(),
+    first_name: text('first_name').notNull(),
+    last_name: text('last_name').notNull(),
+    email: text('email').notNull(),
+    age: integer('age').notNull(),
+    address: text('address'),
+    realm_id: integer('realm_id'),
+});
+
+export const items = sqliteTable('items', {
+    id: integer('id').primaryKey(),
+    title: text('title').notNull(),
+    color: text('color'),
+    user_id: integer('user_id'),
+});
+
+const schema = {
+    users, 
+    items, 
+    realms, 
+};
+
+export const relations = defineRelations(schema, (r) => ({
+    users: {
+        realm: r.one.realms({ from: r.users.realm_id, to: r.realms.id }),
+        items: r.many.items({ from: r.users.id, to: r.items.user_id }),
+    },
+    items: { user: r.one.users({ from: r.items.user_id, to: r.users.id }) },
+}));
+
+export type EngineDatabase = BetterSQLite3Database<typeof relations>;
+
+const DDL = `
+    create table realms (id integer primary key, name text not null, description text);
+    create table users (
+        id integer primary key,
+        first_name text not null,
+        last_name text not null,
+        email text not null,
+        age integer not null,
+        address text,
+        realm_id integer
+    );
+    create table items (id integer primary key, title text not null, color text, user_id integer);
+`;
+
+/**
+ * A throwaway in-memory database seeded from the nested fixture
+ * records: the engine that decides what an emitted config object
+ * actually selects. No server, no file, no codegen.
+ */
+export function createEngine(records: User[]) : EngineDatabase {
+    const client = new Database(':memory:');
+    client.exec(DDL);
+
+    const insertRealm = client.prepare('insert or ignore into realms values (?, ?, ?)');
+    const insertUser = client.prepare('insert into users values (?, ?, ?, ?, ?, ?, ?)');
+    const insertItem = client.prepare('insert into items values (?, ?, ?, ?)');
+
+    for (const record of records) {
+        if (record.realm) {
+            insertRealm.run(record.realm.id, record.realm.name, record.realm.description);
+        }
+
+        insertUser.run(
+            record.id,
+            record.first_name,
+            record.last_name,
+            record.email,
+            record.age,
+            record.address,
+            record.realm_id,
+        );
+
+        for (const item of record.items) {
+            insertItem.run(item.id, item.title, item.color, record.id);
+        }
+    }
+
+    return drizzle({ client, relations });
+}

--- a/packages/adapter-drizzle/test/data/index.ts
+++ b/packages/adapter-drizzle/test/data/index.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './datamodel';
+export * from './records';
+export * from './schema';
+export * from './type';

--- a/packages/adapter-drizzle/test/data/matrix.ts
+++ b/packages/adapter-drizzle/test/data/matrix.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition } from '@rapiq/core';
+import {
+    and,
+    contains,
+    elemMatch,
+    endsWith,
+    eq,
+    exists,
+    gte,
+    inArray,
+    lt,
+    ne,
+    nin,
+    not,
+    notContains,
+    notEndsWith,
+    notStartsWith,
+    or,
+    startsWith,
+} from '@rapiq/core';
+import type { User } from './type';
+
+/**
+ * The shared parity matrix, replayed by the sqlite engine (default
+ * suite) and by postgres (`test:db`). Complement pairs partition the
+ * fixture records; every row is also checked against
+ * `@rapiq/adapter-memory`.
+ *
+ * The values here are case-exact on purpose: sqlite has no `ilike`,
+ * so the case-insensitive equality default only holds on postgres and
+ * is measured by {@link casePairs} there.
+ */
+export const complementPairs : [string, Condition, Condition][] = [
+    ['eq/ne', eq('address', 'Hogwarts'), ne('address', 'Hogwarts')],
+    ['eq/ne (null)', eq('address', null), ne('address', null)],
+    ['in/nin', inArray('address', ['Hogwarts', 'Mordor']), nin('address', ['Hogwarts', 'Mordor'])],
+    ['in/nin (null member)', inArray('address', ['Hogwarts', null]), nin('address', ['Hogwarts', null])],
+    ['in/nin (empty)', inArray('address', []), nin('address', [])],
+    ['contains/notContains', contains('address', 'wart'), notContains('address', 'wart')],
+    ['startsWith/notStartsWith', startsWith('address', 'Hog'), notStartsWith('address', 'Hog')],
+    ['endsWith/notEndsWith', endsWith('address', 'arts'), notEndsWith('address', 'arts')],
+    ['exists true/false', exists('address'), exists('address', false)],
+    ['eq/ne (to-one relation)', eq('realm.name', 'master'), ne('realm.name', 'master')],
+    ['eq/ne (to-one presence)', exists('realm'), exists('realm', false)],
+];
+
+// De Morgan push-down has to hold for whole trees, not just leaves.
+export const compounds : [string, Condition][] = [
+    ['not(and)', not(and(eq('address', 'Hogwarts'), gte('age', 18)))],
+    ['not(or)', not(or(eq('address', 'Hogwarts'), eq('address', 'Mordor')))],
+    ['not(not(and))', not(not(and(eq('address', 'Hogwarts'), gte('age', 18))))],
+    ['nested', not(or(and(eq('address', 'Mordor'), lt('age', 40)), exists('address', false)))],
+    ['relation inside a negated group', not(and(eq('realm.name', 'master'), gte('age', 18)))],
+];
+
+/**
+ * A to-many path binds per element (per left-joined row), so a record
+ * with a matching *and* a non-matching element satisfies both a
+ * condition and its negation; the pair does not partition the records
+ * and only agreement with the reference backend is asserted.
+ */
+export const collections : [string, Condition][] = [
+    ['eq', eq('items.title', 'book')],
+    ['ne', ne('items.title', 'book')],
+    ['not(eq)', not(eq('items.title', 'book'))],
+    ['eq (null column)', eq('items.color', null)],
+    ['ne (null column)', ne('items.color', null)],
+    ['exists', exists('items.color')],
+    ['exists false', exists('items.color', false)],
+    ['in', inArray('items.color', ['red', null])],
+    ['nin', nin('items.color', ['red', null])],
+    ['contains', contains('items.title', 'oo')],
+    ['notContains', notContains('items.title', 'oo')],
+    ['elemMatch', elemMatch('items', and(eq('title', 'book'), eq('color', 'red')))],
+    ['not(elemMatch)', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
+];
+
+/**
+ * Same-element binding: sibling conditions on one to-many path bind
+ * to the SAME element on every backend; the split record satisfies
+ * each condition on a DIFFERENT element and must not match.
+ */
+export const sameElement : [string, Condition][] = [
+    ['and on one path', and(eq('items.title', 'book'), eq('items.color', 'red'))],
+    ['or on one path', or(eq('items.title', 'ring'), eq('items.color', 'blue'))],
+    ['negated leaf in the group', and(ne('items.title', 'ring'), eq('items.color', 'red'))],
+    ['mixed root and relation', and(eq('items.title', 'book'), or(eq('items.color', 'red'), eq('id', 9)))],
+    ['negated group over one path', not(and(eq('items.title', 'book'), eq('items.color', 'red')))],
+    ['not(elemMatch) with a mixed record', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
+];
+
+// -----------------------------------------------------------
+
+/**
+ * Case-variant twins of record 1's `first_name`, plus literal LIKE
+ * wildcard values: only postgres can express the case-insensitive
+ * equality default (`ilike`) and the adapter-escaped operand.
+ */
+export const caseRecords : User[] = [
+    {
+        id: 7,
+        first_name: 'caleb',
+        last_name: 'Lower',
+        email: 'caleb.lower@case.io',
+        age: 5,
+        address: '50%',
+        realm_id: null,
+        realm: null,
+        items: [],
+    },
+    {
+        id: 8,
+        first_name: 'CALEB',
+        last_name: 'Upper',
+        email: 'caleb.upper@case.io',
+        age: 6,
+        address: '50x',
+        realm_id: null,
+        realm: null,
+        items: [],
+    },
+];
+
+/**
+ * The case contract (postgres only): the equality family folds by
+ * default, and a lowered `ilike` operand is escaped, so a literal
+ * `%`/`_` never widens the match.
+ */
+export const casePairs : [string, Condition, Condition][] = [
+    ['eq/ne (case fold)', eq('first_name', 'Caleb'), ne('first_name', 'Caleb')],
+    ['in/nin (case fold)', inArray('first_name', ['caleb', 'FRODO']), nin('first_name', ['caleb', 'FRODO'])],
+    ['contains/notContains (case fold)', contains('address', 'WART'), notContains('address', 'WART')],
+    ['eq/ne (literal wildcard)', eq('address', '50%'), ne('address', '50%')],
+    ['startsWith/notStartsWith (escaped)', startsWith('address', '50%'), notStartsWith('address', '50%')],
+];

--- a/packages/adapter-drizzle/test/data/records.ts
+++ b/packages/adapter-drizzle/test/data/records.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { User } from './type';
+
+/**
+ * The parity fixture: address is a value, NULL and another value;
+ * realm is present, absent and present; items has one, zero and two
+ * elements (one with a NULL column).
+ */
+export const records : User[] = [
+    {
+        id: 1,
+        first_name: 'Caleb',
+        last_name: 'Barrows',
+        email: 'caleb.barrows@gmail.com',
+        age: 18,
+        address: 'Hogwarts',
+        realm_id: 1,
+        realm: {
+            id: 1,
+            name: 'master',
+            description: null,
+        },
+        items: [{
+            id: 1,
+            title: 'book',
+            color: 'red',
+        }],
+    },
+    {
+        id: 2,
+        first_name: 'Aston',
+        last_name: 'Nel',
+        email: 'ashton.nel@gmail.com',
+        age: 60,
+        address: null,
+        realm_id: null,
+        realm: null,
+        items: [],
+    },
+    {
+        id: 3,
+        first_name: 'Frodo',
+        last_name: 'Baggins',
+        email: 'frodo.baggins@gmail.com',
+        age: 33,
+        address: 'Mordor',
+        realm_id: 2,
+        realm: {
+            id: 2,
+            name: 'shire',
+            description: 'the shire',
+        },
+        items: [
+            {
+                id: 2,
+                title: 'ring',
+                color: null,
+            },
+            {
+                id: 3,
+                title: 'book',
+                color: 'blue',
+            },
+        ],
+    },
+];
+
+/**
+ * Satisfies `title = 'book'` and `color = 'red'` on DIFFERENT
+ * elements: the same-element binding matrix depends on it not
+ * matching the conjunction.
+ */
+export const splitRecord : User = {
+    id: 9,
+    first_name: 'Split',
+    last_name: 'Case',
+    email: 'split@case.io',
+    age: 1,
+    address: null,
+    realm_id: null,
+    realm: null,
+    items: [
+        {
+            id: 90,
+            title: 'book',
+            color: 'blue',
+        },
+        {
+            id: 91,
+            title: 'ring',
+            color: 'red',
+        },
+    ],
+};

--- a/packages/adapter-drizzle/test/data/schema.ts
+++ b/packages/adapter-drizzle/test/data/schema.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import type { DrizzleAdapterOptions } from '../../src';
+import { defineMetadata } from '../../src';
+import { datamodel } from './datamodel';
+import type { Item, Realm, User } from './type';
+
+export const realmSchema = defineSchema<Realm>({
+    name: 'realm',
+    fields: { allowed: ['id', 'name', 'description'] },
+    filters: { allowed: ['id', 'name'] },
+    sort: { allowed: ['id', 'name'] },
+});
+
+export const itemSchema = defineSchema<Item>({
+    name: 'item',
+    fields: { allowed: ['id', 'title', 'color'] },
+    filters: { allowed: ['id', 'title', 'color'] },
+    sort: { allowed: ['id', 'title'] },
+});
+
+export const userSchema = defineSchema<User>({
+    name: 'user',
+    fields: {
+        default: ['id', 'first_name', 'last_name', 'age'],
+        allowed: ['email'],
+    },
+    filters: { allowed: ['id', 'first_name', 'realm_id', 'age', 'address'] },
+    pagination: { maxLimit: 50 },
+    relations: { allowed: ['realm', 'items'] },
+    sort: { allowed: ['id', 'age', 'first_name'] },
+    schemaMapping: { realm: 'realm', items: 'item' },
+});
+
+export function createRegistry() : SchemaRegistry {
+    const registry = new SchemaRegistry();
+
+    registry.add(userSchema);
+    registry.add(realmSchema);
+    registry.add(itemSchema);
+
+    return registry;
+}
+
+// -----------------------------------------------------------
+
+/**
+ * The default adapter binding for the shape specs: postgres (so the
+ * case-insensitive default is exercised) over the fixture datamodel.
+ */
+export function createAdapterOptions(
+    overrides: Partial<DrizzleAdapterOptions> = {},
+) : DrizzleAdapterOptions {
+    return {
+        provider: 'pg',
+        metadata: defineMetadata(datamodel, 'users'),
+        ...overrides,
+    };
+}

--- a/packages/adapter-drizzle/test/data/type.ts
+++ b/packages/adapter-drizzle/test/data/type.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type Realm = {
+    id: number,
+    name: string,
+    description: string | null,
+};
+
+export type Item = {
+    id: number,
+    title: string,
+    color: string | null,
+};
+
+export type User = {
+    id: number,
+    first_name: string,
+    last_name: string,
+    email: string,
+    age: number,
+    address: string | null,
+    realm_id: number | null,
+    realm: Realm | null,
+    items: Item[],
+};

--- a/packages/adapter-drizzle/test/unit/acceptance.spec.ts
+++ b/packages/adapter-drizzle/test/unit/acceptance.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createURLCodec } from '@rapiq/codec-url';
+import type { FindManyConfig } from '../../src';
+import { DrizzleAdapter } from '../../src';
+import { createAdapterOptions, createRegistry } from '../data';
+import { records } from '../data/records';
+import { createEngine } from '../data/engine';
+
+/**
+ * M2 gate archetype, ported to the config-object adapter: a
+ * repository takes raw client input, validates it against a schema
+ * and hands the result to drizzle.
+ */
+function createUserRepository(provider = 'pg') {
+    const codec = createURLCodec(createRegistry());
+    const adapter = new DrizzleAdapter(createAdapterOptions({ provider }));
+
+    return {
+        findMany(input: string | Record<string, any>, base?: FindManyConfig) {
+            const query = codec.decode(input, { schema: 'user' });
+            expect(query).toBeDefined();
+
+            return adapter.execute(query!, { base });
+        },
+    };
+}
+
+describe('acceptance: request query to drizzle config', () => {
+    const repository = createUserRepository();
+
+    it('should map a full client request', () => {
+        const { config, pagination } = repository.findMany(
+            'fields=%2Bemail&filter[realm_id]=1,null&include=realm&sort=-age&page[limit]=100',
+        );
+
+        // the requested limit is clamped to maxLimit and echoed back
+        expect(pagination).toEqual({ limit: 50, offset: 0 });
+
+        expect(config.limit).toEqual(50);
+        expect(config.offset).toEqual(0);
+        expect(config.orderBy).toEqual({ age: 'desc' });
+
+        // null-aware membership: records of the realm *or* without one
+        expect(config.where).toEqual({
+            OR: [
+                { realm_id: { in: [1] } },
+                { realm_id: { isNull: true } },
+            ],
+        });
+
+        // the sensitive field is projected only because the client
+        // opted in; the hydrated relation is narrowed to the realm
+        // schema's allow-listed fieldset (#847).
+        expect(config.columns).toEqual({
+            id: true,
+            first_name: true,
+            last_name: true,
+            age: true,
+            email: true,
+        });
+        expect(config.with).toEqual({
+            realm: {
+                columns: {
+                    id: true,
+                    name: true,
+                    description: true,
+                },
+            },
+        });
+    });
+
+    it('should hide undeclared parameters', () => {
+        const { config, pagination } = repository.findMany({
+            filter: { age: '18' },
+            sort: '-email',
+        });
+
+        expect(pagination).toEqual({ limit: 50, offset: 0 });
+
+        // age is filterable, email is not sortable
+        expect(config.where).toEqual({ age: { eq: 18 } });
+        expect(config.orderBy).toBeUndefined();
+
+        expect(config.columns).toEqual({
+            id: true,
+            first_name: true,
+            last_name: true,
+            age: true,
+        });
+    });
+
+    it('should preserve a caller-owned scope through the pipeline', () => {
+        const { config } = repository.findMany('filter[age]=18', { where: { realm_id: 1 } });
+
+        expect(config.where).toEqual({
+            AND: [
+                { realm_id: 1 },
+                { age: { eq: 18 } },
+            ],
+        });
+    });
+
+    it('should execute a decoded request against the engine', async () => {
+        const repo = createUserRepository('sqlite');
+
+        const { config } = repo.findMany('filter[age]=>=30&sort=-age&include=realm');
+
+        const rows = await createEngine(records).query.users.findMany(config);
+
+        expect(rows.map((row) => row.id)).toEqual([2, 3]);
+        expect(rows[0]).toEqual({
+            id: 2,
+            first_name: 'Aston',
+            last_name: 'Nel',
+            age: 60,
+            realm: null,
+        });
+    });
+});

--- a/packages/adapter-drizzle/test/unit/complement.spec.ts
+++ b/packages/adapter-drizzle/test/unit/complement.spec.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition } from '@rapiq/core';
+import {
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    not,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/adapter-memory';
+import { DrizzleAdapter } from '../../src';
+import { createAdapterOptions } from '../data';
+import { records, splitRecord } from '../data/records';
+import {
+    collections,
+    complementPairs,
+    compounds,
+    sameElement,
+} from '../data/matrix';
+import { createEngine } from '../data/engine';
+import type { User } from '../data/type';
+
+/**
+ * The cross-backend semantics gate: the emitted config is executed by
+ * a real drizzle query engine (in-memory sqlite, no codegen, no
+ * server) and must select exactly the records `@rapiq/adapter-memory`
+ * selects, the same obligation `@rapiq/adapter-typeorm` and
+ * `@rapiq/adapter-prisma` discharge against their engines. The
+ * postgres `test:db` suite replays the same matrix plus the case
+ * contract (`engine.db.spec.ts`).
+ */
+describe('cross-adapter complement law (memory vs drizzle engine)', () => {
+    const allIds = records.map((record) => record.id).sort((a, b) => a - b);
+
+    const adapter = new DrizzleAdapter(createAdapterOptions({ provider: 'sqlite' }));
+
+    const drizzleIds = async (condition: Condition, rows: User[] = records) : Promise<number[]> => {
+        const filters = new Filters(FilterCompoundOperator.AND, [condition]);
+        const { config } = adapter.execute(new Query({ filters }));
+
+        const found = await createEngine(rows).query.users.findMany(config);
+
+        return found
+            .map((record) => record.id)
+            .sort((a, b) => a - b);
+    };
+
+    const memoryIds = (condition: Condition, rows: User[] = records) : number[] => {
+        const predicate = compileFilters(condition);
+
+        return rows
+            .filter((record) => predicate(record))
+            .map((record) => record.id)
+            .sort((a, b) => a - b);
+    };
+
+    complementPairs.forEach(([name, positive, negative]) => {
+        it(`should agree for ${name}`, async () => {
+            const positiveIds = await drizzleIds(positive);
+            const negativeIds = await drizzleIds(negative);
+
+            expect(positiveIds).toEqual(memoryIds(positive));
+            expect(negativeIds).toEqual(memoryIds(negative));
+
+            // the negation selects exactly the remaining records.
+            expect([...positiveIds, ...negativeIds].sort((a, b) => a - b)).toEqual(allIds);
+
+            // the first-class NOT node is the same complement.
+            expect(await drizzleIds(not(positive))).toEqual(negativeIds);
+            expect(memoryIds(not(positive))).toEqual(negativeIds);
+        });
+    });
+
+    compounds.forEach(([name, condition]) => {
+        it(`should agree for ${name}`, async () => {
+            expect(await drizzleIds(condition)).toEqual(memoryIds(condition));
+        });
+    });
+
+    collections.forEach(([name, condition]) => {
+        it(`should agree for a to-many path: ${name}`, async () => {
+            expect(await drizzleIds(condition)).toEqual(memoryIds(condition));
+        });
+    });
+
+    sameElement.forEach(([name, condition]) => {
+        it(`should bind to the same element for ${name}`, async () => {
+            const rows = [...records, splitRecord];
+
+            expect(await drizzleIds(condition, rows)).toEqual(memoryIds(condition, rows));
+        });
+    });
+});

--- a/packages/adapter-drizzle/test/unit/deep.spec.ts
+++ b/packages/adapter-drizzle/test/unit/deep.spec.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import Database from 'better-sqlite3';
+import { defineRelations } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+import type { Condition } from '@rapiq/core';
+import {
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    and,
+    elemMatch,
+    eq,
+    exists,
+    ne,
+    not,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/adapter-memory';
+import type { Datamodel } from '../../src';
+import { DrizzleAdapter, defineMetadata } from '../../src';
+
+const realms = sqliteTable('realms', {
+    id: integer('id').primaryKey(),
+    name: text('name'),
+});
+
+const owners = sqliteTable('owners', {
+    id: integer('id').primaryKey(),
+    name: text('name'),
+    realm_id: integer('realm_id'),
+});
+
+const items = sqliteTable('items', {
+    id: integer('id').primaryKey(),
+    title: text('title'),
+    owner_id: integer('owner_id'),
+    parent_id: integer('parent_id'),
+});
+
+const parents = sqliteTable('parents', {
+    id: integer('id').primaryKey(),
+    label: text('label'),
+});
+
+const relations = defineRelations({
+    parents,
+    items,
+    owners,
+    realms,
+}, (r) => ({
+    parents: { items: r.many.items({ from: r.parents.id, to: r.items.parent_id }) },
+    items: { user: r.one.owners({ from: r.items.owner_id, to: r.owners.id }) },
+    owners: { realm: r.one.realms({ from: r.owners.realm_id, to: r.realms.id }) },
+}));
+
+function createDeepEngine() {
+    const client = new Database(':memory:');
+    client.exec(`
+        create table realms (id integer primary key, name text);
+        create table owners (id integer primary key, name text, realm_id integer);
+        create table items (id integer primary key, title text, owner_id integer, parent_id integer);
+        create table parents (id integer primary key, label text);
+        insert into realms values (1, 'master'), (2, 'shire');
+        insert into owners values (10, 'o-master', 1), (11, 'o-none', null), (12, 'o-shire', 2);
+        insert into items values
+            (100, 'a', 10, 1000),
+            (101, 'b', 11, 1002),
+            (102, 'c', null, 1003),
+            (103, 'd', 12, 1000);
+        insert into parents values (1000, 'p-two'), (1001, 'p-empty'), (1002, 'p-b'), (1003, 'p-c');
+    `);
+
+    return drizzle({ client, relations });
+}
+
+// nested plain records, mirroring the seeded rows
+const itemRecords = [
+    {
+        id: 100,
+        title: 'a',
+        user: {
+            id: 10,
+            name: 'o-master',
+            realm: { id: 1, name: 'master' },
+        },
+    },
+    {
+        id: 101,
+        title: 'b',
+        user: {
+            id: 11,
+            name: 'o-none',
+            realm: null,
+        },
+    },
+    {
+        id: 102, 
+        title: 'c', 
+        user: null, 
+    },
+    {
+        id: 103,
+        title: 'd',
+        user: {
+            id: 12,
+            name: 'o-shire',
+            realm: { id: 2, name: 'shire' },
+        },
+    },
+];
+
+const parentRecords = [
+    {
+        id: 1000, 
+        label: 'p-two', 
+        items: [itemRecords[0], itemRecords[3]], 
+    },
+    {
+        id: 1001, 
+        label: 'p-empty', 
+        items: [], 
+    },
+    {
+        id: 1002, 
+        label: 'p-b', 
+        items: [itemRecords[1]], 
+    },
+    {
+        id: 1003, 
+        label: 'p-c', 
+        items: [itemRecords[2]], 
+    },
+];
+
+const datamodel : Datamodel = {
+    parents: {
+        columns: { id: { dataType: 'number', nullable: false }, label: 'string' },
+        relations: { items: { target: 'items', many: true } },
+    },
+    items: {
+        columns: {
+            id: { dataType: 'number', nullable: false },
+            title: { dataType: 'string', nullable: false },
+        },
+        relations: { user: { target: 'owners', many: false } },
+    },
+    owners: {
+        columns: { id: { dataType: 'number', nullable: false }, name: 'string' },
+        relations: { realm: { target: 'realms', many: false } },
+    },
+    realms: { columns: { id: { dataType: 'number', nullable: false }, name: 'string' } },
+};
+
+/**
+ * Multi-hop relation chains, the shapes the main fixture cannot
+ * reach: a two-level to-one chain from the root (absence arms at
+ * every hop) and the same chain INSIDE a factored to-many scope. The
+ * engine and `@rapiq/adapter-memory` must select the same records.
+ */
+describe('cross-adapter parity for deep relation chains', () => {
+    const itemAdapter = new DrizzleAdapter({
+        provider: 'sqlite',
+        metadata: defineMetadata(datamodel, 'items'),
+    });
+    const parentAdapter = new DrizzleAdapter({
+        provider: 'sqlite',
+        metadata: defineMetadata(datamodel, 'parents'),
+    });
+
+    const agree = async (
+        adapter: DrizzleAdapter,
+        table: 'items' | 'parents',
+        records: Record<string, any>[],
+        condition: Condition,
+    ) => {
+        const filters = new Filters(FilterCompoundOperator.AND, [condition]);
+        const { config } = adapter.execute(new Query({ filters }));
+
+        const found = await createDeepEngine().query[table].findMany(config);
+        const engine = found.map((row) => row.id).sort((a, b) => a - b);
+        const memory = records
+            .filter(compileFilters(condition))
+            .map((row) => row.id)
+            .sort((a, b) => a - b);
+
+        expect(engine).toEqual(memory);
+    };
+
+    const fromItems : [string, Condition][] = [
+        ['eq through two to-one hops', eq('user.realm.name', 'master')],
+        ['ne through two to-one hops', ne('user.realm.name', 'master')],
+        ['not(eq) through two to-one hops', not(eq('user.realm.name', 'master'))],
+        ['presence of a nested to-one', exists('user.realm')],
+        ['absence of a nested to-one', exists('user.realm', false)],
+        ['exists on a nested column', exists('user.realm.name')],
+        ['not exists on a nested column', exists('user.realm.name', false)],
+    ];
+
+    fromItems.forEach(([name, condition]) => {
+        it(`should agree from the items root for ${name}`, async () => {
+            await agree(itemAdapter, 'items', itemRecords, condition);
+        });
+    });
+
+    const fromParents : [string, Condition][] = [
+        ['eq through a to-many then two to-one hops', eq('items.user.realm.name', 'master')],
+        ['ne through a to-many then two to-one hops', ne('items.user.realm.name', 'master')],
+        ['not(eq) through the full chain', not(eq('items.user.realm.name', 'master'))],
+        ['same-scope conjunct at different depths', and(eq('items.title', 'a'), eq('items.user.realm.name', 'master'))],
+        ['same-scope negated deep leaf', and(eq('items.title', 'a'), ne('items.user.realm.name', 'shire'))],
+        ['negated group over the chain', not(and(eq('items.title', 'a'), eq('items.user.realm.name', 'master')))],
+        ['elemMatch with a deep interior', elemMatch('items', eq('user.realm.name', 'master'))],
+        ['not(elemMatch) with a deep interior', not(elemMatch('items', eq('user.realm.name', 'master')))],
+        ['presence through the to-many', exists('items.user')],
+        ['absence through the to-many', exists('items.user', false)],
+    ];
+
+    fromParents.forEach(([name, condition]) => {
+        it(`should agree from the parents root for ${name}`, async () => {
+            await agree(parentAdapter, 'parents', parentRecords, condition);
+        });
+    });
+});

--- a/packages/adapter-drizzle/test/unit/engine.db.spec.ts
+++ b/packages/adapter-drizzle/test/unit/engine.db.spec.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { defineRelations } from 'drizzle-orm';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import pg from 'pg';
+import type { Condition } from '@rapiq/core';
+import {
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    eq,
+    not,
+} from '@rapiq/core';
+import { compileFilters } from '@rapiq/adapter-memory';
+import { DrizzleAdapter } from '../../src';
+import { createAdapterOptions } from '../data';
+import { records, splitRecord } from '../data/records';
+import {
+    casePairs,
+    caseRecords,
+    collections,
+    complementPairs,
+    compounds,
+    sameElement,
+} from '../data/matrix';
+import type { User } from '../data/type';
+
+const realms = pgTable('realms', {
+    id: integer('id').primaryKey(),
+    name: text('name').notNull(),
+    description: text('description'),
+});
+
+const users = pgTable('users', {
+    id: integer('id').primaryKey(),
+    first_name: text('first_name').notNull(),
+    last_name: text('last_name').notNull(),
+    email: text('email').notNull(),
+    age: integer('age').notNull(),
+    address: text('address'),
+    realm_id: integer('realm_id'),
+});
+
+const items = pgTable('items', {
+    id: integer('id').primaryKey(),
+    title: text('title').notNull(),
+    color: text('color'),
+    user_id: integer('user_id'),
+});
+
+const relations = defineRelations({
+    users, 
+    items, 
+    realms, 
+}, (r) => ({
+    users: {
+        realm: r.one.realms({ from: r.users.realm_id, to: r.realms.id }),
+        items: r.many.items({ from: r.users.id, to: r.items.user_id }),
+    },
+}));
+
+const enabled = (process.env.DB_TYPE || '').toLowerCase().startsWith('postgres');
+
+const suite = enabled ? describe : describe.skip;
+
+/**
+ * The same parity matrix as `complement.spec.ts`, replayed against a
+ * live PostgreSQL server, plus the case contract: postgres is the
+ * only dialect where `ilike` exists, so the case-insensitive equality
+ * default and the escaped-operand exactness can only be measured
+ * here. The CI `tests-db` job provides the server.
+ */
+suite('engine: postgres parity and case contract', () => {
+    const rows : User[] = [...records, splitRecord, ...caseRecords];
+    const allIds = rows.map((record) => record.id).sort((a, b) => a - b);
+
+    const adapter = new DrizzleAdapter(createAdapterOptions({ provider: 'pg' }));
+
+    let pool : pg.Pool;
+    let db : ReturnType<typeof drizzle<typeof relations>>;
+
+    beforeAll(async () => {
+        pool = new pg.Pool({
+            host: process.env.DB_HOST || '127.0.0.1',
+            port: Number(process.env.DB_PORT || '5432'),
+            user: process.env.DB_USERNAME || 'postgres',
+            password: process.env.DB_PASSWORD || 'start123',
+            database: process.env.DB_DATABASE || 'test',
+        });
+
+        db = drizzle({ client: pool, relations });
+
+        await pool.query('drop table if exists items, users, realms');
+        await pool.query('create table realms (id integer primary key, name text not null, description text)');
+        await pool.query(`create table users (
+            id integer primary key,
+            first_name text not null,
+            last_name text not null,
+            email text not null,
+            age integer not null,
+            address text,
+            realm_id integer
+        )`);
+        await pool.query('create table items (id integer primary key, title text not null, color text, user_id integer)');
+
+        const seen = new Set<number>();
+        for (const record of rows) {
+            if (record.realm && !seen.has(record.realm.id)) {
+                seen.add(record.realm.id);
+                await pool.query(
+                    'insert into realms values ($1, $2, $3)',
+                    [record.realm.id, record.realm.name, record.realm.description],
+                );
+            }
+
+            await pool.query(
+                'insert into users values ($1, $2, $3, $4, $5, $6, $7)',
+                [
+                    record.id,
+                    record.first_name,
+                    record.last_name,
+                    record.email,
+                    record.age,
+                    record.address,
+                    record.realm_id,
+                ],
+            );
+
+            for (const item of record.items) {
+                await pool.query(
+                    'insert into items values ($1, $2, $3, $4)',
+                    [item.id, item.title, item.color, record.id],
+                );
+            }
+        }
+    });
+
+    afterAll(async () => {
+        if (pool) {
+            await pool.query('drop table if exists items, users, realms');
+            await pool.end();
+        }
+    });
+
+    const drizzleIds = async (condition: Condition) : Promise<number[]> => {
+        const filters = new Filters(FilterCompoundOperator.AND, [condition]);
+        const { config } = adapter.execute(new Query({ filters }));
+
+        const found = await db.query.users.findMany(config);
+
+        return found
+            .map((record) => record.id)
+            .sort((a, b) => a - b);
+    };
+
+    const memoryIds = (condition: Condition) : number[] => {
+        const predicate = compileFilters(condition);
+
+        return rows
+            .filter((record) => predicate(record))
+            .map((record) => record.id)
+            .sort((a, b) => a - b);
+    };
+
+    [...complementPairs, ...casePairs].forEach(([name, positive, negative]) => {
+        it(`should agree for ${name}`, async () => {
+            const positiveIds = await drizzleIds(positive);
+            const negativeIds = await drizzleIds(negative);
+
+            expect(positiveIds).toEqual(memoryIds(positive));
+            expect(negativeIds).toEqual(memoryIds(negative));
+
+            expect([...positiveIds, ...negativeIds].sort((a, b) => a - b)).toEqual(allIds);
+
+            expect(await drizzleIds(not(positive))).toEqual(negativeIds);
+        });
+    });
+
+    [...compounds, ...collections, ...sameElement].forEach(([name, condition]) => {
+        it(`should agree for ${name}`, async () => {
+            expect(await drizzleIds(condition)).toEqual(memoryIds(condition));
+        });
+    });
+
+    it('should keep an opted-out equality exact', async () => {
+        const exact = new DrizzleAdapter(createAdapterOptions({
+            provider: 'pg',
+            filters: { caseSensitive: true },
+        }));
+
+        // matches only the exact-case record, unlike the folded
+        // default measured above.
+        const { config } = exact.execute(new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('first_name', 'caleb')]) }));
+
+        const found = await db.query.users.findMany(config);
+
+        expect(found.map((record) => record.id)).toEqual([7]);
+    });
+});

--- a/packages/adapter-drizzle/test/unit/engine.spec.ts
+++ b/packages/adapter-drizzle/test/unit/engine.spec.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    Fields,
+    FilterCompoundOperator,
+    Filters,
+    Pagination,
+    Query,
+    Relation,
+    Relations,
+    Sort,
+    SortDirection,
+    Sorts,
+    inArray,
+} from '@rapiq/core';
+import { DrizzleAdapter } from '../../src';
+import { createAdapterOptions } from '../data';
+import { records } from '../data/records';
+import { createEngine } from '../data/engine';
+
+/**
+ * The emitted selection, ordering and pagination shapes executed by
+ * the real engine: what a consumer actually receives.
+ */
+describe('engine: selection and ordering', () => {
+    const adapter = new DrizzleAdapter(createAdapterOptions({ provider: 'sqlite' }));
+
+    const run = (query: Query) => {
+        const { config } = adapter.execute(query);
+
+        return createEngine(records).query.users.findMany(config);
+    };
+
+    it('should hydrate an included relation whole', async () => {
+        const rows = await run(new Query({
+            fields: new Fields([new Field('id')]),
+            relations: new Relations([new Relation('realm')]),
+        }));
+
+        expect(rows[0]).toEqual({
+            id: 1,
+            realm: {
+                id: 1,
+                name: 'master',
+                description: null,
+            },
+        });
+        expect(rows[1]).toEqual({ id: 2, realm: null });
+    });
+
+    it('should narrow an included relation to its fieldset (#847)', async () => {
+        const rows = await run(new Query({
+            fields: new Fields([new Field('id'), new Field('items.title')]),
+            relations: new Relations([new Relation('items')]),
+        }));
+
+        expect(rows[0]).toEqual({ id: 1, items: [{ title: 'book' }] });
+        expect(rows[1]).toEqual({ id: 2, items: [] });
+    });
+
+    it('should narrow the root to no scalars when only relation columns are picked', async () => {
+        const rows = await run(new Query({
+            fields: new Fields([new Field('realm.name')]),
+            relations: new Relations([new Relation('realm')]),
+        }));
+
+        expect(rows[0]).toEqual({ realm: { name: 'master' } });
+    });
+
+    it('should keep the sort priority of a multi-key orderBy', async () => {
+        const rows = await run(new Query({
+            fields: new Fields([new Field('id')]),
+            sorts: new Sorts([
+                new Sort('age', SortDirection.DESC),
+                new Sort('id', SortDirection.DESC),
+            ]),
+        }));
+
+        expect(rows.map((row) => row.id)).toEqual([2, 3, 1]);
+    });
+
+    it('should apply limit and offset', async () => {
+        const rows = await run(new Query({
+            fields: new Fields([new Field('id')]),
+            sorts: new Sorts([new Sort('id')]),
+            pagination: new Pagination(1, 1),
+        }));
+
+        expect(rows.map((row) => row.id)).toEqual([2]);
+    });
+
+    it('should return no rows for an unsatisfiable condition', async () => {
+        const rows = await run(new Query({ filters: new Filters(FilterCompoundOperator.AND, [inArray('id', [])]) }));
+
+        expect(rows).toEqual([]);
+    });
+});

--- a/packages/adapter-drizzle/test/unit/fields.spec.ts
+++ b/packages/adapter-drizzle/test/unit/fields.spec.ts
@@ -13,6 +13,7 @@ import {
     Relation,
     Relations,
     eq,
+    exists,
 } from '@rapiq/core';
 import { createAdapterOptions } from '../data';
 import { DrizzleAdapter } from '../../src';
@@ -157,6 +158,19 @@ describe('src/adapter/fields.ts', () => {
         ], ['realm'])).toEqual({
             columns: { id: true, email: true },
             with: { realm: { columns: { id: true, name: true } } },
+        });
+    });
+
+    it('should hydrate a relation-valued gate operand through `with`, not `columns`', () => {
+        // a presence gate like exists('realm') reads the relation
+        // itself; `columns: { realm: true }` is not a drizzle column
+        // key, so the operand hydrates instead.
+        expect(buildGated([
+            new Field('id'),
+            new Field('email', undefined, exists('realm')),
+        ])).toEqual({
+            columns: { id: true, email: true },
+            with: { realm: true },
         });
     });
 

--- a/packages/adapter-drizzle/test/unit/fields.spec.ts
+++ b/packages/adapter-drizzle/test/unit/fields.spec.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    FieldOperator,
+    Fields,
+    Query,
+    Relation,
+    Relations,
+    eq,
+} from '@rapiq/core';
+import { createAdapterOptions } from '../data';
+import { DrizzleAdapter } from '../../src';
+
+function build(fields: string[] = [], relations: string[] = []) {
+    const adapter = new DrizzleAdapter(createAdapterOptions());
+
+    const { config } = adapter.execute(new Query({
+        fields: new Fields(fields.map((field) => {
+            if (field.startsWith('-')) {
+                return new Field(field.substring(1), FieldOperator.EXCLUDE);
+            }
+
+            return new Field(field);
+        })),
+        relations: new Relations(relations.map((relation) => new Relation(relation))),
+    }));
+
+    return config;
+}
+
+describe('src/adapter/fields.ts', () => {
+    it('should emit nothing without fields or relations', () => {
+        expect(build()).toEqual({});
+    });
+
+    it('should project picked fields with columns', () => {
+        expect(build(['id', 'first_name'])).toEqual({ columns: { id: true, first_name: true } });
+    });
+
+    it('should drop excluded fields from the pick set', () => {
+        // an excluded field is simply not projected, as on every other
+        // rapiq backend.
+        expect(build(['id', '-email'])).toEqual({ columns: { id: true } });
+    });
+
+    it('should hydrate relations with `with`', () => {
+        expect(build([], ['realm'])).toEqual({ with: { realm: true } });
+    });
+
+    it('should hydrate sibling relations', () => {
+        expect(build([], ['realm', 'items'])).toEqual({ with: { realm: true, items: true } });
+    });
+
+    it('should nest a dotted relation path', () => {
+        expect(build([], ['items.realm'])).toEqual({ with: { items: { with: { realm: true } } } });
+    });
+
+    it('should keep columns and with orthogonal', () => {
+        expect(build(['id'], ['realm'])).toEqual({
+            columns: { id: true },
+            with: { realm: true },
+        });
+    });
+
+    it('should narrow an included relation to its direct field picks (#847)', () => {
+        // revised projection contract (#847), shared with
+        // @rapiq/adapter-memory and @rapiq/adapter-typeorm: a per-relation
+        // fieldset governs the projection of an included relation; only a
+        // pick-free include hydrates whole.
+        expect(build(['id', 'realm.name'], ['realm'])).toEqual({
+            columns: { id: true },
+            with: { realm: { columns: { name: true } } },
+        });
+    });
+
+    it('should keep an included relation whole when only a deeper relation is picked (#847)', () => {
+        // a pick belongs to the relation that owns the column:
+        // `items.realm.id` narrows `items.realm`, never the traversed
+        // prefix `items`.
+        expect(build(['id', 'items.realm.id'], ['items'])).toEqual({
+            columns: { id: true },
+            with: { items: { with: { realm: { columns: { id: true } } } } },
+        });
+    });
+
+    it('should project a relation sparsely when it is not included', () => {
+        expect(build(['id', 'realm.name'])).toEqual({
+            columns: { id: true },
+            with: { realm: { columns: { name: true } } },
+        });
+    });
+
+    it('should keep deeper relations of a wholly hydrated one', () => {
+        expect(build(['id'], ['items', 'items.realm'])).toEqual({
+            columns: { id: true },
+            with: { items: { with: { realm: true } } },
+        });
+    });
+
+    it('should narrow the root to no scalars when only relation columns are picked', () => {
+        // `columns: {}` deselects every root scalar: the drizzle form
+        // of the sparse root `select` the prisma adapter emits.
+        expect(build(['realm.name'])).toEqual({
+            columns: {},
+            with: { realm: { columns: { name: true } } },
+        });
+    });
+
+    it('should narrow a relation traversed only to reach a deeper one', () => {
+        expect(build(['items.realm.id'])).toEqual({
+            columns: {},
+            with: { items: { columns: {}, with: { realm: { columns: { id: true } } } } },
+        });
+    });
+
+    const buildGated = (fields: Field[], relations: string[] = []) => {
+        const adapter = new DrizzleAdapter(createAdapterOptions());
+
+        const { config } = adapter.execute(new Query({
+            fields: new Fields(fields),
+            relations: new Relations(relations.map((relation) => new Relation(relation))),
+        }));
+
+        return config;
+    };
+
+    it('should force-project the operand a visibility gate reads (#830)', () => {
+        // the gate is enforced post-fetch (applyFieldConditions); a
+        // missing operand would over-redact an eq-gate and let a
+        // negated gate disclose.
+        expect(buildGated([
+            new Field('id'),
+            new Field('email', undefined, eq('age', 60)),
+        ])).toEqual({
+            columns: {
+                id: true,
+                email: true,
+                age: true,
+            },
+        });
+    });
+
+    it('should keep a forced operand selected under a narrowed include (#847)', () => {
+        // the `realm.id` pick narrows the include; the gate operand
+        // `realm.name` rides along without widening the narrowing back
+        // up.
+        expect(buildGated([
+            new Field('id'),
+            new Field('realm.id'),
+            new Field('email', undefined, eq('realm.name', 'master')),
+        ], ['realm'])).toEqual({
+            columns: { id: true, email: true },
+            with: { realm: { columns: { id: true, name: true } } },
+        });
+    });
+
+    it('should leave a pick-free whole include covering its operands (#830/#847)', () => {
+        // no direct pick: the include hydrates whole, which already
+        // fetches the operand — the forced entry must not narrow the
+        // relation.
+        expect(buildGated([
+            new Field('id'),
+            new Field('email', undefined, eq('realm.name', 'master')),
+        ], ['realm'])).toEqual({
+            columns: { id: true, email: true },
+            with: { realm: true },
+        });
+    });
+});

--- a/packages/adapter-drizzle/test/unit/filters.spec.ts
+++ b/packages/adapter-drizzle/test/unit/filters.spec.ts
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition } from '@rapiq/core';
+import {
+    AdapterError,
+    FilterCompoundOperator,
+    Filters,
+    Query,
+    and,
+    contains,
+    elemMatch,
+    eq,
+    exists,
+    gte,
+    inArray,
+    lt,
+    mod,
+    ne,
+    nin,
+    not,
+    notContains,
+    or,
+    regex,
+    size,
+    startsWith,
+} from '@rapiq/core';
+import type { FindManyConfig } from '../../src';
+import { DrizzleAdapter } from '../../src';
+import { createAdapterOptions } from '../data';
+
+function serialize(condition: Condition, overrides: Record<string, any> = {}) : FindManyConfig {
+    const filters = new Filters(FilterCompoundOperator.AND, [condition]);
+    const adapter = new DrizzleAdapter(createAdapterOptions(overrides));
+
+    return adapter.execute(new Query({ filters })).config;
+}
+
+describe('src/adapter/where.ts', () => {
+    describe('equality family', () => {
+        it('should lower an insensitive equality to an escaped ilike', () => {
+            expect(serialize(eq('address', 'Hogwarts')).where).toEqual({ address: { ilike: 'Hogwarts' } });
+        });
+
+        it('should escape LIKE wildcards in the lowered operand', () => {
+            expect(serialize(eq('address', '50%_\\')).where).toEqual({ address: { ilike: '50\\%\\_\\\\' } });
+        });
+
+        it('should keep non-string comparisons exact', () => {
+            expect(serialize(eq('age', 18)).where).toEqual({ age: { eq: 18 } });
+        });
+
+        it('should keep an opted-out field exact', () => {
+            const config = serialize(eq('address', 'Hogwarts'), { filters: { caseSensitive: ['address'] } });
+
+            expect(config.where).toEqual({ address: { eq: 'Hogwarts' } });
+        });
+
+        it('should complement ne with a null arm', () => {
+            expect(serialize(ne('address', 'Hogwarts')).where).toEqual({
+                OR: [
+                    { address: { notIlike: 'Hogwarts' } },
+                    { address: { isNull: true } },
+                ],
+            });
+        });
+
+        it('should drop the null arm on a non-nullable column', () => {
+            expect(serialize(ne('first_name', 'Caleb')).where).toEqual({ first_name: { notIlike: 'Caleb' } });
+        });
+
+        it('should render a null comparison as a null check', () => {
+            expect(serialize(eq('address', null)).where).toEqual({ address: { isNull: true } });
+            expect(serialize(ne('address', null)).where).toEqual({ address: { isNotNull: true } });
+        });
+    });
+
+    describe('ordering family', () => {
+        it('should map ordering operators one to one', () => {
+            expect(serialize(lt('age', 40)).where).toEqual({ age: { lt: 40 } });
+            expect(serialize(gte('age', 18)).where).toEqual({ age: { gte: 18 } });
+        });
+
+        it('should complement a negated ordering through the dual operator', () => {
+            // the null arm dies on the non-nullable column.
+            expect(serialize(not(gte('age', 18))).where).toEqual({ age: { lt: 18 } });
+        });
+    });
+
+    describe('membership', () => {
+        it('should decompose an insensitive membership into ilike arms', () => {
+            expect(serialize(inArray('address', ['Hogwarts', 'Mordor'])).where).toEqual({
+                OR: [
+                    { address: { ilike: 'Hogwarts' } },
+                    { address: { ilike: 'Mordor' } },
+                ],
+            });
+        });
+
+        it('should keep non-string members an exact membership test', () => {
+            expect(serialize(inArray('age', [18, 33])).where).toEqual({ age: { in: [18, 33] } });
+        });
+
+        it('should widen a null member to a null check', () => {
+            expect(serialize(inArray('address', ['Hogwarts', null])).where).toEqual({
+                OR: [
+                    { address: { ilike: 'Hogwarts' } },
+                    { address: { isNull: true } },
+                ],
+            });
+        });
+
+        it('should complement nin as notIlike arms plus the null arm', () => {
+            expect(serialize(nin('address', ['Hogwarts', 'Mordor'])).where).toEqual({
+                OR: [
+                    {
+                        AND: [
+                            { address: { notIlike: 'Hogwarts' } },
+                            { address: { notIlike: 'Mordor' } },
+                        ],
+                    },
+                    { address: { isNull: true } },
+                ],
+            });
+        });
+
+        it('should complement a null member with a not-null guard', () => {
+            expect(serialize(nin('address', ['Hogwarts', null])).where).toEqual({
+                AND: [
+                    { address: { notIlike: 'Hogwarts' } },
+                    { address: { isNotNull: true } },
+                ],
+            });
+        });
+    });
+
+    describe('anchored operators', () => {
+        it('should derive escaped ilike patterns', () => {
+            expect(serialize(contains('address', 'wart')).where).toEqual({ address: { ilike: '%wart%' } });
+            expect(serialize(startsWith('address', 'Hog')).where).toEqual({ address: { ilike: 'Hog%' } });
+            expect(serialize(contains('address', '50%')).where).toEqual({ address: { ilike: '%50\\%%' } });
+        });
+
+        it('should complement a negated anchor with the null arm', () => {
+            expect(serialize(notContains('address', 'wart')).where).toEqual({
+                OR: [
+                    { address: { notIlike: '%wart%' } },
+                    { address: { isNull: true } },
+                ],
+            });
+        });
+    });
+
+    describe('relations', () => {
+        it('should nest a to-one path', () => {
+            expect(serialize(eq('realm.name', 'master')).where).toEqual({ realm: { name: { ilike: 'master' } } });
+        });
+
+        it('should add the absence arm to a to-one complement', () => {
+            expect(serialize(ne('realm.name', 'master')).where).toEqual({
+                OR: [
+                    { realm: { name: { notIlike: 'master' } } },
+                    { NOT: { realm: true } },
+                ],
+            });
+        });
+
+        it('should quantify a to-many path existentially', () => {
+            expect(serialize(eq('items.title', 'book')).where).toEqual({ items: { title: { ilike: 'book' } } });
+        });
+
+        it('should factor same-path conjuncts into one scope', () => {
+            const condition = and(
+                eq('items.title', 'book'),
+                eq('items.color', 'red'),
+            );
+
+            expect(serialize(condition).where).toEqual({
+                items: {
+                    AND: [
+                        { title: { ilike: 'book' } },
+                        { color: { ilike: 'red' } },
+                    ],
+                },
+            });
+        });
+
+        it('should add the empty-collection arm to a to-many complement', () => {
+            expect(serialize(ne('items.title', 'book')).where).toEqual({
+                OR: [
+                    { items: { title: { notIlike: 'book' } } },
+                    { NOT: { items: true } },
+                ],
+            });
+        });
+
+        it('should render a relation null check as a presence test', () => {
+            expect(serialize(exists('realm')).where).toEqual({ realm: true });
+            expect(serialize(exists('realm', false)).where).toEqual({ NOT: { realm: true } });
+        });
+
+        it('should treat a to-many collection as always present', () => {
+            // exists() asks for the value, and a collection is
+            // possibly empty, never absent.
+            const config = serialize(exists('items'));
+
+            expect(config.where).toBeUndefined();
+            expect(config.limit).toBeUndefined();
+
+            const negated = serialize(exists('items', false));
+
+            expect(negated.where).toBeUndefined();
+            expect(negated.limit).toEqual(0);
+        });
+    });
+
+    describe('elemMatch', () => {
+        it('should map a to-many elemMatch onto one scope', () => {
+            const condition = elemMatch('items', and(eq('title', 'book'), eq('color', 'red')));
+
+            expect(serialize(condition).where).toEqual({
+                items: {
+                    AND: [
+                        { title: { ilike: 'book' } },
+                        { color: { ilike: 'red' } },
+                    ],
+                },
+            });
+        });
+
+        it('should reject an elemMatch on a scalar column', () => {
+            expect(() => serialize(elemMatch('address', eq('length', 1))))
+                .toThrow(AdapterError);
+        });
+
+        it('should reject an elemMatch on a to-one relation', () => {
+            expect(() => serialize(elemMatch('realm', eq('name', 'master'))))
+                .toThrow(AdapterError);
+        });
+    });
+
+    describe('unsupported operators', () => {
+        it('should reject regex, mod and size typed', () => {
+            expect(() => serialize(regex('address', /wart/))).toThrow(AdapterError);
+            expect(() => serialize(mod('age', 3, 1))).toThrow(AdapterError);
+            expect(() => serialize(size('items', 2))).toThrow(AdapterError);
+        });
+    });
+
+    describe('expansion limit', () => {
+        it('should fail typed instead of downgrading a huge mixed tree', () => {
+            const conditions : Condition[] = [];
+            for (let i = 0; i < 7; i++) {
+                conditions.push(or(eq('items.title', `title-${i}`), eq('age', i)));
+            }
+
+            expect(() => serialize(and(...conditions))).toThrow(AdapterError);
+        });
+    });
+
+    describe('dialect presets', () => {
+        it('should fall back to like on sqlite and mysql', () => {
+            const sqlite = serialize(contains('address', 'wart'), { provider: 'sqlite' });
+            expect(sqlite.where).toEqual({ address: { like: '%wart%' } });
+
+            const mysql = serialize(eq('address', 'Hogwarts'), { provider: 'mysql' });
+            expect(mysql.where).toEqual({ address: { eq: 'Hogwarts' } });
+        });
+
+        it('should escape LIKE operands on mysql', () => {
+            expect(serialize(contains('address', '50%'), { provider: 'mysql' }).where).toEqual({ address: { like: '%50\\%%' } });
+        });
+
+        it('should reject an inexpressible literal wildcard on sqlite', () => {
+            expect(() => serialize(contains('address', '50%'), { provider: 'sqlite' }))
+                .toThrow(AdapterError);
+        });
+
+        it('should reject an unknown dialect name', () => {
+            expect(() => serialize(eq('age', 1), { provider: 'oracle' }))
+                .toThrow(AdapterError);
+        });
+    });
+});

--- a/packages/adapter-drizzle/test/unit/filters.spec.ts
+++ b/packages/adapter-drizzle/test/unit/filters.spec.ts
@@ -284,5 +284,12 @@ describe('src/adapter/where.ts', () => {
             expect(() => serialize(eq('age', 1), { provider: 'oracle' }))
                 .toThrow(AdapterError);
         });
+
+        it('should reject an inherited object member as a dialect name', () => {
+            // `valueOf` resolves through Object.prototype on a naive
+            // lookup and would pose as a preset.
+            expect(() => serialize(eq('age', 1), { provider: 'valueOf' }))
+                .toThrow(AdapterError);
+        });
     });
 });

--- a/packages/adapter-drizzle/test/unit/metadata.spec.ts
+++ b/packages/adapter-drizzle/test/unit/metadata.spec.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { AdapterError } from '@rapiq/core';
+import { defineMetadata } from '../../src';
+import { datamodel } from '../data';
+
+describe('src/metadata/module.ts', () => {
+    const metadata = defineMetadata(datamodel, 'users');
+
+    it('should reject an unknown root table', () => {
+        expect(() => defineMetadata(datamodel, 'user')).toThrow(AdapterError);
+    });
+
+    it('should classify columns and relations', () => {
+        expect(metadata.isRelation('realm')).toBe(true);
+        expect(metadata.isRelation('items')).toBe(true);
+        expect(metadata.isRelation('age')).toBe(false);
+        expect(metadata.isRelation('missing')).toBeUndefined();
+    });
+
+    it('should answer relation cardinality', () => {
+        expect(metadata.isToMany('items')).toBe(true);
+        expect(metadata.isToMany('realm')).toBe(false);
+        expect(metadata.isToMany('age')).toBeUndefined();
+    });
+
+    it('should walk dotted paths across tables', () => {
+        expect(metadata.isString('realm.name')).toBe(true);
+        expect(metadata.isNullable('realm.description')).toBe(true);
+        expect(metadata.isNullable('items.title')).toBe(false);
+        expect(metadata.isRelation('realm.name')).toBe(false);
+    });
+
+    it('should answer string typedness', () => {
+        expect(metadata.isString('first_name')).toBe(true);
+        expect(metadata.isString('age')).toBe(false);
+        expect(metadata.isString('realm')).toBeUndefined();
+    });
+
+    it('should answer nullability', () => {
+        expect(metadata.isNullable('address')).toBe(true);
+        expect(metadata.isNullable('first_name')).toBe(false);
+        expect(metadata.isNullable('realm')).toBeUndefined();
+    });
+
+    it('should treat an undeclared fact as unknown', () => {
+        const sparse = defineMetadata({ users: { columns: { name: 'string', age: {} } } }, 'users');
+
+        expect(sparse.isString('name')).toBe(true);
+        expect(sparse.isNullable('name')).toBeUndefined();
+        expect(sparse.isString('age')).toBeUndefined();
+        expect(sparse.isNullable('age')).toBeUndefined();
+    });
+
+    it('should not walk through a column', () => {
+        expect(metadata.isString('age.value')).toBeUndefined();
+    });
+});

--- a/packages/adapter-drizzle/test/unit/metadata.spec.ts
+++ b/packages/adapter-drizzle/test/unit/metadata.spec.ts
@@ -60,4 +60,14 @@ describe('src/metadata/module.ts', () => {
     it('should not walk through a column', () => {
         expect(metadata.isString('age.value')).toBeUndefined();
     });
+
+    it('should treat inherited object members as unknown', () => {
+        // wire filter keys index the datamodel literals; a prototype
+        // member must never pose as a declared entry.
+        expect(metadata.isRelation('constructor')).toBeUndefined();
+        expect(metadata.isToMany('constructor')).toBeUndefined();
+        expect(metadata.isString('toString')).toBeUndefined();
+        expect(metadata.isNullable('valueOf')).toBeUndefined();
+        expect(metadata.isRelation('realm.constructor')).toBeUndefined();
+    });
 });

--- a/packages/adapter-drizzle/test/unit/query.spec.ts
+++ b/packages/adapter-drizzle/test/unit/query.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    Field,
+    Fields,
+    FilterCompoundOperator,
+    Filters,
+    Pagination,
+    Query,
+    Relation,
+    Relations,
+    Sort,
+    SortDirection,
+    Sorts,
+    eq,
+    inArray,
+} from '@rapiq/core';
+import { createAdapterOptions } from '../data';
+import { DrizzleAdapter, buildDrizzleConfig } from '../../src';
+
+describe('src/adapter/module.ts', () => {
+    it('should compose the whole config object', () => {
+        const query = new Query({
+            fields: new Fields([new Field('id'), new Field('first_name')]),
+            filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]),
+            pagination: new Pagination(10, 20),
+            sorts: new Sorts([
+                new Sort('age', SortDirection.DESC),
+                new Sort('first_name'),
+            ]),
+        });
+
+        const { config, pagination } = new DrizzleAdapter(createAdapterOptions()).execute(query);
+
+        expect(config).toEqual({
+            columns: { id: true, first_name: true },
+            where: { age: { eq: 18 } },
+            orderBy: { age: 'desc', first_name: 'asc' },
+            limit: 10,
+            offset: 20,
+        });
+
+        expect(pagination).toEqual({ limit: 10, offset: 20 });
+    });
+
+    it('should emit no keys for an empty query', () => {
+        const { config, pagination } = new DrizzleAdapter(createAdapterOptions()).execute(new Query());
+
+        expect(config).toEqual({});
+        expect(pagination).toEqual({ limit: undefined, offset: undefined });
+    });
+
+    it('should express an unsatisfiable condition through limit 0', () => {
+        // the filter object has no dialect-free false literal: an
+        // empty `OR` group is stripped by drizzle (measured), so the
+        // config caps the result instead.
+        const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [inArray('id', [])]) });
+
+        const { config } = new DrizzleAdapter(createAdapterOptions()).execute(query);
+
+        expect(config).toEqual({ limit: 0 });
+    });
+
+    describe('baseline config', () => {
+        it('should narrow a caller-owned predicate instead of replacing it', () => {
+            const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]) });
+
+            const { config } = new DrizzleAdapter(createAdapterOptions()).execute(query, { base: { where: { realm_id: 1 } } });
+
+            expect(config.where).toEqual({
+                AND: [
+                    { realm_id: 1 },
+                    { age: { eq: 18 } },
+                ],
+            });
+        });
+
+        it('should keep a caller-owned predicate without query filters', () => {
+            const { config } = new DrizzleAdapter(createAdapterOptions()).execute(new Query(), { base: { where: { realm_id: 1 } } });
+
+            expect(config.where).toEqual({ realm_id: 1 });
+        });
+
+        it('should cap an unsatisfiable condition over any baseline', () => {
+            const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [inArray('id', [])]) });
+
+            const { config } = new DrizzleAdapter(createAdapterOptions()).execute(query, { base: { where: { realm_id: 1 }, limit: 25 } });
+
+            expect(config.where).toEqual({ realm_id: 1 });
+            expect(config.limit).toEqual(0);
+        });
+
+        it('should preserve unrelated baseline keys', () => {
+            const { config } = new DrizzleAdapter(createAdapterOptions()).execute(new Query(), { base: { limit: 5, orderBy: { id: 'asc' } } });
+
+            expect(config).toEqual({ limit: 5, orderBy: { id: 'asc' } });
+        });
+
+        it('should replace a baseline projection with the produced one', () => {
+            const query = new Query({ fields: new Fields([new Field('id')]) });
+
+            const { config } = new DrizzleAdapter(createAdapterOptions()).execute(query, { base: { columns: { email: true } } });
+
+            expect(config).toEqual({ columns: { id: true } });
+        });
+
+        it('should join produced relations into a baseline `with`', () => {
+            const query = new Query({ relations: new Relations([new Relation('realm')]) });
+
+            const { config } = new DrizzleAdapter(createAdapterOptions()).execute(query, { base: { with: { items: true }, columns: { id: true } } });
+
+            expect(config).toEqual({
+                columns: { id: true },
+                with: { items: true, realm: true },
+            });
+        });
+    });
+
+    it('should hold no state between runs', () => {
+        const adapter = new DrizzleAdapter(createAdapterOptions());
+
+        adapter.execute(new Query({
+            filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]),
+            sorts: new Sorts([new Sort('age', SortDirection.DESC)]),
+        }));
+
+        const { config } = adapter.execute(new Query());
+
+        expect(config).toEqual({});
+    });
+
+    it('should not carry per-call filter options into the next run', () => {
+        const adapter = new DrizzleAdapter(createAdapterOptions());
+        const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('first_name', 'Peter')]) });
+
+        adapter.execute(query, { filters: { caseSensitive: true } });
+
+        expect(adapter.execute(query).config.where).toEqual({ first_name: { ilike: 'Peter' } });
+    });
+
+    it('should expose a one-shot helper', () => {
+        const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('age', 18)]) });
+
+        expect(buildDrizzleConfig(query, createAdapterOptions()).config).toEqual({ where: { age: { eq: 18 } } });
+    });
+});

--- a/packages/adapter-drizzle/test/unit/sort.spec.ts
+++ b/packages/adapter-drizzle/test/unit/sort.spec.ts
@@ -47,6 +47,15 @@ describe('src/adapter/sort.ts', () => {
         ]))).toEqual({ id: 'desc' });
     });
 
+    it('should reject an integer-like name typed', () => {
+        // JS enumerates canonical integer keys first, which would
+        // silently reorder the priority the object form encodes.
+        expect(() => orderBy(new Sorts([
+            new Sort('name', SortDirection.ASC),
+            new Sort('2024', SortDirection.DESC),
+        ]))).toThrow(AdapterError);
+    });
+
     it('should reject a relation path typed', () => {
         // the relational API orders the root by its own columns only;
         // an undocumented nested shape could be silently ignored, and

--- a/packages/adapter-drizzle/test/unit/sort.spec.ts
+++ b/packages/adapter-drizzle/test/unit/sort.spec.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    AdapterError,
+    Query,
+    Sort,
+    SortDirection,
+    Sorts,
+} from '@rapiq/core';
+import { createAdapterOptions } from '../data';
+import { DrizzleAdapter } from '../../src';
+
+function orderBy(sorts: Sorts) {
+    const adapter = new DrizzleAdapter(createAdapterOptions());
+
+    return adapter.execute(new Query({ sorts })).config.orderBy;
+}
+
+describe('src/adapter/sort.ts', () => {
+    it('should emit nothing without sorts', () => {
+        expect(orderBy(new Sorts())).toBeUndefined();
+    });
+
+    it('should keep the sort priority through key order', () => {
+        const output = orderBy(new Sorts([
+            new Sort('age', SortDirection.DESC),
+            new Sort('first_name', SortDirection.ASC),
+        ]));
+
+        expect(output).toEqual({ age: 'desc', first_name: 'asc' });
+        expect(Object.keys(output as object)).toEqual(['age', 'first_name']);
+    });
+
+    it('should default to ascending', () => {
+        expect(orderBy(new Sorts([new Sort('id')]))).toEqual({ id: 'asc' });
+    });
+
+    it('should keep the first occurrence of a duplicate key', () => {
+        expect(orderBy(new Sorts([
+            new Sort('id', SortDirection.DESC),
+            new Sort('id', SortDirection.ASC),
+        ]))).toEqual({ id: 'desc' });
+    });
+
+    it('should reject a relation path typed', () => {
+        // the relational API orders the root by its own columns only;
+        // an undocumented nested shape could be silently ignored, and
+        // loud beats silent.
+        expect(() => orderBy(new Sorts([new Sort('realm.name', SortDirection.DESC)])))
+            .toThrow(AdapterError);
+    });
+});

--- a/packages/adapter-drizzle/test/vitest.config.ts
+++ b/packages/adapter-drizzle/test/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/unit/**/*.{spec,test}.{ts,js}'],
+        // the postgres engine specs need a live server, so they live
+        // behind `test:db` (see test/vitest.db.config.ts); the sqlite
+        // engine runs in-memory and stays in the default suite.
+        exclude: ['**/node_modules/**', '**/dist/**', '**/*.db.spec.ts'],
+        coverage: {
+            provider: 'v8',
+            include: ['src/**/*.{ts,tsx,js,jsx}'],
+            exclude: ['src/**/*.d.ts'],
+        },
+    },
+});

--- a/packages/adapter-drizzle/test/vitest.db.config.ts
+++ b/packages/adapter-drizzle/test/vitest.db.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * The live-server engine suite: the emitted config objects executed
+ * against PostgreSQL, where `ilike` exists and the case contract can
+ * be measured. The specs skip themselves unless `DB_TYPE=postgres`
+ * points at a live server (the CI `tests-db` job provides one).
+ */
+export default defineConfig({
+    test: {
+        globals: true,
+        environment: 'node',
+        include: ['test/unit/**/*.db.spec.{ts,js}'],
+        // one server, one schema at a time
+        fileParallelism: false,
+    },
+});

--- a/packages/adapter-drizzle/tsconfig.build.json
+++ b/packages/adapter-drizzle/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src/**/*"]
+}

--- a/packages/adapter-drizzle/tsconfig.json
+++ b/packages/adapter-drizzle/tsconfig.json
@@ -1,0 +1,7 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "types": ["node", "vitest/globals"]
+    },
+    "include": ["src/**/*", "test/**/*"]
+}

--- a/packages/adapter-drizzle/tsdown.config.ts
+++ b/packages/adapter-drizzle/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: 'src/index.ts',
+    format: 'esm',
+    dts: true,
+    sourcemap: true,
+    tsconfig: 'tsconfig.build.json',
+});

--- a/packages/docs/.vitepress/config.mjs
+++ b/packages/docs/.vitepress/config.mjs
@@ -125,6 +125,7 @@ export default defineConfig({
                         { text: '@rapiq/adapter-sql', link: '/packages/adapter-sql' },
                         { text: '@rapiq/adapter-typeorm', link: '/packages/adapter-typeorm' },
                         { text: '@rapiq/adapter-prisma', link: '/packages/adapter-prisma' },
+                        { text: '@rapiq/adapter-drizzle', link: '/packages/adapter-drizzle' },
                         { text: '@rapiq/adapter-memory', link: '/packages/adapter-memory' },
                     ],
                 },

--- a/packages/docs/.vitepress/theme/components/PackageLayers.vue
+++ b/packages/docs/.vitepress/theme/components/PackageLayers.vue
@@ -28,6 +28,7 @@ const layers: Layer[] = [
             { name: '@rapiq/parser-simple', href: '/packages/parser-simple', deps: 'core' },
             { name: '@rapiq/adapter-sql', href: '/packages/adapter-sql', deps: 'core' },
             { name: '@rapiq/adapter-prisma', href: '/packages/adapter-prisma', deps: 'core' },
+            { name: '@rapiq/adapter-drizzle', href: '/packages/adapter-drizzle', deps: 'core' },
             { name: '@rapiq/adapter-memory', href: '/packages/adapter-memory', deps: 'core' },
         ],
     },

--- a/packages/docs/guide/executing-queries.md
+++ b/packages/docs/guide/executing-queries.md
@@ -1,15 +1,16 @@
 # Executing Queries
 
-A validated `Query` becomes results through an **adapter**. Four ship with rapiq; pick by where your data lives:
+A validated `Query` becomes results through an **adapter**. Five ship with rapiq; pick by where your data lives:
 
 | Adapter | Target | Returns |
 |---|---|---|
 | [@rapiq/adapter-typeorm](/packages/adapter-typeorm) | TypeORM `SelectQueryBuilder` | mutates the builder in place |
 | [@rapiq/adapter-prisma](/packages/adapter-prisma) | Prisma Client | a `findMany` argument object |
+| [@rapiq/adapter-drizzle](/packages/adapter-drizzle) | Drizzle relational queries (v1 RQBv2) | a `findMany` config object |
 | [@rapiq/adapter-sql](/packages/adapter-sql) | any SQL driver | parameterized SQL fragments |
 | [@rapiq/adapter-memory](/packages/adapter-memory) | plain objects & arrays | compiled functions / filtered data |
 
-All four consume the same AST, and they agree on semantics: the records a query selects in memory are the records it selects in the database.
+All five consume the same AST, and they agree on semantics: the records a query selects in memory are the records it selects in the database.
 
 ## TypeORM
 
@@ -56,6 +57,27 @@ const total = await adapter.count(query);  // pre-pagination, for the meta block
 ```
 
 Unlike the builder-bound adapters, one `PrismaAdapter` instance is stateless and safely shared across requests. The [package page](/packages/adapter-prisma) covers the provider presets (`mode: 'insensitive'` support) and how negation is rendered exactly despite Prisma's three-valued `NOT`.
+
+## Drizzle
+
+Drizzle's relational queries v2 API (drizzle-orm v1) takes a config object, so this adapter is a pure serializer too:
+
+```typescript
+import { DrizzleAdapter, defineMetadata } from '@rapiq/adapter-drizzle';
+
+const adapter = new DrizzleAdapter({
+    provider: 'pg',
+    metadata: defineMetadata(datamodel, 'users'),
+});
+
+const { config, pagination } = adapter.execute(query, {
+    base: { where: { realm_id } },  // an application-owned scope, conjoined
+});
+
+const users = await db.query.users.findMany(config);
+```
+
+One `DrizzleAdapter` instance is stateless and safely shared across requests. The [package page](/packages/adapter-drizzle) covers the dialect presets, the table metadata and how negation is rendered exactly despite SQL's three-valued `NOT`.
 
 ## Raw SQL
 

--- a/packages/docs/guide/installation.md
+++ b/packages/docs/guide/installation.md
@@ -32,6 +32,10 @@ npm install @rapiq/adapter-sql @rapiq/adapter-typeorm
 npm install @rapiq/adapter-prisma
 ```
 
+```sh [Drizzle]
+npm install @rapiq/adapter-drizzle
+```
+
 ```sh [Raw SQL]
 npm install @rapiq/adapter-sql
 ```

--- a/packages/docs/packages/adapter-drizzle.md
+++ b/packages/docs/packages/adapter-drizzle.md
@@ -134,7 +134,7 @@ A record whose elements satisfy the two conditions only separately does not matc
 
 ## Case sensitivity
 
-String comparison is [case-insensitive by default](/guide/filters#case-sensitivity) across all rapiq backends. Drizzle has no `mode: 'insensitive'`; the fold is expressed through operators, so the adapter takes a provider:
+String comparison is [case-insensitive by default](/guide/filters#case-sensitivity) across the rapiq backends. Drizzle has no `mode: 'insensitive'`; the fold is expressed through operators, so the adapter takes a provider, and dialect capability decides how far the contract reaches (on sqlite the equality family cannot fold, see the table):
 
 ```typescript
 new DrizzleAdapter({ provider: 'mysql', metadata });

--- a/packages/docs/packages/adapter-drizzle.md
+++ b/packages/docs/packages/adapter-drizzle.md
@@ -1,0 +1,182 @@
+# @rapiq/adapter-drizzle
+
+Serializes a parsed [`Query`](/guide/query-ast) into a **Drizzle relational query config**: filters become `where`, fields become `columns`, relations become `with`, sort becomes `orderBy` and pagination becomes `limit`/`offset`.
+
+```sh
+npm install @rapiq/core @rapiq/adapter-drizzle
+```
+
+The adapter targets the object-based relational queries v2 API of **drizzle-orm v1**. Like the Prisma adapter there is nothing to mutate: it is a pure serializer that returns a plain object. `drizzle-orm` is neither a runtime nor a peer dependency of this package; it is a devDependency only, because the test suite runs the emitted configs through a real engine.
+
+## Usage
+
+```typescript
+import { DrizzleAdapter, defineMetadata } from '@rapiq/adapter-drizzle';
+
+const adapter = new DrizzleAdapter({
+    provider: 'pg',
+    metadata: defineMetadata(datamodel, 'users'),
+});
+
+const { config, pagination } = adapter.execute(query);
+
+const users = await db.query.users.findMany(config);
+```
+
+`provider` names the dialect the config will execute against (see [Case sensitivity](#case-sensitivity)); `metadata` supplies the table facts the serializer needs (see [Table metadata](#table-metadata)). `pagination` echoes the limit/offset actually applied, e.g. for a response `meta` block.
+
+Because the adapter produces a value instead of writing into a builder, it is **stateless**: construct one instance per table and share it across requests. To combine several queries, compose them *before* serializing with [`mergeQueries`](/guide/merging-queries) or `query.filters.and(...)`; the adapter deliberately has no accumulation API. `buildDrizzleConfig(query, options)` is the one-shot convenience form.
+
+## Table metadata
+
+The adapter needs four facts about your tables that a `Query` cannot carry, and each one changes what a *correct* drizzle filter looks like:
+
+| fact | what it decides |
+|---|---|
+| is the path a relation? | a relation takes a nested filter object or a presence test, never a column operator |
+| is that relation to-many? | the shape of the empty-collection arm of a complement |
+| can the column hold `null`? | whether a complement carries its `isNull` arm |
+| does it hold strings? | only string columns fold case through `ilike` |
+
+Guessing any of them produces a wrong result set rather than graceful degradation, so the adapter refuses to run without them. The datamodel is a plain object in drizzle's own vocabulary (`dataType` as on a drizzle column, relations keyed the way `defineRelations` keys them); a bare string is shorthand for `{ dataType }`:
+
+```typescript
+const metadata = defineMetadata({
+    users: {
+        columns: {
+            id: { dataType: 'number', nullable: false },
+            name: 'string',
+            address: { dataType: 'string', nullable: true },
+        },
+        relations: {
+            items: { target: 'items', many: true },
+            realm: { target: 'realms', many: false },
+        },
+    },
+    items: { /* ... */ },
+    realms: { /* ... */ },
+}, 'users');
+```
+
+An undeclared fact is treated as unknown, never guessed: an unknown nullability keeps the complement's null arm (semantically safe either way), an unknown data type keeps the case fold.
+
+## Parameter mapping
+
+| Query parameter | findMany config key |
+|---|---|
+| `filters`    | `where` |
+| `fields`     | `columns` |
+| `relations`  | `with` (nested `columns` when fields are picked) |
+| `sort`       | `orderBy` (one object, key order carries the priority) |
+| `pagination` | `limit` / `offset` |
+
+Unlike Prisma's `select`/`include`, drizzle keeps scalar selection (`columns`) and relation hydration (`with`) in separate keys that compose at every level. An explicitly included relation without direct picks is hydrated whole; a per-relation fieldset (direct `relation.field` picks) narrows it to exactly those columns, matching the projection contract of [@rapiq/adapter-memory](/packages/adapter-memory) ([#847](https://github.com/tada5hi/rapiq/issues/847)). Picks belonging to a deeper relation never narrow the traversed prefix, and a level reached only to project deeper emits `columns: {}` (no scalars of its own).
+
+Every column a [field visibility gate](/guide/schemas#condition-verdicts) reads is force-projected into `columns` (the gates themselves are enforced post-fetch via `@rapiq/adapter-memory`'s `applyFieldConditions`, exactly as with the SQL backends). Those operand entries never narrow an include: behind a pick-free whole relation the hydration covers them anyway.
+
+```typescript
+// fields: ['id', 'realm.name']
+{ columns: { id: true }, with: { realm: { columns: { name: true } } } }
+
+// fields: ['id'], relations: ['realm']
+{ columns: { id: true }, with: { realm: true } }
+
+// relations: ['items', 'items.realm']
+{ with: { items: { with: { realm: true } } } }
+```
+
+An unsatisfiable condition (e.g. `in([])`) has no dialect-free false literal in the filter object (drizzle strips an empty `OR` group instead of failing the row set), so it is expressed through the config: `limit: 0` returns no rows on every dialect, and a caller-owned baseline cannot widen it.
+
+## Preserving an application-owned predicate
+
+Rapiq filters **narrow** a query, they never replace it. Hand the adapter a baseline config and the client's conditions are conjoined with your tenant or authorization scope:
+
+```typescript
+const { config } = adapter.execute(query, {
+    base: { where: { realm_id: realmId } },
+});
+
+// where: { AND: [ { realm_id: ... }, { ...client filters } ] }
+```
+
+An overriding `columns` replaces the baseline projection (a caller-owned projection is never widened), produced `with` entries join baseline ones, and `orderBy`/`limit`/`offset` follow the override. The merge rules are exported as `mergeConfig(base, override)` for use outside the adapter.
+
+## Negation
+
+rapiq's negated operators (`ne`, `nin`, `notContains`, ...) and `not(...)` groups are the **exact null-inclusive complement** of their positive twin: they match precisely the records the positive form does not. Drizzle renders `NOT` as plain SQL `NOT (...)`, which follows three-valued logic and silently drops rows whose column is `NULL`.
+
+The adapter therefore never applies drizzle's `NOT` to a user condition. It pushes negation down to the leaves (De Morgan, via `@rapiq/core`'s `distributeNegation`) and renders each complement itself; `isNull`/`isNotNull` make every arm expressible in the filter object:
+
+```typescript
+// ne('address', 'Mordor')
+{ OR: [ { address: { notIlike: 'Mordor' } }, { address: { isNull: true } } ] }
+
+// ne('realm.name', 'master'): realm is an optional to-one relation
+{ OR: [
+    { realm: { name: { notIlike: 'master' } } },
+    { NOT: { realm: true } },      // ...or there is no realm at all
+] }
+```
+
+The one emitted `NOT` negates a relation **presence test** (`{ realm: true }`), which compiles to `EXISTS` and is two-valued by construction. When metadata proves a column non-nullable the null arm is dropped, because no null can exist there. The result set is identical to `@rapiq/adapter-sql`, `@rapiq/adapter-typeorm`, `@rapiq/adapter-prisma` and `@rapiq/adapter-memory`; the complement law is pinned by the engine-backed parity suite.
+
+**Same-element binding holds.** A relation filter object is a single correlated `EXISTS` scope in drizzle, so conditions sharing a to-many path are factored into ONE object and bind to the same related record, exactly like the per-join-row evaluation of the SQL backends:
+
+```typescript
+// and(eq('items.title', 'book'), eq('items.color', 'red'))
+{ items: { AND: [
+    { title: { ilike: 'book' } },
+    { color: { ilike: 'red' } },
+] } }
+```
+
+A record whose elements satisfy the two conditions only separately does not match, on any backend. Trees mixing root and relation conditions are expanded distributively first (bounded; a tree beyond the bound fails typed instead of degrading), and every quantifier gains a `NOT: { relation: true }` empty-collection arm exactly when its interior holds at the all-null binding an empty collection contributes. [`elemMatch`](/guide/filters#elemmatch) remains the explicit same-element construct and maps onto the same single scope.
+
+## Case sensitivity
+
+String comparison is [case-insensitive by default](/guide/filters#case-sensitivity) across all rapiq backends. Drizzle has no `mode: 'insensitive'`; the fold is expressed through operators, so the adapter takes a provider:
+
+```typescript
+new DrizzleAdapter({ provider: 'mysql', metadata });
+```
+
+| provider | behavior |
+|---|---|
+| `pg` | anchored operators use `ilike`; an insensitive equality/membership lowers to `ilike` with a fully escaped operand |
+| `mysql` | plain operators: the default `*_ci` collation already compares case-insensitively |
+| `sqlite` | `like` is ASCII-case-insensitive, `eq`/`in` are **not**: a documented limitation |
+
+`provider` is required, and an unrecognized name throws rather than falling back: emitting `ilike` on a dialect without it breaks every case-insensitive filter, which is too sharp an edge to guess at.
+
+Because the adapter builds the LIKE operand itself, a lowered equality escapes `%`, `_` and `\` first: `eq('code', '50%')` matches exactly the literal string, never a wildcard pattern. (The Prisma adapter needs a wildcard veto here because Prisma passes the operand through verbatim; this adapter does not.) An insensitive membership decomposes into `ilike` arms per string member, keeping non-string members an exact `in`.
+
+Two boundaries remain. A non-string column never folds. And on dialects without a default LIKE escape character (sqlite), an anchored operator whose text contains a literal `%` or `_` cannot be matched exactly: the adapter fails typed instead of silently widening the match.
+
+Opt individual fields out through the schema:
+
+```typescript
+defineSchema<User>({
+    filters: { allowed: ['id', 'token'], caseSensitive: ['token'] },
+});
+```
+
+## Limitations
+
+Operators without a drizzle filter equivalent raise a typed `AdapterError` (`FEATURE_UNSUPPORTED`) instead of being approximated:
+
+- `regex`: the filter object exposes no regular-expression operator
+- `mod`: no modulo filter
+- `size`: no array-length filter
+- `elemMatch` on a scalar array and the `$this` element marker: only to-many *relations* have addressable elements
+- **ordering by a relation path**: the relational API orders the root by its own columns only; an undocumented nested shape could be silently ignored, and loud beats silent
+
+`exists()` on a to-many relation is constantly true: it asks whether a *value is present*, and a collection is possibly empty, never absent. That matches [@rapiq/adapter-memory](/packages/adapter-memory).
+
+## Verification
+
+The default test suite already executes every emitted config through a real drizzle engine: in-memory SQLite via `better-sqlite3`, no codegen, no server. `npm run test:db` replays the same parity matrix against PostgreSQL when `DB_TYPE=postgres` names a live server (CI runs it), which is the only place `ilike` exists and the case contract can be measured. Every condition is cross-checked against [@rapiq/adapter-memory](/packages/adapter-memory); the dialect-specific claims on this page are measurements from that suite rather than assumptions.
+
+## Documentation
+
+- [Filters](/guide/filters): operator reference and case semantics
+- [Executing Queries](/guide/executing-queries): the adapter surface shared by all backends

--- a/packages/docs/packages/index.md
+++ b/packages/docs/packages/index.md
@@ -14,6 +14,7 @@ rapiq is a family of small packages around one shared data structure — the [`Q
 | [@rapiq/adapter-sql](/packages/adapter-sql) | Dialect-agnostic SQL adapter (pg, mysql, sqlite, mssql, oracle presets) |
 | [@rapiq/adapter-typeorm](/packages/adapter-typeorm) | Applies a `Query` to a TypeORM `SelectQueryBuilder` |
 | [@rapiq/adapter-prisma](/packages/adapter-prisma) | Serializes a `Query` into a Prisma argument object |
+| [@rapiq/adapter-drizzle](/packages/adapter-drizzle) | Serializes a `Query` into a Drizzle relational query config |
 | [@rapiq/adapter-memory](/packages/adapter-memory) | Evaluates a `Query` against in-memory objects & arrays |
 
 ## Which packages do I need?

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,7 @@
         "packages/adapter-sql": { "component": "adapter-sql" },
         "packages/adapter-typeorm": { "component": "adapter-typeorm" },
         "packages/adapter-prisma": { "component": "adapter-prisma" },
+        "packages/adapter-drizzle": { "component": "adapter-drizzle" },
         "packages/adapter-memory": { "component": "adapter-memory" }
     },
     "plugins": [
@@ -35,6 +36,7 @@
                 "adapter-sql",
                 "adapter-typeorm",
                 "adapter-prisma",
+                "adapter-drizzle",
                 "adapter-memory"
             ]
         }


### PR DESCRIPTION
## What

The second args-object ORM adapter (plan 023, target 2 after prisma): `@rapiq/adapter-drizzle` serializes a parsed `Query` into a **drizzle relational queries v2** `findMany` config object (`{ where, columns, with, orderBy, limit, offset }`) for drizzle-orm v1 (`1.0.0-rc.4`). A pure serializer: nothing is mutated, `drizzle-orm` is a devDependency only (engine tests), the package peer-depends on `@rapiq/core` alone.

## Semantics

Reuses the pipeline the prisma adapter settled: `planCondition`, core `distributeNegation`, same-element factoring, leaf-literal table. Drizzle spellings were settled by **engine measurement**, not docs reading:

- A relation-filter object compiles to ONE correlated `EXISTS` scope, so same-path conjuncts factor into a single nested object and bind to the same related record, matching sql/typeorm/memory/prisma. Presence is `{ rel: true }`, absence `NOT: { rel: true }` (the only emitted `NOT`: EXISTS is two-valued); every quantifier and to-one hop gains its absence arm exactly when the interior holds at the all-null binding.
- `isNull`/`isNotNull` exist in the filter object, so complement null arms are expressible directly (nullability-gated via metadata).
- Drizzle **strips** an empty `OR: []` group (measured: it matches everything), so an unsatisfiable root is expressed as `limit: 0`, never `{ OR: [] }`.
- Case contract: the `pg` preset lowers foldable equality/membership/anchored operators to `ilike`/`notIlike` with **adapter-escaped** operands (no wildcard veto needed, unlike prisma: the adapter builds the pattern); `in` decomposes into per-string `ilike` arms. mysql is collation-CI, sqlite is `LIKE`-only (`eq`/`in` stay exact, documented), and sqlite's missing default LIKE escape makes a literal `%`/`_` anchored operand a typed error instead of a silent widening.
- `metadata` + `provider` are required options (the settled prisma rule); `defineMetadata` takes a hand-written drizzle-vocabulary datamodel. Derivation from live `defineRelations` handles is a follow-up, same staging as the typeorm/prisma schema derivation.
- `regex`/`mod`/`size`/ITSELF/`elemMatch` on scalar arrays or to-one relations, and relation-path `orderBy`, fail typed.

Fields/relations follow the #847/#830 contract: `columns` + `with` compose orthogonally, per-relation fieldsets narrow includes, gate operands are force-projected without narrowing, and a traversal-only level emits `columns: {}`.

## Verification

- 118 specs in the default suite, including the full complement/same-element parity matrix executed by a **real engine** (in-memory better-sqlite3, no codegen, no server) and cross-checked against `@rapiq/adapter-memory`.
- `test:db` replays the matrix plus the case contract (fold, in-decomposition, escaped-wildcard exactness, opt-out) against PostgreSQL: 41 specs, wired into the `tests-db` CI job. Verified locally against a postgres:18 container.
- Monorepo build, lint and all 10 projects' tests green.

## Wiring

release-please config/manifest, tests-db CI step, docs site page (+ sidebar, package map, installation, executing-queries), root README rows, .agents guides and a new `.agents/references/drizzle.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the beta `@rapiq/adapter-drizzle` package for converting queries into Drizzle relational query configurations.
  * Supports filtering, sorting, pagination, field selection, nested relations, provider-specific behavior, and baseline configuration merging.
  * Added PostgreSQL, MySQL, and SQLite provider support.

* **Documentation**
  * Added installation, usage, package, and architecture documentation for the Drizzle adapter.

* **Tests**
  * Added comprehensive SQLite and PostgreSQL coverage for filtering, relations, pagination, projections, sorting, and cross-adapter parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->