### PR TITLE
docs: backfill prisma and drizzle across the shared overview surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ an API gateway, for instance, validates an incoming query against its own schema
 - 🧭 **Typed end to end**: every field path in `defineQuery<User>` is checked against the record type; condition helpers (`eq`, `gte`, `and`, `or`, …) replace magic value strings.
 - 🛡️ **The receiving side has the last word**: a `Schema` declares what a caller may request per parameter (allow-lists, defaults, mappings). Invalid input is dropped or rejected according to the parser dialect and schema policy, and injected conditions (`query.filters.and(...)`) can't be displaced by caller input.
 - 🔁 **Loss-free transport**: within each codec dialect, `decode(encode(query))` restores the same query; outside its subset, encoding fails loudly with a typed error instead of silently changing semantics.
-- 🔌 **Any backend**: the AST is consumed through visitors: parameterized SQL fragments with presets for Postgres, MySQL, SQLite, MSSQL & Oracle, or applied straight to a TypeORM `SelectQueryBuilder`.
+- 🔌 **Any backend**: the same AST executes everywhere: parameterized SQL fragments with presets for Postgres, MySQL, SQLite, MSSQL & Oracle, a TypeORM `SelectQueryBuilder`, a Prisma `findMany` args object, a drizzle relational-queries config, or compiled functions over in-memory data.
 - 📦 **Composable packages**: no monolith, install only what each side needs; `@rapiq/core` is the single shared foundation.
 
 ## Installation
@@ -68,7 +68,9 @@ Querying application, build queries and encode them as URL query strings:
 npm install @rapiq/core @rapiq/codec-url
 ```
 
-Queried application, decode & validate incoming query input and apply it to the database:
+Queried application, decode & validate incoming query input and apply it to the database
+(swap the adapters for `@rapiq/adapter-prisma`, `@rapiq/adapter-drizzle` or
+`@rapiq/adapter-memory` to match your backend):
 
 ```bash
 npm install @rapiq/core @rapiq/codec-url @rapiq/adapter-sql @rapiq/adapter-typeorm

--- a/packages/docs/.vitepress/theme/components/PackageShowcase.vue
+++ b/packages/docs/.vitepress/theme/components/PackageShowcase.vue
@@ -31,6 +31,28 @@ const packages: PackageCard[] = [
         ],
     },
     {
+        name: '@rapiq/parser-expression',
+        accent: 'var(--rq-color-primary)',
+        href: '/packages/parser-expression',
+        summary: 'Parses the function-call expression dialect into the same Query AST.',
+        bullets: [
+            'and(eq(name, \'John\'), gte(age, \'18\'))',
+            'Nested or() / not() groups on the wire',
+            'Default filter dialect of the URL codec',
+        ],
+    },
+    {
+        name: '@rapiq/parser-mongo',
+        accent: 'var(--rq-color-success)',
+        href: '/packages/parser-mongo',
+        summary: 'Parses MongoDB-style filter documents with typed values.',
+        bullets: [
+            '{ age: { $gte: 18 } }, $and / $or / $not',
+            '$elemMatch incl. the element-level form',
+            'Grammar errors always throw typed',
+        ],
+    },
+    {
         name: '@rapiq/codec-url',
         accent: 'var(--rq-color-warning)',
         href: '/packages/codec-url',
@@ -61,6 +83,28 @@ const packages: PackageCard[] = [
             'Mutates the query builder in place',
             'Relations become joins automatically',
             'Builds on the @rapiq/adapter-sql visitors',
+        ],
+    },
+    {
+        name: '@rapiq/adapter-prisma',
+        accent: 'var(--rq-color-accent)',
+        href: '/packages/adapter-prisma',
+        summary: 'Serializes a parsed Query into a Prisma findMany args object.',
+        bullets: [
+            'Pure value: no prisma dependency',
+            'Same-element relation semantics preserved',
+            'Engine-verified parity (SQLite & Postgres)',
+        ],
+    },
+    {
+        name: '@rapiq/adapter-drizzle',
+        accent: 'var(--rq-color-warning)',
+        href: '/packages/adapter-drizzle',
+        summary: 'Serializes a parsed Query into a drizzle relational-queries findMany config.',
+        bullets: [
+            'Pure value: no drizzle dependency',
+            'Correlated EXISTS relation filters',
+            'Engine-verified parity in the default suite',
         ],
     },
     {

--- a/packages/docs/.vitepress/theme/components/QueryHub.vue
+++ b/packages/docs/.vitepress/theme/components/QueryHub.vue
@@ -57,6 +57,14 @@
                 <span>parameterized fragments</span>
             </div>
             <div class="rq-hub-item">
+                <strong>@rapiq/adapter-prisma</strong>
+                <span>findMany args</span>
+            </div>
+            <div class="rq-hub-item">
+                <strong>@rapiq/adapter-drizzle</strong>
+                <span>findMany config</span>
+            </div>
+            <div class="rq-hub-item">
                 <strong>@rapiq/adapter-memory</strong>
                 <span>compiled functions</span>
             </div>

--- a/packages/docs/.vitepress/theme/components/QueryPipeline.vue
+++ b/packages/docs/.vitepress/theme/components/QueryPipeline.vue
@@ -76,6 +76,20 @@
                 </a>
                 <a
                     class="rq-pipe-adapter"
+                    href="/packages/adapter-prisma"
+                >
+                    <strong>@rapiq/adapter-prisma</strong>
+                    <span>findMany args</span>
+                </a>
+                <a
+                    class="rq-pipe-adapter"
+                    href="/packages/adapter-drizzle"
+                >
+                    <strong>@rapiq/adapter-drizzle</strong>
+                    <span>findMany config</span>
+                </a>
+                <a
+                    class="rq-pipe-adapter"
                     href="/packages/adapter-memory"
                 >
                     <strong>@rapiq/adapter-memory</strong>

--- a/packages/docs/guide/concepts.md
+++ b/packages/docs/guide/concepts.md
@@ -92,9 +92,11 @@ Adapters execute a `Query` against a backend:
 
 - [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) — mutates a TypeORM `SelectQueryBuilder`
 - [`@rapiq/adapter-sql`](/packages/adapter-sql) — renders parameterized SQL fragments for any driver
+- [`@rapiq/adapter-prisma`](/packages/adapter-prisma) — serializes the query into a Prisma `findMany` args object
+- [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) — serializes the query into a drizzle relational-queries `findMany` config
 - [`@rapiq/adapter-memory`](/packages/adapter-memory) — compiles the query into plain functions over in-memory data
 
-They all consume the AST through the **visitor pattern**: every node has `accept(visitor)`, and a backend implements visitor interfaces for the nodes it cares about. New backends never require changes to core — see [The Query AST](/guide/query-ast) if you want to build one.
+They all consume the same AST: the SQL-facing pair walk it through the **visitor pattern** (every node has `accept(visitor)`), prisma and drizzle serialize it into plain config values, and memory compiles it into functions. New backends never require changes to core — see [The Query AST](/guide/query-ast) if you want to build one.
 
 ## Composition — queries are values
 
@@ -124,7 +126,7 @@ Both patterns are covered in [Merging & Composition](/guide/merging-queries).
 | Build | `@rapiq/core` (`defineQuery`, helpers) |
 | Transport | `@rapiq/codec-url` |
 | Parse & validate | `@rapiq/parser-simple`, `@rapiq/parser-expression`, `@rapiq/parser-mongo` + `Schema` from core |
-| Execute | `@rapiq/adapter-typeorm`, `@rapiq/adapter-sql`, `@rapiq/adapter-memory` |
+| Execute | `@rapiq/adapter-typeorm`, `@rapiq/adapter-sql`, `@rapiq/adapter-prisma`, `@rapiq/adapter-drizzle`, `@rapiq/adapter-memory` |
 
 ## Next steps
 

--- a/packages/docs/guide/index.md
+++ b/packages/docs/guide/index.md
@@ -82,7 +82,7 @@ Install only what each side of your application needs — `@rapiq/core` is the s
 | **Build & compose** | [@rapiq/core](/packages/core) — the query AST, `defineQuery`, condition helpers, schemas |
 | **Parse input** | [@rapiq/parser-simple](/packages/parser-simple) · [@rapiq/parser-expression](/packages/parser-expression) · [@rapiq/parser-mongo](/packages/parser-mongo) |
 | **Cross the wire** | [@rapiq/codec-url](/packages/codec-url) |
-| **Execute** | [@rapiq/adapter-typeorm](/packages/adapter-typeorm) · [@rapiq/adapter-sql](/packages/adapter-sql) · [@rapiq/adapter-memory](/packages/adapter-memory) |
+| **Execute** | [@rapiq/adapter-typeorm](/packages/adapter-typeorm) · [@rapiq/adapter-sql](/packages/adapter-sql) · [@rapiq/adapter-prisma](/packages/adapter-prisma) · [@rapiq/adapter-drizzle](/packages/adapter-drizzle) · [@rapiq/adapter-memory](/packages/adapter-memory) |
 
 See the [package overview](/packages/) for the full map and a "which packages do I need?" guide.
 
@@ -90,7 +90,7 @@ See the [package overview](/packages/) for the full map and a "which packages do
 
 - Your API exposes **list endpoints** and clients need to filter, sort, paginate or shape the result.
 - You want the query surface **declared, typed and enforced** instead of scattered across handlers.
-- You want the **same query semantics** everywhere — SQL, TypeORM, in-memory guards, tests.
+- You want the **same query semantics** everywhere — SQL, TypeORM, Prisma, Drizzle, in-memory guards, tests.
 
 It deliberately does **not** define the response format, replace your ORM, or generate endpoints — it only standardizes what a query *is* and what a client *may* ask for.
 

--- a/packages/docs/packages/adapter-sql.md
+++ b/packages/docs/packages/adapter-sql.md
@@ -143,3 +143,20 @@ The [`ITSELF` marker](/guide/filters#operators) — an `elemMatch` interior cond
 ### size (array length)
 
 The [`size` operator](/guide/filters#operators) has no SQL rendering either — an array-length check needs per-dialect JSON-array support (`json_array_length` on Postgres/SQLite, `JSON_LENGTH` on MySQL, `cardinality` for Postgres arrays). Both `@rapiq/adapter-sql` and `@rapiq/adapter-typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`); evaluate such filters with [`@rapiq/adapter-memory`](/packages/adapter-memory) in the meantime.
+
+## Field visibility gates
+
+A schema's `fields` [validate hook](/guide/schemas#condition-verdicts) may gate a column with a condition, meaning *visible only on rows satisfying it*. The rendered SQL cannot express that: a selection stays a bare escaped column, so the column is projected for **every** row and the gate has to be enforced on the fetched rows.
+
+The gate is compiled from the same AST the adapter walks, so the helper that applies it lives in [`@rapiq/adapter-memory`](/packages/adapter-memory), the package that evaluates conditions against plain objects. Install it alongside this one when a schema gates a field:
+
+```typescript
+import { applyFieldConditions } from '@rapiq/adapter-memory';
+
+const fragments = adapter.execute(query);
+const rows = await driver.query(assemble(fragments));
+
+const output = applyFieldConditions(query.fields, rows);
+```
+
+Skipping this step fails open: consumers receive the gated column unredacted.

--- a/packages/docs/packages/core.md
+++ b/packages/docs/packages/core.md
@@ -10,11 +10,11 @@ npm install @rapiq/core
 
 | Area | Exports (selection) | Guide |
 |---|---|---|
-| **Query AST** | `Query`, `Fields`/`Field`, `Filters`/`Filter`, `Relations`/`Relation`, `Sorts`/`Sort`, `Pagination`, operator constants (`FilterFieldOperator`, `FilterCompoundOperator`, `FieldOperator`, `SortDirection`, `Parameter`), visitor interfaces (`IQueryVisitor`, `IFiltersVisitor`, …) | [The Query AST](/guide/query-ast) |
+| **Query AST** | `Query`, `Fields`/`Field`, `Filters`/`Filter`, `Relations`/`Relation`, `Sorts`/`Sort`, `Pagination`, operator constants (`FilterFieldOperator`, `FilterCompoundOperator`, `FieldOperator`, `SortDirection`, `Parameter`), visitor interfaces (`IQueryVisitor`, `IFiltersVisitor`, …), `hasFieldConditions` | [The Query AST](/guide/query-ast) |
 | **Build layer** | `defineQuery`, `defineFields`, `defineFilters`, `definePagination`, `defineRelations`, `defineSorts` | [Building Queries](/guide/building-queries) |
-| **Condition helpers** | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `inArray`, `nin`, `startsWith`, `notStartsWith`, `endsWith`, `notEndsWith`, `contains`, `notContains`, `regex`, `mod`, `size`, `exists`, `elemMatch`, `and`, `or` | [Condition helpers](/guide/building-queries#condition-helpers) |
+| **Condition helpers** | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `inArray`, `nin`, `startsWith`, `notStartsWith`, `endsWith`, `notEndsWith`, `contains`, `notContains`, `regex`, `mod`, `size`, `exists`, `elemMatch`, `and`, `or`, `not` | [Condition helpers](/guide/building-queries#condition-helpers) |
 | **Composition** | `mergeQueries`, `Filters.merge` / `.and` / `.or` | [Merging & Composition](/guide/merging-queries) |
-| **Schema system** | `defineSchema`, `Schema`, `SchemaRegistry`, per-parameter `define*Schema` factories, `ResolutionScope` | [Schemas & Validation](/guide/schemas) |
+| **Schema system** | `defineSchema`, `Schema`, `SchemaRegistry`, per-parameter `define*Schema` factories, `ResolutionScope`, `Schema.describe()` | [Schemas & Validation](/guide/schemas) |
 | **Parser base** | `BaseParser`, per-parameter parse-option types | [Custom parsers](/guide/query-ast#writing-a-custom-parser-resolutionscope) |
 | **Errors** | `BaseError`, `ParseError` + per-parameter subclasses, `BuildError`, `MergeError`, `AdapterError`, `CodecError`, `ErrorCode` | [Error Handling](/guide/errors) |
 | **Utils** | `parseKey`, `stringifyKey`, `isObject`, `isPropertySet` | — |
@@ -34,6 +34,6 @@ defineQuery<User>({
 
 - **No wire formats** — URL parameter names and query-string handling live in [`@rapiq/codec-url`](/packages/codec-url).
 - **No input dialects** — parsing simple/expression/mongo input lives in the [parser packages](/packages/parser-simple).
-- **No backends** — SQL/TypeORM/memory execution lives in the [adapter packages](/packages/adapter-sql).
+- **No backends** — SQL/TypeORM/Prisma/Drizzle/memory execution lives in the [adapter packages](/packages/adapter-sql).
 
 If you only build queries in code and hand them to an in-process consumer, core is the only dependency you need.

--- a/packages/docs/packages/index.md
+++ b/packages/docs/packages/index.md
@@ -37,6 +37,12 @@ npm install @rapiq/core @rapiq/codec-url @rapiq/adapter-sql @rapiq/adapter-typeo
 npm install @rapiq/core @rapiq/codec-url @rapiq/adapter-prisma
 ```
 
+**An HTTP API backed by Drizzle:**
+
+```sh
+npm install @rapiq/core @rapiq/codec-url @rapiq/adapter-drizzle
+```
+
 **An HTTP API composing SQL by hand:**
 
 ```sh


### PR DESCRIPTION
Plan 025 §6b: the per-package pages were complete, but the two newest adapters never got backfilled onto the surfaces that enumerate the fleet.

- `guide/concepts.md`: adapter list + the "where each package sits" Execute row now name all five backends; the consumption sentence distinguishes visitors (sql/typeorm), serializers (prisma/drizzle) and compiled functions (memory).
- `guide/index.md`: Execute row + the "same query semantics" bullet.
- Homepage components: `PackageShowcase.vue` now shows all ten packages (adapter-prisma, adapter-drizzle, parser-expression and parser-mongo were missing); `QueryHub.vue` and `QueryPipeline.vue` diagrams include the two serializers, consistent with the already-complete `PackageLayers.vue`.
- `packages/index.md`: Drizzle install recipe (the map table listed the package but the recipes skipped it, disagreeing with `guide/installation.md`).
- `packages/core.md`: adds the missing `not` helper, `hasFieldConditions` and `Schema.describe()` to the exports table; the "no backends" line names all five.
- `packages/adapter-sql.md`: new field visibility gates section mirroring the typeorm page (post-fetch `applyFieldConditions`, fail-open warning).
- Root `README.md`: the "Any backend" bullet predates prisma/drizzle/memory; the receiver install snippet now points at the adapter alternatives.

Docs site builds clean (`npm run build --workspace=packages/docs`).