### PR TITLE
fix(codec-url)!: spell the root field group $root on the wire

### DIFF
--- a/packages/codec-url/src/constants.ts
+++ b/packages/codec-url/src/constants.ts
@@ -25,3 +25,13 @@ export enum URLParameter {
  * expression and legacy simple input apart by the filter wire shape).
  */
 export const CODEC_PARAMETER = 'codec';
+
+/**
+ * Wire spelling of the root field group when root and relation
+ * fieldsets encode together: `fields[$root]=id&fields[realm]=name`.
+ * A lone root group keeps the bare form (`fields=id`). Core's
+ * internal DEFAULT_ID sentinel never appears on the wire; decoding
+ * additionally accepts the legacy `__DEFAULT__` spelling written by
+ * the 2.0 betas.
+ */
+export const URL_FIELDS_ROOT = '$root';

--- a/packages/codec-url/src/decoder/module.ts
+++ b/packages/codec-url/src/decoder/module.ts
@@ -19,11 +19,12 @@ import type {
     ParseQueryOptions,
 } from '@rapiq/core';
 import {
+    DEFAULT_ID,
     Parameter,
     isObject,
     isPropertySet,
 } from '@rapiq/core';
-import { URLParameter } from '../constants';
+import { URLParameter, URL_FIELDS_ROOT } from '../constants';
 
 /**
  * Wire name → canonical parameter of the shared URL grammar.
@@ -35,6 +36,32 @@ const URL_PARAMETER_MAP = [
     [URLParameter.RELATIONS, Parameter.RELATIONS],
     [URLParameter.SORT, Parameter.SORT],
 ] as const;
+
+/**
+ * Map the wire spelling of the root field group onto core's internal
+ * DEFAULT_ID sentinel before the parser sees it. Decoding accepts
+ * both the public `$root` token and the legacy `__DEFAULT__` leak
+ * written by the 2.0 betas (the latter needs no mapping: it IS the
+ * sentinel). In the pathological case of both spellings appearing,
+ * the groups are concatenated instead of one silently winning.
+ */
+function normalizeFieldsWireInput(input: unknown) : unknown {
+    if (!isObject(input) || !isPropertySet(input, URL_FIELDS_ROOT)) {
+        return input;
+    }
+
+    const { [URL_FIELDS_ROOT]: root, ...groups } = input;
+    if (!isPropertySet(groups, DEFAULT_ID)) {
+        return { [DEFAULT_ID]: root, ...groups };
+    }
+
+    const toArray = (value: unknown) => (Array.isArray(value) ? value : [value]);
+
+    return {
+        ...groups,
+        [DEFAULT_ID]: [...toArray(groups[DEFAULT_ID]), ...toArray(root)],
+    };
+}
 
 /**
  * Shared decode pipeline of the URL dialects: qs-parse the input,
@@ -91,10 +118,13 @@ export abstract class BaseURLDecoder {
         }
 
         if (isPropertySet(output, URLParameter.FIELDS)) {
-            return this.parser.parseFields(output[URLParameter.FIELDS], options);
+            return this.parser.parseFields(
+                normalizeFieldsWireInput(output[URLParameter.FIELDS]),
+                options,
+            );
         }
 
-        return this.parser.parseFields(output, options);
+        return this.parser.parseFields(normalizeFieldsWireInput(output), options);
     }
 
     decodeFilters(
@@ -204,7 +234,9 @@ export abstract class BaseURLDecoder {
 
         for (const [urlKey, key] of URL_PARAMETER_MAP) {
             if (isPropertySet(parsed, urlKey)) {
-                mapped[key] = parsed[urlKey];
+                mapped[key] = key === Parameter.FIELDS ?
+                    normalizeFieldsWireInput(parsed[urlKey]) :
+                    parsed[urlKey];
             }
         }
 

--- a/packages/codec-url/src/simple/encoder/serializer/record-array.ts
+++ b/packages/codec-url/src/simple/encoder/serializer/record-array.ts
@@ -6,6 +6,7 @@
  */
 
 import { DEFAULT_ID } from '@rapiq/core';
+import { URL_FIELDS_ROOT } from '../../../constants';
 import { serializeAsURI } from '../../utils';
 import type { ISerializer } from './types';
 
@@ -53,8 +54,15 @@ export class RecordArraySerializer<
             );
         }
 
+        // the internal DEFAULT_ID sentinel never leaks onto the wire:
+        // the root group is spelled with the public token instead.
+        const { [DEFAULT_ID]: root, ...groups } = this.value;
+        const output : Record<string, ItemType[]> = typeof root === 'undefined' ?
+            groups :
+            { [URL_FIELDS_ROOT]: root, ...groups };
+
         return serializeAsURI(
-            this.value,
+            output,
             {
                 prefixParts: [
                     ...(this.prefix ? [this.prefix] : []),

--- a/packages/codec-url/test/unit/simple-encoder-schema.spec.ts
+++ b/packages/codec-url/test/unit/simple-encoder-schema.spec.ts
@@ -51,7 +51,7 @@ describe('encoder (schema-aware)', () => {
         // included relations materialize their field groups, exactly as
         // the server-side decode of this input would resolve them.
         expect(decodeURIComponent(encoded!)).toEqual(
-            'fields[__DEFAULT__]=id&fields[realm]=id,name,description&filter[name]=John&include=realm&sort=-id',
+            'fields[$root]=id&fields[realm]=id,name,description&filter[name]=John&include=realm&sort=-id',
         );
     });
 

--- a/packages/codec-url/test/unit/simple-fields.spec.ts
+++ b/packages/codec-url/test/unit/simple-fields.spec.ts
@@ -53,8 +53,8 @@ describe('fields', () => {
         ]);
 
         const encoded = encoder.encodeFields(value);
-        // fields[__DEFAULT__]=+id,-name&fields[realm]=-name
-        expect(encoded).toEqual('fields%5B__DEFAULT__%5D=%2Bid%2C-name&fields%5Brealm%5D=-name');
+        // fields[$root]=+id,-name&fields[realm]=-name
+        expect(encoded).toEqual('fields%5B%24root%5D=%2Bid%2C-name&fields%5Brealm%5D=-name');
 
         // the operator prefixes are deltas against the receiving schema's
         // defaults: a schemaless decode resolves them via Fields.execute,
@@ -64,5 +64,17 @@ describe('fields', () => {
         expect(decoded).toEqual(new Fields([
             new Field('id'),
         ]));
+    });
+
+    it('should decode the legacy __DEFAULT__ root group spelling', async () => {
+        const blessed = decoder.decodeFields('fields[$root]=id,name&fields[realm]=name');
+        const legacy = decoder.decodeFields('fields[__DEFAULT__]=id,name&fields[realm]=name');
+
+        expect(blessed).toEqual(new Fields([
+            new Field('id'),
+            new Field('name'),
+            new Field('realm.name'),
+        ]));
+        expect(legacy).toEqual(blessed);
     });
 });

--- a/packages/docs/guide/wire.md
+++ b/packages/docs/guide/wire.md
@@ -24,6 +24,8 @@ New payloads use the expression filter dialect and carry `codec=url-expression`.
 | relations | `include` | `include=realm,items` |
 | sort | `sort` | `sort=name,-age` |
 
+When root and relation fieldsets encode together, the root group is spelled with the reserved `$root` token: `fields[$root]=id,name&fields[items]=id`. A lone root group keeps the bare form (`fields=id,name`). Decoding accepts `$root` and the legacy `__DEFAULT__` spelling written by early 2.0 betas.
+
 ## Decoding (receiver)
 
 The same façade accepts a raw query string or an already-parsed object such as Express' `req.query`:


### PR DESCRIPTION
Pre-GA API freeze, decision 6 of plan 025: GA freezes the wire format, and mixed root + relation fieldsets were leaking core's internal `DEFAULT_ID` sentinel onto it (`fields[__DEFAULT__]=...`) -- in the default expression encoding too, since it reuses the simple fields serializer.

## What

- New public constant `URL_FIELDS_ROOT = '$root'` in `@rapiq/codec-url`.
- Encoder: the multi-group record form spells the root group `fields[$root]=...`; a lone root group keeps the bare `fields=...` form (unchanged).
- Decoder: `$root` maps onto the internal sentinel before the parser sees it, in both the full-query pipeline and `decodeFields`; the legacy `__DEFAULT__` spelling written by the 2.0 betas keeps decoding (it needs no mapping), and the pathological both-present case concatenates the groups instead of one silently winning.
- Wire guide documents the token and the legacy acceptance.

## Why not the bare mixed form

`fields=+id&fields[realm]=name` was measured to parse under qs as a mixed string/object array (`{"fields":["+id",{"realm":"name"}]}`), pushing that shape into every consumer's `req.query` handling; a reserved token keeps the record uniform. `$` cannot collide with a relation name.

The schema-aware encode path (encode -> schema decode -> re-encode) exercises both directions and stays green.

BREAKING CHANGE: receivers matching the raw `fields[__DEFAULT__]` wire key must switch to `fields[$root]`; rapiq decoders read both.