### PR TITLE
chore: pre-GA cleanup sweep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3445,43 +3445,6 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@ucast/core": {
-            "version": "1.10.2",
-            "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.2.tgz",
-            "integrity": "sha512-ons5CwXZ/51wrUPfoduC+cO7AS1/wRb0ybpQJ9RrssossDxVy4t49QxWoWgfBDvVKsz9VXzBk9z0wqTdZ+Cq8g==",
-            "dev": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@ucast/sql": {
-            "version": "1.0.0-alpha.12",
-            "resolved": "https://registry.npmjs.org/@ucast/sql/-/sql-1.0.0-alpha.12.tgz",
-            "integrity": "sha512-3rKzT6XxSTlnD10P9N0iaOY7xBo/VzGBSGreQUmHngzgnkl/VqVaKxafBgYrFjVERZCvp6H6kuPjhBczmgvqtQ==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@ucast/core": "^1.0.0"
-            },
-            "peerDependencies": {
-                "mikro-orm": "^3.0.0",
-                "objection": "^2.0.0",
-                "sequelize": "^5.0.0 || ^6.0.0",
-                "typeorm": "^0.2.0"
-            },
-            "peerDependenciesMeta": {
-                "mikro-orm": {
-                    "optional": true
-                },
-                "objection": {
-                    "optional": true
-                },
-                "sequelize": {
-                    "optional": true
-                },
-                "typeorm": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
@@ -12535,9 +12498,6 @@
             "license": "MIT",
             "dependencies": {
                 "pathtrace": "^2.2.2"
-            },
-            "devDependencies": {
-                "@ucast/sql": "^1.0.0-alpha.12"
             }
         },
         "packages/docs": {

--- a/packages/adapter-typeorm/package.json
+++ b/packages/adapter-typeorm/package.json
@@ -56,7 +56,22 @@
         "access": "public",
         "tag": "beta"
     },
-    "keywords": [],
+    "keywords": [
+        "query",
+        "json",
+        "json-api",
+        "api",
+        "rest",
+        "api-utils",
+        "typeorm",
+        "include",
+        "pagination",
+        "sort",
+        "fields",
+        "filter",
+        "relations",
+        "typescript"
+    ],
     "repository": {
         "type": "git",
         "url": "git+https://github.com/Tada5hi/rapiq.git",

--- a/packages/codec-url/test/unit/simple-fields.spec.ts
+++ b/packages/codec-url/test/unit/simple-fields.spec.ts
@@ -7,11 +7,10 @@
 
 import {
     Field,
+    FieldOperator,
     Fields,
 } from '@rapiq/core';
 import { SimpleURLDecoder, SimpleURLEncoder } from '../../src/simple';
-
-// todo: operator missing
 
 describe('fields', () => {
     let encoder : SimpleURLEncoder;
@@ -44,5 +43,26 @@ describe('fields', () => {
         const decoded = decoder.decodeFields(encoded!);
 
         expect(value).toEqual(decoded);
+    });
+
+    it('should encode operators & resolve them on decode', async () => {
+        const value = new Fields([
+            new Field('id', FieldOperator.INCLUDE),
+            new Field('name', FieldOperator.EXCLUDE),
+            new Field('realm.name', FieldOperator.EXCLUDE),
+        ]);
+
+        const encoded = encoder.encodeFields(value);
+        // fields[__DEFAULT__]=+id,-name&fields[realm]=-name
+        expect(encoded).toEqual('fields%5B__DEFAULT__%5D=%2Bid%2C-name&fields%5Brealm%5D=-name');
+
+        // the operator prefixes are deltas against the receiving schema's
+        // defaults: a schemaless decode resolves them via Fields.execute,
+        // so an opt-in include flattens to a plain field and an exclusion
+        // with no default set to subtract from drops.
+        const decoded = decoder.decodeFields(encoded!);
+        expect(decoded).toEqual(new Fields([
+            new Field('id'),
+        ]));
     });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -59,8 +59,5 @@
     "homepage": "https://github.com/Tada5hi/rapiq#readme",
     "dependencies": {
         "pathtrace": "^2.2.2"
-    },
-    "devDependencies": {
-        "@ucast/sql": "^1.0.0-alpha.12"
     }
 }

--- a/packages/core/src/parser/parameter/filters/types.ts
+++ b/packages/core/src/parser/parameter/filters/types.ts
@@ -8,11 +8,10 @@
 import type { Relations } from '../../../parameter';
 import type { FiltersSchema, Schema } from '../../../schema';
 import type { ObjectLiteral } from '../../../types';
-import type { IParserOptions } from '../../types';
 
 export type FiltersParseOptions<
     RECORD extends ObjectLiteral = ObjectLiteral,
-> = IParserOptions & {
+> = {
     relations?: Relations,
     schema?: string | Schema<RECORD> | FiltersSchema<RECORD>,
     throwOnFailure?: boolean,

--- a/packages/core/src/parser/types.ts
+++ b/packages/core/src/parser/types.ts
@@ -13,7 +13,7 @@ import type { PendingKeyValidation } from './parameter/validate';
 
 export type ParseParameterOptions<
     RECORD extends ObjectLiteral = ObjectLiteral,
-> = IParserOptions & {
+> = {
     schema?: Schema<RECORD> | string,
     relations?: Relations,
     strict?: boolean,
@@ -71,15 +71,10 @@ export type ParseQueryOptions<
     context?: unknown,
 };
 
-export type IParserOptions = {
-    /** @deprecated Call parseAsync() instead of selecting execution mode in options. */
-    async?: boolean,
-};
-
 export interface IParser<
     Input = any,
     Output = any,
-    Options extends IParserOptions = IParserOptions,
+    Options extends ObjectLiteral = ObjectLiteral,
 > {
     parse(input: Input, options?: Options): Output;
 

--- a/packages/parser-simple/src/parameter/filters/module.ts
+++ b/packages/parser-simple/src/parameter/filters/module.ts
@@ -219,8 +219,6 @@ export class SimpleFiltersParser extends BaseParser<
         data: TempType,
         scope: ResolutionScope<`${Parameter.FILTERS}`, RECORD>,
     ) : IFilter[] {
-        // todo: currentKey.value  === DEFAULT_ID && empty data =>build defaults otherwise
-
         const output : IFilter[] = [];
 
         let keys = Object.keys(data.attributes);

--- a/packages/parser-simple/test/unit/parser/filters.spec.ts
+++ b/packages/parser-simple/test/unit/parser/filters.spec.ts
@@ -490,8 +490,8 @@ describe('src/filter/index.ts', () => {
             ),
         );
 
-        // todo: should be "role"."id" instead of "user_roles"."role.id"
-        // with deep nested include
+        // deep nested include: the IR keeps the full dotted path;
+        // column aliasing is the adapters' concern (buildRelationAlias)
         output = parseFlat({ id: 1, 'realm.item.id': 4 }, { schema: 'user' });
         expect(output).toEqual(
             new Filters(


### PR DESCRIPTION
Small pre-GA cleanups surfaced by the release-readiness audit (plan 025 follow-up):

- **core**: remove the deprecated `IParserOptions.async` escape hatch (plan 025 §4 item 1; zero readers, `parseAsync()` is the settled path). Breaking, pre-GA sanctioned.
- **core**: drop the unused `@ucast/sql` devDependency (only reference was the manifest itself).
- **adapter-typeorm**: fill the empty npm `keywords` list (mirrors adapter-sql, plus `typeorm`).
- **parser-simple**: remove two stale v1-era todo comments. The deep-nested filter assertion itself is correct under the v2 alias model (the IR keeps the full dotted path; aliasing is the adapters' concern), so only the comments go. This also restores the plan 025 gate that `src/` carries no todo markers.
- **codec-url**: cover the fields operators in the simple codec spec (closing the `operator missing` note): the encoder writes the `+`/`-` prefixes onto the wire, and a schemaless decode resolves them via `Fields.execute` (opt-in flattens, exclusion drops).

Deliberately untouched: the `@rapiq/adapter-memory` peer on adapter-sql/adapter-typeorm (it arrived with the field-gates work in #837 and signals the post-fetch `applyFieldConditions` contract).

Full build, lint and test are green across all packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive package keywords to improve discoverability.
  * Added coverage for encoding and decoding included and excluded field operators in URLs.

* **Refactor**
  * Simplified parser option typing and removed a deprecated public type.

* **Documentation**
  * Clarified nested field handling in parser tests.
  * Removed an obsolete internal TODO comment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->