### PR TITLE
fix(adapters): cross-backend drift fixes from the architecture audit

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -60,6 +60,8 @@ A `Schema<RECORD>` declares what a client *may* request per parameter (`allowed`
 
 `@rapiq/adapter-sql` is database-agnostic; per-database behavior is injected via `DialectOptions` callbacks (`escapeField`, `paramPlaceholder`, `regexp`). Presets live in `packages/adapter-sql/src/dialect/`. Regex strings pass through unchanged for the database engine to interpret and validate; JavaScript `RegExp` values contribute their `source` and `ignoreCase` flag.
 
+Preset resolution follows one fleet-wide invariant (audited 2026-08-02, do not re-flag): **user-supplied names throw typed everywhere; derived facts fall back documented**. prisma/drizzle validate a user-supplied provider name (a typo must throw, it would break every case-insensitive filter), while typeorm's `resolveQueryDialect` derives the dialect from the query builder's driver — the user supplied nothing, an exotic driver must still work, and the pg last-resort default is documented.
+
 ## Key Abstractions
 
 ### Query AST (core)
@@ -92,6 +94,8 @@ interface IFilterVisitor {
     // ...
 }
 ```
+
+The **filters contract of record** is `ICondition → planCondition`: every backend consumes the operator-semantics plan, interpreter-style via `interpretPlan` (sql/typeorm/memory) or serializer-style via `distributeNegation` + a pure renderer (prisma/drizzle). The per-operator `IFilterVisitor` methods are a legacy fast-path surface — sql and memory hop through two-line shims onto the plan path. Removal is sanctioned but unhurried; do not build new backends on it.
 
 ### Schema definition (core)
 
@@ -166,6 +170,8 @@ type DialectOptions = {
 ```
 
 `@rapiq/adapter-typeorm`: `TypeormAdapter` mirrors the SQL adapter but mutates a TypeORM query builder. The builder is bound at construction (`new TypeormAdapter({ queryBuilder: qb })`); `adapter.execute(query)` then walks the query and applies the accumulated state to that builder in a single call. Filters use `andWhere`, preserving application-owned tenant/auth predicates already present on the builder. Relation aliases come from @rapiq/adapter-sql's shared, injective length-prefixed `buildRelationAlias` derivation; fields, filters, sorts and joins must all use that same function.
+
+`@rapiq/adapter-sql`'s exported base classes — INCLUDING their protected members — are an intended extension surface, consumed by `@rapiq/adapter-typeorm`'s subclasses (typeorm even owns `executed`, declared in sql's types). The two packages version in lockstep through the linked release group, but changes to that surface are semver-relevant for external subclassers.
 
 `@rapiq/adapter-prisma`: pure IR **serializer**. `PrismaAdapter.execute(query)` is stateless (one
 instance per app, not per request; composition happens BEFORE serialization via

--- a/packages/adapter-drizzle/src/provider/module.ts
+++ b/packages/adapter-drizzle/src/provider/module.ts
@@ -25,9 +25,10 @@ const ALIASES : Record<string, `${Provider}`> = {
 export function resolveProvider(name: string) : ProviderOptions | undefined {
     const normalized = name.toLowerCase();
 
-    // own-property lookups: an inherited name like `valueOf` must
-    // answer "unknown" instead of resolving to an Object.prototype
-    // member that then poses as a preset.
+    // own-property lookups: an inherited name that survives the
+    // lowercasing (`constructor`, `__proto__`) must answer "unknown"
+    // instead of resolving to an Object.prototype member that then
+    // poses as a preset.
     const key = Object.hasOwn(ALIASES, normalized) ?
         ALIASES[normalized] as `${Provider}` :
         normalized as `${Provider}`;

--- a/packages/adapter-drizzle/test/data/matrix.ts
+++ b/packages/adapter-drizzle/test/data/matrix.ts
@@ -13,9 +13,11 @@ import {
     endsWith,
     eq,
     exists,
+    gt,
     gte,
     inArray,
     lt,
+    lte,
     ne,
     nin,
     not,
@@ -47,8 +49,17 @@ export const complementPairs : [string, Condition, Condition][] = [
     ['startsWith/notStartsWith', startsWith('address', 'Hog'), notStartsWith('address', 'Hog')],
     ['endsWith/notEndsWith', endsWith('address', 'arts'), notEndsWith('address', 'arts')],
     ['exists true/false', exists('address'), exists('address', false)],
+    // ordering has no negative twins; not() is the null-inclusive
+    // complement (dual operator OR null), matching the prisma matrix.
+    ['gte/not(gte)', gte('age', 33), not(gte('age', 33))],
+    ['gt/not(gt)', gt('age', 18), not(gt('age', 18))],
+    ['lte/not(lte)', lte('age', 33), not(lte('age', 33))],
     ['eq/ne (to-one relation)', eq('realm.name', 'master'), ne('realm.name', 'master')],
+    ['eq/ne (to-one null column)', eq('realm.description', null), ne('realm.description', null)],
     ['eq/ne (to-one presence)', exists('realm'), exists('realm', false)],
+    // a collection is never absent: the positive arm is constantly
+    // true, the negative an impossible root (limit: 0).
+    ['exists (to-many presence)', exists('items'), exists('items', false)],
 ];
 
 // De Morgan push-down has to hold for whole trees, not just leaves.
@@ -79,6 +90,7 @@ export const collections : [string, Condition][] = [
     ['contains', contains('items.title', 'oo')],
     ['notContains', notContains('items.title', 'oo')],
     ['elemMatch', elemMatch('items', and(eq('title', 'book'), eq('color', 'red')))],
+    ['elemMatch (null interior)', elemMatch('items', eq('color', null))],
     ['not(elemMatch)', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
 ];
 

--- a/packages/adapter-drizzle/test/unit/engine.spec.ts
+++ b/packages/adapter-drizzle/test/unit/engine.spec.ts
@@ -19,6 +19,7 @@ import {
     Sorts,
     inArray,
 } from '@rapiq/core';
+import { applyQuery } from '@rapiq/adapter-memory';
 import { DrizzleAdapter } from '../../src';
 import { createAdapterOptions } from '../data';
 import { records } from '../data/records';
@@ -99,5 +100,20 @@ describe('engine: selection and ordering', () => {
         const rows = await run(new Query({ filters: new Filters(FilterCompoundOperator.AND, [inArray('id', [])]) }));
 
         expect(rows).toEqual([]);
+    });
+
+    it('should agree with the memory adapter on an explicit limit of 0', async () => {
+        // limit: 0 is a value, not absence, across the whole fleet;
+        // the impossible-root encoding depends on this reading.
+        const query = new Query({
+            fields: new Fields([new Field('id')]),
+            pagination: new Pagination(0),
+        });
+
+        const rows = await run(query);
+        const { data } = applyQuery(query, records);
+
+        expect(rows).toEqual([]);
+        expect(rows).toEqual(data);
     });
 });

--- a/packages/adapter-drizzle/test/unit/enrollment.spec.ts
+++ b/packages/adapter-drizzle/test/unit/enrollment.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition } from '@rapiq/core';
+import { FILTER_OPERATOR_SEMANTICS, isFilter, isFilters } from '@rapiq/core';
+import {
+    casePairs,
+    collections,
+    complementPairs,
+    compounds,
+    sameElement,
+} from '../data/matrix';
+
+/**
+ * Operators the serializer refuses typed (see the
+ * unsupported-operators specs); no engine parity row can exist for
+ * them. A new semantics-table member must land in exactly one of the
+ * two lists: an engine matrix row, or this set plus its typed spec.
+ */
+const UNSUPPORTED = new Set(['regex', 'mod', 'size']);
+
+function collect(condition: ICondition, output: Set<string>) : void {
+    if (isFilters(condition)) {
+        condition.value.forEach((child) => collect(child as ICondition, output));
+        return;
+    }
+
+    if (isFilter(condition)) {
+        output.add(condition.operator);
+
+        // the interior is a condition of its own
+        if (condition.operator === 'elemMatch') {
+            collect(condition.value as ICondition, output);
+        }
+    }
+}
+
+/**
+ * The enrollment tripwire the typeorm parity suite established: a
+ * new member of the core semantics table fails here until it is
+ * enrolled in the engine parity matrix (or documented unsupported),
+ * instead of shipping unmeasured.
+ */
+describe('operator enrollment', () => {
+    it('should enroll every operator of the semantics table', () => {
+        const covered = new Set<string>();
+
+        [...complementPairs, ...casePairs].forEach(([, positive, negative]) => {
+            collect(positive, covered);
+            collect(negative, covered);
+        });
+
+        [...compounds, ...collections, ...sameElement].forEach(([, condition]) => {
+            collect(condition, covered);
+        });
+
+        for (const operator of Object.keys(FILTER_OPERATOR_SEMANTICS)) {
+            if (UNSUPPORTED.has(operator)) {
+                continue;
+            }
+
+            expect(covered, `operator ${operator} has no parity case`)
+                .toContain(operator);
+        }
+    });
+});

--- a/packages/adapter-drizzle/test/unit/filters.spec.ts
+++ b/packages/adapter-drizzle/test/unit/filters.spec.ts
@@ -286,8 +286,12 @@ describe('src/adapter/where.ts', () => {
         });
 
         it('should reject an inherited object member as a dialect name', () => {
-            // `valueOf` resolves through Object.prototype on a naive
-            // lookup and would pose as a preset.
+            // `constructor` survives the lowercased lookup and would
+            // resolve through Object.prototype on a naive access;
+            // `valueOf` pins the camel-case spelling the normalization
+            // already blocks.
+            expect(() => serialize(eq('age', 1), { provider: 'constructor' }))
+                .toThrow(AdapterError);
             expect(() => serialize(eq('age', 1), { provider: 'valueOf' }))
                 .toThrow(AdapterError);
         });

--- a/packages/adapter-memory/src/parameter/pagination/module.ts
+++ b/packages/adapter-memory/src/parameter/pagination/module.ts
@@ -19,7 +19,7 @@ export class PaginationVisitor implements IPaginationVisitor<Slicer> {
                 output = output.slice(offset);
             }
 
-            if (limit && limit > 0) {
+            if (typeof limit === 'number' && limit >= 0) {
                 output = output.slice(0, limit);
             }
 

--- a/packages/adapter-memory/test/unit/pagination.spec.ts
+++ b/packages/adapter-memory/test/unit/pagination.spec.ts
@@ -21,10 +21,13 @@ describe('pagination', () => {
         expect(compilePagination(new Pagination())(data)).toEqual(data);
     });
 
-    it('should not apply falsy values', () => {
-        // parity with the typeorm adapter, which applies
-        // take/skip only for truthy values.
-        expect(compilePagination(new Pagination(0, 0))(data)).toEqual(data);
+    it('should treat an explicit limit of 0 as a value, not absence', () => {
+        // fleet semantics: typeorm takes 0 rows, prisma emits take: 0 and
+        // drizzle limit: 0 (both engines return no rows), and drizzle's
+        // impossible-root encoding relies on limit: 0 meaning "no rows".
+        expect(compilePagination(new Pagination(0))(data)).toEqual([]);
+        expect(compilePagination(new Pagination(0, 2))(data)).toEqual([]);
+        expect(compilePagination(new Pagination(undefined))(data)).toEqual(data);
     });
 
     it('should ignore negative values', () => {

--- a/packages/adapter-prisma/src/adapter/module.ts
+++ b/packages/adapter-prisma/src/adapter/module.ts
@@ -6,7 +6,7 @@
  */
 
 import type { IQuery, IQueryVisitor } from '@rapiq/core';
-import { AdapterError, ErrorCode } from '@rapiq/core';
+import { AdapterError, ErrorCode, hasFieldConditions } from '@rapiq/core';
 import type { IMetadata } from '../metadata';
 import { defineMetadata, resolveDelegateClient, resolveModelName } from '../metadata';
 import type { ProviderOptions } from '../provider';
@@ -214,6 +214,21 @@ export class PrismaAdapter<
         query: IQuery,
         options: ExecuteOptions<ARGS> = {},
     ) : Promise<T[]> {
+        if (hasFieldConditions(query.fields)) {
+            // a field visibility gate (see `IField.condition`) is
+            // enforced post-fetch; returning the delegate's rows raw
+            // would ship the gated columns unredacted. The runner
+            // refuses instead of failing open: serialize with
+            // `execute()` and pipe the fetched rows through
+            // `@rapiq/adapter-memory`'s `applyFieldConditions`.
+            throw new AdapterError({
+                message: 'The query carries field conditions, which findMany() cannot ' +
+                    'enforce; use execute() and apply the conditions to the fetched ' +
+                    'rows (e.g. applyFieldConditions of @rapiq/adapter-memory).',
+                code: ErrorCode.FEATURE_UNSUPPORTED,
+            });
+        }
+
         const { args } = this.execute(query, options);
 
         return this.delegate().findMany(args);

--- a/packages/adapter-prisma/src/adapter/where.ts
+++ b/packages/adapter-prisma/src/adapter/where.ts
@@ -16,6 +16,7 @@ import type {
 } from '@rapiq/core';
 import {
     AdapterError,
+    ITSELF,
     distributeNegation,
     planCondition,
 } from '@rapiq/core';
@@ -208,8 +209,17 @@ export class WhereRenderer {
                 if (plan.negated) {
                     // a residual wrapper only ever encloses kinds
                     // without a complement form; rendering the child
-                    // raises the matching typed error.
-                    return this.render(plan.children[0] as ConditionPlan, ctx);
+                    // raises the matching typed error. Any other kind
+                    // here means the distribution invariant broke:
+                    // failing typed beats silently emitting the
+                    // positive (inverted) form.
+                    const child = plan.children[0] as ConditionPlan;
+
+                    if (child.kind !== 'mod' && child.kind !== 'size') {
+                        throw AdapterError.featureUnsupported('filters:negation');
+                    }
+
+                    return this.render(child, ctx);
                 }
 
                 if (plan.operator === 'or') {
@@ -529,6 +539,12 @@ export class WhereRenderer {
         const segments = relative.split('.');
         const name = segments.pop() as string;
 
+        if (name === ITSELF) {
+            // the bound element itself is not a column; prisma has
+            // no scalar-array element filter to address it with.
+            throw AdapterError.featureUnsupported('filters:itself');
+        }
+
         return this.wrapToOne(
             segments,
             this.renderLiteral(leaf, name, absolute),
@@ -604,7 +620,13 @@ export class WhereRenderer {
     protected renderCompare(plan: ComparePlan, name: string, absolute: string) : Result {
         if (plan.op !== 'eq') {
             // ordering never carries negation after distribution: its
-            // complement became the dual operator or a null check.
+            // complement became the dual operator or a null check. An
+            // unnoticed break of that invariant must fail typed, not
+            // emit the positive (inverted) form.
+            if (plan.negated) {
+                throw AdapterError.featureUnsupported('filters:negation');
+            }
+
             return { [name]: { [plan.op]: plan.value } };
         }
 

--- a/packages/adapter-prisma/src/provider/module.ts
+++ b/packages/adapter-prisma/src/provider/module.ts
@@ -26,7 +26,14 @@ const ALIASES : Record<string, `${Provider}`> = {
 export function resolveProvider(name: string) : ProviderOptions | undefined {
     const normalized = name.toLowerCase();
 
-    return PROVIDERS[ALIASES[normalized] ?? normalized as `${Provider}`];
+    // own-property lookups: an inherited name like `valueOf` must
+    // answer "unknown" instead of resolving to an Object.prototype
+    // member that then poses as a preset.
+    const key = Object.hasOwn(ALIASES, normalized) ?
+        ALIASES[normalized] as `${Provider}` :
+        normalized as `${Provider}`;
+
+    return Object.hasOwn(PROVIDERS, key) ? PROVIDERS[key] : undefined;
 }
 
 /**

--- a/packages/adapter-prisma/src/provider/module.ts
+++ b/packages/adapter-prisma/src/provider/module.ts
@@ -26,9 +26,10 @@ const ALIASES : Record<string, `${Provider}`> = {
 export function resolveProvider(name: string) : ProviderOptions | undefined {
     const normalized = name.toLowerCase();
 
-    // own-property lookups: an inherited name like `valueOf` must
-    // answer "unknown" instead of resolving to an Object.prototype
-    // member that then poses as a preset.
+    // own-property lookups: an inherited name that survives the
+    // lowercasing (`constructor`, `__proto__`) must answer "unknown"
+    // instead of resolving to an Object.prototype member that then
+    // poses as a preset.
     const key = Object.hasOwn(ALIASES, normalized) ?
         ALIASES[normalized] as `${Provider}` :
         normalized as `${Provider}`;

--- a/packages/adapter-prisma/test/data/matrix.ts
+++ b/packages/adapter-prisma/test/data/matrix.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Condition } from '@rapiq/core';
+import {
+    and,
+    contains,
+    elemMatch,
+    endsWith,
+    eq,
+    exists,
+    gt,
+    gte,
+    inArray,
+    lt,
+    lte,
+    ne,
+    nin,
+    not,
+    notContains,
+    notEndsWith,
+    notStartsWith,
+    or,
+    startsWith,
+} from '@rapiq/core';
+
+/**
+ * The engine parity matrix, replayed by `engine.db.spec.ts` against a
+ * real query engine (sqlite by default, postgres under
+ * `DB_TYPE=postgres`); the enrollment tripwire holds it against the
+ * core semantics table.
+ *
+ * Case-matched literals throughout: SQLite compares `equals`
+ * case-sensitively and has no `mode`, which the engine suite's
+ * dedicated case-contract spec measures instead of assuming.
+ */
+export const parityConditions : [string, Condition][] = [
+    ['eq', eq('address', 'Hogwarts')],
+    ['ne', ne('address', 'Hogwarts')],
+    ['eq (null)', eq('address', null)],
+    ['ne (null)', ne('address', null)],
+    ['exists', exists('address')],
+    ['exists false', exists('address', false)],
+    ['in', inArray('address', ['Hogwarts', 'Mordor'])],
+    ['nin', nin('address', ['Hogwarts', 'Mordor'])],
+    ['in (null member)', inArray('address', ['Hogwarts', null])],
+    ['nin (null member)', nin('address', ['Hogwarts', null])],
+    ['in (empty)', inArray('address', [])],
+    ['nin (empty)', nin('address', [])],
+    ['gte', gte('age', 33)],
+    ['not(gte)', not(gte('age', 33))],
+    ['gt', gt('age', 18)],
+    ['not(gt)', not(gt('age', 18))],
+    ['lt', lt('age', 33)],
+    ['not(lt)', not(lt('age', 33))],
+    ['lte', lte('age', 33)],
+    ['not(lte)', not(lte('age', 33))],
+    ['contains', contains('address', 'ord')],
+    ['notContains', notContains('address', 'ord')],
+    ['startsWith', startsWith('address', 'Hog')],
+    ['notStartsWith', notStartsWith('address', 'Hog')],
+    ['endsWith', endsWith('address', 'arts')],
+    ['notEndsWith', notEndsWith('address', 'arts')],
+
+    ['to-one eq', eq('realm.name', 'master')],
+    ['to-one ne', ne('realm.name', 'master')],
+    ['to-one null column', eq('realm.description', null)],
+    ['to-one null column (negated)', ne('realm.description', null)],
+    ['to-one relation exists', exists('realm')],
+    ['to-one relation absent', exists('realm', false)],
+
+    ['to-many eq', eq('items.title', 'book')],
+    ['to-many ne', ne('items.title', 'book')],
+    ['to-many not(eq)', not(eq('items.title', 'book'))],
+    ['to-many null column', eq('items.color', null)],
+    ['to-many null column (negated)', ne('items.color', null)],
+    ['to-many in', inArray('items.color', ['red', null])],
+    ['to-many nin', nin('items.color', ['red', null])],
+    ['to-many contains', contains('items.title', 'oo')],
+    ['to-many notContains', notContains('items.title', 'oo')],
+    ['to-many relation exists', exists('items')],
+    ['to-many relation absent', exists('items', false)],
+
+    ['same-element and', and(eq('items.title', 'book'), eq('items.color', 'red'))],
+    ['same-element or', or(eq('items.title', 'ring'), eq('items.color', 'silver'))],
+    ['same-element negated leaf', and(ne('items.title', 'ring'), eq('items.color', 'red'))],
+    ['same-element mixed nesting', and(eq('items.title', 'book'), or(eq('items.color', 'red'), gte('age', 21)))],
+    ['same-element negated group', not(and(eq('items.title', 'book'), eq('items.color', 'red')))],
+
+    ['elemMatch', elemMatch('items', and(eq('title', 'book'), eq('color', 'red')))],
+    ['elemMatch (null interior)', elemMatch('items', eq('color', null))],
+    ['not(elemMatch)', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
+
+    ['not(and)', not(and(eq('address', 'Hogwarts'), gte('age', 18)))],
+    ['not(or)', not(or(eq('address', 'Hogwarts'), eq('address', 'Mordor')))],
+    ['nested', not(or(and(eq('address', 'Mordor'), lt('age', 40)), exists('address', false)))],
+    ['relation in a negated group', not(and(eq('realm.name', 'master'), gte('age', 18)))],
+];

--- a/packages/adapter-prisma/test/unit/engine.db.spec.ts
+++ b/packages/adapter-prisma/test/unit/engine.db.spec.ts
@@ -18,6 +18,7 @@ import {
     and,
     eq,
     gte,
+    inArray,
     ne,
     not,
 } from '@rapiq/core';

--- a/packages/adapter-prisma/test/unit/engine.db.spec.ts
+++ b/packages/adapter-prisma/test/unit/engine.db.spec.ts
@@ -16,22 +16,10 @@ import {
     SortDirection,
     Sorts,
     and,
-    contains,
-    elemMatch,
-    endsWith,
     eq,
-    exists,
     gte,
-    inArray,
-    lt,
     ne,
-    nin,
     not,
-    notContains,
-    notEndsWith,
-    notStartsWith,
-    or,
-    startsWith,
 } from '@rapiq/core';
 import { compileFilters } from '@rapiq/adapter-memory';
 import { PrismaAdapter, defineMetadata } from '../../src';
@@ -39,6 +27,7 @@ import type { TestDatabase } from '../data/client';
 import { createDatabase } from '../data/client';
 import { datamodel } from '../data/datamodel';
 import { selectRows } from '../data/evaluate';
+import { parityConditions } from '../data/matrix';
 import type { User } from '../data/type';
 
 /**
@@ -174,67 +163,7 @@ describe('engine parity (prisma vs memory)', () => {
         .map((record) => record.id)
         .sort((a, b) => a - b);
 
-    // Case-matched literals throughout: SQLite compares `equals`
-    // case-sensitively and has no `mode`, which the dedicated test
-    // below measures instead of assuming.
-    const conditions : [string, Condition][] = [
-        ['eq', eq('address', 'Hogwarts')],
-        ['ne', ne('address', 'Hogwarts')],
-        ['eq (null)', eq('address', null)],
-        ['ne (null)', ne('address', null)],
-        ['exists', exists('address')],
-        ['exists false', exists('address', false)],
-        ['in', inArray('address', ['Hogwarts', 'Mordor'])],
-        ['nin', nin('address', ['Hogwarts', 'Mordor'])],
-        ['in (null member)', inArray('address', ['Hogwarts', null])],
-        ['nin (null member)', nin('address', ['Hogwarts', null])],
-        ['in (empty)', inArray('address', [])],
-        ['nin (empty)', nin('address', [])],
-        ['gte', gte('age', 33)],
-        ['not(gte)', not(gte('age', 33))],
-        ['contains', contains('address', 'ord')],
-        ['notContains', notContains('address', 'ord')],
-        ['startsWith', startsWith('address', 'Hog')],
-        ['notStartsWith', notStartsWith('address', 'Hog')],
-        ['endsWith', endsWith('address', 'arts')],
-        ['notEndsWith', notEndsWith('address', 'arts')],
-
-        ['to-one eq', eq('realm.name', 'master')],
-        ['to-one ne', ne('realm.name', 'master')],
-        ['to-one null column', eq('realm.description', null)],
-        ['to-one null column (negated)', ne('realm.description', null)],
-        ['to-one relation exists', exists('realm')],
-        ['to-one relation absent', exists('realm', false)],
-
-        ['to-many eq', eq('items.title', 'book')],
-        ['to-many ne', ne('items.title', 'book')],
-        ['to-many not(eq)', not(eq('items.title', 'book'))],
-        ['to-many null column', eq('items.color', null)],
-        ['to-many null column (negated)', ne('items.color', null)],
-        ['to-many in', inArray('items.color', ['red', null])],
-        ['to-many nin', nin('items.color', ['red', null])],
-        ['to-many contains', contains('items.title', 'oo')],
-        ['to-many notContains', notContains('items.title', 'oo')],
-        ['to-many relation exists', exists('items')],
-        ['to-many relation absent', exists('items', false)],
-
-        ['same-element and', and(eq('items.title', 'book'), eq('items.color', 'red'))],
-        ['same-element or', or(eq('items.title', 'ring'), eq('items.color', 'silver'))],
-        ['same-element negated leaf', and(ne('items.title', 'ring'), eq('items.color', 'red'))],
-        ['same-element mixed nesting', and(eq('items.title', 'book'), or(eq('items.color', 'red'), gte('age', 21)))],
-        ['same-element negated group', not(and(eq('items.title', 'book'), eq('items.color', 'red')))],
-
-        ['elemMatch', elemMatch('items', and(eq('title', 'book'), eq('color', 'red')))],
-        ['elemMatch (null interior)', elemMatch('items', eq('color', null))],
-        ['not(elemMatch)', not(elemMatch('items', and(eq('title', 'book'), eq('color', 'red'))))],
-
-        ['not(and)', not(and(eq('address', 'Hogwarts'), gte('age', 18)))],
-        ['not(or)', not(or(eq('address', 'Hogwarts'), eq('address', 'Mordor')))],
-        ['nested', not(or(and(eq('address', 'Mordor'), lt('age', 40)), exists('address', false)))],
-        ['relation in a negated group', not(and(eq('realm.name', 'master'), gte('age', 18)))],
-    ];
-
-    conditions.forEach(([name, condition]) => {
+    parityConditions.forEach(([name, condition]) => {
         it(`should agree with the engine for ${name}`, async () => {
             const ids = await engineIds(condition);
 

--- a/packages/adapter-prisma/test/unit/enrollment.spec.ts
+++ b/packages/adapter-prisma/test/unit/enrollment.spec.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ICondition } from '@rapiq/core';
+import { FILTER_OPERATOR_SEMANTICS, isFilter, isFilters } from '@rapiq/core';
+import { parityConditions } from '../data/matrix';
+
+/**
+ * Operators the serializer refuses typed (see the
+ * unsupported-features specs); no engine parity row can exist for
+ * them. A new semantics-table member must land in exactly one of the
+ * two lists: an engine matrix row, or this set plus its typed spec.
+ */
+const UNSUPPORTED = new Set(['regex', 'mod', 'size']);
+
+function collect(condition: ICondition, output: Set<string>) : void {
+    if (isFilters(condition)) {
+        condition.value.forEach((child) => collect(child as ICondition, output));
+        return;
+    }
+
+    if (isFilter(condition)) {
+        output.add(condition.operator);
+
+        // the interior is a condition of its own
+        if (condition.operator === 'elemMatch') {
+            collect(condition.value as ICondition, output);
+        }
+    }
+}
+
+/**
+ * The enrollment tripwire the typeorm parity suite established: a
+ * new member of the core semantics table fails here until it is
+ * enrolled in the engine parity matrix (or documented unsupported),
+ * instead of shipping unmeasured.
+ */
+describe('operator enrollment', () => {
+    it('should enroll every operator of the semantics table', () => {
+        const covered = new Set<string>();
+
+        parityConditions.forEach(([, condition]) => {
+            collect(condition, covered);
+        });
+
+        for (const operator of Object.keys(FILTER_OPERATOR_SEMANTICS)) {
+            if (UNSUPPORTED.has(operator)) {
+                continue;
+            }
+
+            expect(covered, `operator ${operator} has no parity case`)
+                .toContain(operator);
+        }
+    });
+});

--- a/packages/adapter-prisma/test/unit/filters.spec.ts
+++ b/packages/adapter-prisma/test/unit/filters.spec.ts
@@ -10,6 +10,7 @@ import {
     ErrorCode,
     FilterCompoundOperator,
     Filters,
+    ITSELF,
     Query,
     and,
     contains,
@@ -321,6 +322,14 @@ describe('src/adapter/filters.ts', () => {
             ['regex', regex('first_name', '^Pe')],
             ['mod', mod('age', 2, 0)],
             ['size', size('items', 2)],
+            // the residual negation wrapper stays typed instead of
+            // silently rendering the positive form.
+            ['negated mod', not(mod('age', 2, 0))],
+            ['negated size', not(size('items', 2))],
+            // the bound element itself is not a prisma column; the
+            // gate must throw here instead of emitting a `$this` key
+            // and leaning on prisma's unknown-field error.
+            ['itself', eq(ITSELF, 'Peter')],
         ];
 
         cases.forEach(([name, condition]) => {

--- a/packages/adapter-prisma/test/unit/metadata.spec.ts
+++ b/packages/adapter-prisma/test/unit/metadata.spec.ts
@@ -79,6 +79,20 @@ describe('src/provider/module.ts', () => {
         );
     });
 
+    it('should reject an inherited object member as a provider name', () => {
+        // `valueOf` resolves through Object.prototype on a naive
+        // lookup and would pose as a preset.
+        expect(resolveProvider('valueOf')).toBeUndefined();
+        expect(resolveProvider('toString')).toBeUndefined();
+
+        expect(() => new PrismaAdapter({ provider: 'valueOf', metadata })).toThrowError(
+            expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
+        );
+        expect(() => new PrismaAdapter({ provider: 'toString', metadata })).toThrowError(
+            expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
+        );
+    });
+
     it('should accept an explicit capability preset', () => {
         expect(() => new PrismaAdapter({ provider: { caseInsensitiveMode: false }, metadata })).not.toThrow();
     });

--- a/packages/adapter-prisma/test/unit/metadata.spec.ts
+++ b/packages/adapter-prisma/test/unit/metadata.spec.ts
@@ -80,15 +80,19 @@ describe('src/provider/module.ts', () => {
     });
 
     it('should reject an inherited object member as a provider name', () => {
-        // `valueOf` resolves through Object.prototype on a naive
-        // lookup and would pose as a preset.
+        // only all-lowercase Object.prototype members (`constructor`,
+        // `__proto__`) survive the lowercasing and can reach the
+        // prototype chain on a naive lookup; the camel-case spellings
+        // pin the contract for names the normalization already blocks.
+        expect(resolveProvider('constructor')).toBeUndefined();
+        expect(resolveProvider('__proto__')).toBeUndefined();
         expect(resolveProvider('valueOf')).toBeUndefined();
         expect(resolveProvider('toString')).toBeUndefined();
 
-        expect(() => new PrismaAdapter({ provider: 'valueOf', metadata })).toThrowError(
+        expect(() => new PrismaAdapter({ provider: 'constructor', metadata })).toThrowError(
             expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
         );
-        expect(() => new PrismaAdapter({ provider: 'toString', metadata })).toThrowError(
+        expect(() => new PrismaAdapter({ provider: '__proto__', metadata })).toThrowError(
             expect.objectContaining({ code: ErrorCode.FEATURE_UNSUPPORTED }),
         );
     });

--- a/packages/adapter-prisma/test/unit/run.spec.ts
+++ b/packages/adapter-prisma/test/unit/run.spec.ts
@@ -7,6 +7,8 @@
 
 import {
     ErrorCode,
+    Field,
+    Fields,
     FilterCompoundOperator,
     Filters,
     Pagination,
@@ -112,6 +114,28 @@ describe('src/adapter/module.ts (runners)', () => {
         // promise, so a .catch() must observe the failure.
         await expect(adapter.findMany(query)).rejects.toMatchObject({ code: ErrorCode.FEATURE_UNSUPPORTED });
         await expect(adapter.count(query)).rejects.toMatchObject({ code: ErrorCode.FEATURE_UNSUPPORTED });
+    });
+
+    it('should reject typed when a field carries a visibility condition', async () => {
+        const { client, calls } = createRecordingClient();
+        const adapter = new PrismaAdapter({ model: client.user });
+
+        // the gate is enforced post-fetch; returning delegate rows raw
+        // would ship the gated column unredacted (#830 fail-open).
+        const gated = new Query({
+            fields: new Fields([
+                new Field('id'),
+                new Field('email', undefined, gte('age', 18)),
+            ]),
+        });
+
+        await expect(adapter.findMany(gated)).rejects.toMatchObject({ code: ErrorCode.FEATURE_UNSUPPORTED });
+        expect(calls.findMany).toHaveLength(0);
+
+        // execute() stays a pure serializer, and count() is safe: a
+        // gate changes column visibility, never the row set.
+        expect(adapter.execute(gated).args.select).toBeDefined();
+        await expect(adapter.count(gated)).resolves.toEqual(7);
     });
 
     it('should reject typed for a model object that cannot run', async () => {

--- a/packages/adapter-sql/src/visitor/types.ts
+++ b/packages/adapter-sql/src/visitor/types.ts
@@ -8,11 +8,12 @@
 export type VisitorOptions = {
     /**
      * Field keys whose equality comparisons (eq/ne/in/nin) stay
-     * case-sensitive instead of the case-insensitive default —
-     * e.g. identifier or token columns. Typically forwarded from
-     * a schema's `filters.caseSensitive` list.
+     * case-sensitive instead of the case-insensitive default, e.g.
+     * identifier or token columns; `true` opts every field out.
+     * Typically forwarded from a schema's `filters.caseSensitive`
+     * list.
      */
-    caseSensitive?: string[],
+    caseSensitive?: string[] | boolean,
 
     [key: string]: any;
 };

--- a/packages/adapter-sql/test/unit/interpreters/case-sensitivity.spec.ts
+++ b/packages/adapter-sql/test/unit/interpreters/case-sensitivity.spec.ts
@@ -42,6 +42,17 @@ describe('equality case sensitivity', () => {
         ]);
     });
 
+    it('keeps every field exact for the blanket caseSensitive opt-out', () => {
+        const adapter = createAdapter({ ...pg });
+        const visitor = new FiltersVisitor(adapter, { caseSensitive: true });
+        new Filter('eq', 'name', 'John').accept(visitor);
+
+        expect(adapter.getQueryAndParameters()).toEqual([
+            '"name" = $1',
+            ['John'],
+        ]);
+    });
+
     it('keeps caseSensitive in-lists exact', () => {
         const adapter = createAdapter({ ...pg });
         const visitor = new FiltersVisitor(adapter, { caseSensitive: ['id'] });

--- a/packages/adapter-typeorm/test/unit/filters.spec.ts
+++ b/packages/adapter-typeorm/test/unit/filters.spec.ts
@@ -414,6 +414,25 @@ describe('src/filters', () => {
         expect(data.length).toEqual(0);
     });
 
+    it('should keep every field exact for the blanket caseSensitive opt-out', async () => {
+        const repository = dataSource.getRepository(User);
+        const queryBuilder = repository.createQueryBuilder('user');
+
+        const adapter = new TypeormAdapter({ queryBuilder });
+        adapter.execute(
+            new Query({
+                filters: new Filters(FilterCompoundOperator.AND, [
+                    new Filter(FilterFieldOperator.EQUAL, 'first_name', 'ASTON'),
+                ]),
+            }),
+            { visitor: { caseSensitive: true } },
+        );
+
+        const data = await queryBuilder.getMany();
+
+        expect(data.length).toEqual(0);
+    });
+
     it('should case-fold only string-typed columns', () => {
         const repository = dataSource.getRepository(User);
         const queryBuilder = repository.createQueryBuilder('user');

--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -169,6 +169,8 @@ adapter.execute(query, { visitor: { caseSensitive: schema.filters.caseSensitive 
 applyQuery(query, data, { filters: { caseSensitive: schema.filters.caseSensitive } });
 ```
 
+Passing `caseSensitive: true` instead of a list keeps **every** equality comparison exact, on all backends: for condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies.
+
 Under the hood, `@rapiq/adapter-sql` folds both sides of the comparison — `lower(field) = lower(?)` — and only when the filter value is a string. Dialects whose plain `=` already compares case-insensitively under their default collation (the MySQL and MSSQL presets) skip the folding through the `caseFold` dialect option, so plain indexes stay usable. On folding dialects (Postgres, SQLite, Oracle), add an expression index for hot string filter columns — `CREATE INDEX ON "user" (lower(name))` — or list the column in `caseSensitive`.
 
 The TypeORM adapter goes one step further: it resolves each filtered field against the entity metadata and folds **only string-typed columns**. Numeric, date, uuid or enum columns never pay the `lower()` cost — even when the value arrives as an untyped wire string like `filter[age]=18`.

--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -169,7 +169,7 @@ adapter.execute(query, { visitor: { caseSensitive: schema.filters.caseSensitive 
 applyQuery(query, data, { filters: { caseSensitive: schema.filters.caseSensitive } });
 ```
 
-Passing `caseSensitive: true` instead of a list keeps **every** equality comparison exact, on all backends: for condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies.
+Passing `caseSensitive: true` instead of a list opts **every** field out of the fold at once: for condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies. The collation caveat below applies unchanged: on the MySQL/MSSQL presets equality delegates to the column collation either way, so a `*_ci` collated column still matches case-insensitively.
 
 Under the hood, `@rapiq/adapter-sql` folds both sides of the comparison — `lower(field) = lower(?)` — and only when the filter value is a string. Dialects whose plain `=` already compares case-insensitively under their default collation (the MySQL and MSSQL presets) skip the folding through the `caseFold` dialect option, so plain indexes stay usable. On folding dialects (Postgres, SQLite, Oracle), add an expression index for hot string filter columns — `CREATE INDEX ON "user" (lower(name))` — or list the column in `caseSensitive`.
 

--- a/packages/docs/packages/adapter-memory.md
+++ b/packages/docs/packages/adapter-memory.md
@@ -178,7 +178,7 @@ Records with nothing to hide are passed through **by reference**; only affected 
 
 - Multi-key stable sort; absent values sort last ascending, first descending (pg semantics).
 - Dotted sort paths traverse to-one objects; to-many paths resolve as absent.
-- `limit`/`offset` apply only when strictly positive — `limit: 0` (and any negative) means *no limit*, mirroring the TypeORM adapter.
+- An explicit `limit: 0` is a value, not absence: it returns no rows, matching every other backend (TypeORM takes 0 rows; the prisma and drizzle configs return none on a real engine). A negative limit and a non-positive offset are ignored.
 
 ## Errors
 

--- a/packages/docs/packages/adapter-prisma.md
+++ b/packages/docs/packages/adapter-prisma.md
@@ -45,6 +45,10 @@ const total = await adapter.count(query);
 
 `count` sees the query's filters (and any baseline `where`) but never the page window: the pre-pagination total a response meta block reports. The two compose however your endpoint needs them; there is deliberately no bundled rows-plus-total call, because it would hide a second query and, without a transaction, could pair mutually inconsistent results. On an adapter constructed with explicit `{ provider, metadata }` the runners reject with a typed error, since there is nothing to run against; `execute()` stays the pure serializer either way.
 
+::: warning
+`findMany` refuses (typed) a query whose fields carry a [visibility condition](/guide/schemas#condition-verdicts): those gates are enforced post-fetch, and returning the delegate's rows raw would ship the gated columns unredacted. Serialize with `execute()` and run the fetched rows through `applyFieldConditions` of [@rapiq/adapter-memory](/packages/adapter-memory) instead. `count` is unaffected: a gate changes column visibility, never the row set.
+:::
+
 ## Merging arguments
 
 Prisma ships no per-call args composition (`$extends` intercepts every call globally), so the merge rules the adapter applies to its `base` option are exported as a standalone helper:


### PR DESCRIPTION
Follow-up to the 2026-08-02 architecture audit: the cross-backend drift it confirmed, fixed one commit per concern, each with the regression spec that would have caught it.

## Fixes

- **adapter-memory: `limit: 0` is a value, not absence.** The pagination slicer returned every row for `limit: 0` while typeorm/prisma/drizzle (engine-measured) return none, and drizzle's impossible-root encoding (`limit: 0`) leans on that reading. The slice now applies for any non-negative numeric limit; negative values stay absence. A drizzle engine spec pins the agreement with `applyQuery`.
- **adapter-prisma: drizzle hardening backported.** Own-property provider lookups (inherited object members answer unknown instead of posing as presets), the `distributeNegation` invariant guards (typed failure instead of silently emitting the inverted positive form), and the typed ITSELF gate (previously an emitted `$this` key leaning on prisma's unknown-field error). Deliberately not ported because prisma is immune by construction: the metadata prototype hole (array-based walker) and numeric sort-name rejection (array-form orderBy).
- **adapter-prisma: `findMany()` no longer fails open on field visibility gates (#830).** The runner refuses typed when the query's fields carry conditions, directing to `execute()` plus `applyFieldConditions` of @rapiq/adapter-memory; `count()` is unaffected. Documented in the Running the query section.
- **adapter-sql/typeorm: `caseSensitive` widened to `string[] | boolean`.** Core and the other three backends already accept the blanket opt-out (`true`); the SQL pair silently did not. Passes through to `planCondition` unchanged. The option key split (`visitor` vs `filters`) is untouched; that is an API-freeze question for the GA checklist.

## Tests

- Engine parity matrices aligned: the rows prisma had and drizzle lacked are ported (ordering complements, to-one null column, to-many presence, elemMatch null interior), and both packages gain the operator-enrollment tripwire the typeorm suite established. The tripwire immediately caught `gt`/`lte` enrolled in neither matrix; both backends gain rows, verified against the live engines (sqlite locally; postgres via the tests-db matrix).
- Prisma's inline engine condition list moved to `test/data/matrix.ts` so the tripwire runs in the default suite while the engine spec replays the same fixture.

## Docs

- Architecture guide records the audit rationales: the preset resolution invariant (user-supplied names throw typed everywhere; derived facts fall back documented), adapter-sql's protected members as an intended extension surface, and `ICondition` via `planCondition` as the filters contract of record (per-operator visitor methods are a legacy fast-path).

No public API breaks beyond the additive `caseSensitive` widening.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a global `caseSensitive: true` option for exact equality comparisons across supported SQL and TypeORM adapters.
  - Added documentation for case-sensitive filtering and safe handling of visibility-restricted Prisma queries.

- **Bug Fixes**
  - Pagination with an explicit limit of `0` now correctly returns no rows.
  - Prisma rejects unsupported or unsafe field-condition queries instead of returning unfiltered results.
  - Provider resolution no longer accepts inherited object property names as valid providers.

- **Tests**
  - Expanded coverage for filtering, relationships, null handling, negation, collection matching, and adapter parity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->