### PR TITLE
fix: close the pre-GA audit gaps in code and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ Every REST list endpoint answers the same five questions: which **fields**, whic
 
 | Stage | What happens |
 |---|---|
-| **Build** <sub>calling application</sub> | `defineQuery<User>({ filters: { age: gte(18) }, sort: '-name' })`: typed input in, query AST out |
+| **Build** <sub>calling application</sub> | `defineQuery<User>({ filters: { age: { $gte: 18 } }, sort: '-name' })`: typed input in, query AST out |
 | **Transport** <sub>wire</sub> | encoded as a self-described URL query string: `?codec=url-expression&filter=gte(age,'18')&sort=-name` |
 | **Validate** <sub>receiving application</sub> | decoded back into the same AST, checked against a `Schema`: allow-lists, defaults, mappings |
-| **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/adapter-sql`), to a TypeORM `SelectQueryBuilder` (`@rapiq/adapter-typeorm`), as Prisma arguments (`@rapiq/adapter-prisma`) or as a Drizzle relational query config (`@rapiq/adapter-drizzle`) |
+| **Execute** <sub>database</sub> | applied as parameterized SQL (`@rapiq/adapter-sql`), to a TypeORM `SelectQueryBuilder` (`@rapiq/adapter-typeorm`), as Prisma arguments (`@rapiq/adapter-prisma`), as a Drizzle relational query config (`@rapiq/adapter-drizzle`) or evaluated against in-memory data (`@rapiq/adapter-memory`) |
 
 The two ends are just applications. A browser querying an API is the common case, but services compose the same way:
 an API gateway, for instance, validates an incoming query against its own schema, scopes it

--- a/packages/adapter-drizzle/src/adapter/module.ts
+++ b/packages/adapter-drizzle/src/adapter/module.ts
@@ -66,7 +66,7 @@ export class DrizzleAdapter<
 
         const filters = this.renderer.build(
             query.filters,
-            options.filters || this.options.filters || {},
+            { caseSensitive: options.caseSensitive ?? this.options.caseSensitive },
         );
 
         const produced : FindManyConfig = {};

--- a/packages/adapter-drizzle/src/adapter/types.ts
+++ b/packages/adapter-drizzle/src/adapter/types.ts
@@ -63,7 +63,14 @@ export type DrizzleAdapterOptions = {
      */
     metadata: IMetadata,
 
-    filters?: FiltersAdapterOptions,
+    /**
+     * Field keys whose equality comparisons (eq/ne/in/nin) stay
+     * case-sensitive instead of the case-insensitive default, e.g.
+     * identifier or token columns; `true` opts every field out.
+     * Typically forwarded from a schema's `filters.caseSensitive`
+     * list.
+     */
+    caseSensitive?: string[] | boolean,
 };
 
 // -----------------------------------------------------------
@@ -77,7 +84,10 @@ export type ExecuteOptions<CONFIG extends FindManyConfig = FindManyConfig> = {
      */
     base?: CONFIG,
 
-    filters?: FiltersAdapterOptions,
+    /**
+     * Per-call override of the adapter-level `caseSensitive` option.
+     */
+    caseSensitive?: string[] | boolean,
 };
 
 export type DrizzleAdapterOutput<CONFIG extends FindManyConfig = FindManyConfig> = {

--- a/packages/adapter-drizzle/test/unit/engine.db.spec.ts
+++ b/packages/adapter-drizzle/test/unit/engine.db.spec.ts
@@ -191,7 +191,7 @@ suite('engine: postgres parity and case contract', () => {
     it('should keep an opted-out equality exact', async () => {
         const exact = new DrizzleAdapter(createAdapterOptions({
             provider: 'pg',
-            filters: { caseSensitive: true },
+            caseSensitive: true,
         }));
 
         // matches only the exact-case record, unlike the folded

--- a/packages/adapter-drizzle/test/unit/filters.spec.ts
+++ b/packages/adapter-drizzle/test/unit/filters.spec.ts
@@ -55,7 +55,7 @@ describe('src/adapter/where.ts', () => {
         });
 
         it('should keep an opted-out field exact', () => {
-            const config = serialize(eq('address', 'Hogwarts'), { filters: { caseSensitive: ['address'] } });
+            const config = serialize(eq('address', 'Hogwarts'), { caseSensitive: ['address'] });
 
             expect(config.where).toEqual({ address: { eq: 'Hogwarts' } });
         });

--- a/packages/adapter-drizzle/test/unit/query.spec.ts
+++ b/packages/adapter-drizzle/test/unit/query.spec.ts
@@ -138,7 +138,7 @@ describe('src/adapter/module.ts', () => {
         const adapter = new DrizzleAdapter(createAdapterOptions());
         const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('first_name', 'Peter')]) });
 
-        adapter.execute(query, { filters: { caseSensitive: true } });
+        adapter.execute(query, { caseSensitive: true });
 
         expect(adapter.execute(query).config.where).toEqual({ first_name: { ilike: 'Peter' } });
     });

--- a/packages/adapter-prisma/src/adapter/module.ts
+++ b/packages/adapter-prisma/src/adapter/module.ts
@@ -147,7 +147,7 @@ export class PrismaAdapter<
 
         const filters = this.renderer.build(
             query.filters,
-            options.filters || this.options.filters || {},
+            { caseSensitive: options.caseSensitive ?? this.options.caseSensitive },
         );
 
         const produced : Args = {};

--- a/packages/adapter-prisma/src/adapter/types.ts
+++ b/packages/adapter-prisma/src/adapter/types.ts
@@ -63,7 +63,14 @@ export type PrismaAdapterExplicitOptions = {
      */
     metadata: IMetadata,
 
-    filters?: FiltersAdapterOptions,
+    /**
+     * Field keys whose equality comparisons (eq/ne/in/nin) stay
+     * case-sensitive instead of the case-insensitive default, e.g.
+     * identifier or token columns; `true` opts every field out.
+     * Typically forwarded from a schema's `filters.caseSensitive`
+     * list.
+     */
+    caseSensitive?: string[] | boolean,
 };
 
 /**
@@ -92,7 +99,12 @@ export type PrismaAdapterClientOptions = {
 
     metadata?: IMetadata,
 
-    filters?: FiltersAdapterOptions,
+    /**
+     * Field keys whose equality comparisons (eq/ne/in/nin) stay
+     * case-sensitive instead of the case-insensitive default;
+     * `true` opts every field out.
+     */
+    caseSensitive?: string[] | boolean,
 };
 
 export type PrismaAdapterOptions =    PrismaAdapterExplicitOptions |
@@ -109,7 +121,10 @@ export type ExecuteOptions<ARGS extends Args = Args> = {
      */
     base?: ARGS,
 
-    filters?: FiltersAdapterOptions,
+    /**
+     * Per-call override of the adapter-level `caseSensitive` option.
+     */
+    caseSensitive?: string[] | boolean,
 };
 
 export type PrismaAdapterOutput<ARGS extends Args = Args> = {

--- a/packages/adapter-prisma/src/schema/module.ts
+++ b/packages/adapter-prisma/src/schema/module.ts
@@ -13,6 +13,7 @@ import type {
 import {
     AdapterError,
     ErrorCode,
+    SchemaError,
     SchemaRegistry,
     defineSchema,
 } from '@rapiq/core';
@@ -176,7 +177,10 @@ export function defineSchemaRegistryWithDatamodel(
     for (const model of datamodel.models) {
         const name = buildModelSchemaName(model);
         if (names.has(name)) {
-            throw new Error(`The derived schema name "${name}" is not unique across the datamodel.`);
+            throw new SchemaError({
+                message: `The derived schema name "${name}" is not unique across the datamodel.`,
+                code: ErrorCode.SCHEMA_NAME_INVALID,
+            });
         }
 
         names.add(name);
@@ -184,7 +188,10 @@ export function defineSchemaRegistryWithDatamodel(
         // an already registered schema (e.g. hand-written) takes precedence.
         if (registry.get(name)) {
             if (schemasOptions[name]) {
-                throw new Error(`The schemas option key "${name}" cannot be applied, since the schema is already registered.`);
+                throw new SchemaError({
+                    message: `The schemas option key "${name}" cannot be applied, since the schema is already registered.`,
+                    code: ErrorCode.INPUT_INVALID,
+                });
             }
 
             continue;
@@ -195,7 +202,10 @@ export function defineSchemaRegistryWithDatamodel(
 
     for (const name of Object.keys(schemasOptions)) {
         if (!names.has(name)) {
-            throw new Error(`The schemas option key "${name}" does not match any model of the datamodel.`);
+            throw new SchemaError({
+                message: `The schemas option key "${name}" does not match any model of the datamodel.`,
+                code: ErrorCode.INPUT_INVALID,
+            });
         }
     }
 

--- a/packages/adapter-prisma/test/unit/filters.spec.ts
+++ b/packages/adapter-prisma/test/unit/filters.spec.ts
@@ -164,7 +164,7 @@ describe('src/adapter/filters.ts', () => {
         });
 
         it('should honor the per-field opt-out', () => {
-            expect(build(eq('email', 'a@b.c'), { filters: { caseSensitive: ['email'] } })).toEqual({ email: { equals: 'a@b.c' } });
+            expect(build(eq('email', 'a@b.c'), { caseSensitive: ['email'] })).toEqual({ email: { equals: 'a@b.c' } });
         });
 
         it('should keep membership case-insensitive despite a wildcard', () => {

--- a/packages/adapter-prisma/test/unit/query.spec.ts
+++ b/packages/adapter-prisma/test/unit/query.spec.ts
@@ -144,7 +144,7 @@ describe('src/adapter/module.ts', () => {
         const adapter = new PrismaAdapter(createAdapterOptions());
         const query = new Query({ filters: new Filters(FilterCompoundOperator.AND, [eq('first_name', 'Peter')]) });
 
-        adapter.execute(query, { filters: { caseSensitive: true } });
+        adapter.execute(query, { caseSensitive: true });
 
         expect(adapter.execute(query).args.where).toEqual({ first_name: { equals: 'Peter', mode: 'insensitive' } });
     });

--- a/packages/adapter-typeorm/src/schema/assert.ts
+++ b/packages/adapter-typeorm/src/schema/assert.ts
@@ -6,7 +6,9 @@
  */
 
 import type { ICondition, ObjectLiteral, Schema } from '@rapiq/core';
-import { isFilter, isFilters } from '@rapiq/core';
+import {
+    ErrorCode, SchemaError, isFilter, isFilters,
+} from '@rapiq/core';
 import { DataSource, EntityMetadata } from 'typeorm';
 import type { EntityTarget } from 'typeorm';
 import { SchemaEntityMismatchError } from '../errors';
@@ -46,7 +48,10 @@ export function assertSchemaMatchesEntity<
         metadata = target;
     } else {
         if (!(dataSource instanceof DataSource)) {
-            throw new Error('A data source is required to resolve the metadata of an entity target.');
+            throw new SchemaError({
+                message: 'A data source is required to resolve the metadata of an entity target.',
+                code: ErrorCode.INPUT_INVALID,
+            });
         }
 
         metadata = dataSource.getMetadata(target);

--- a/packages/adapter-typeorm/src/schema/assert.ts
+++ b/packages/adapter-typeorm/src/schema/assert.ts
@@ -7,7 +7,10 @@
 
 import type { ICondition, ObjectLiteral, Schema } from '@rapiq/core';
 import {
-    ErrorCode, SchemaError, isFilter, isFilters,
+    ErrorCode, 
+    SchemaError, 
+    isFilter, 
+    isFilters,
 } from '@rapiq/core';
 import { DataSource, EntityMetadata } from 'typeorm';
 import type { EntityTarget } from 'typeorm';

--- a/packages/adapter-typeorm/src/schema/module.ts
+++ b/packages/adapter-typeorm/src/schema/module.ts
@@ -10,7 +10,9 @@ import type {
     Schema,
     SchemaOptions,
 } from '@rapiq/core';
-import { SchemaRegistry, defineSchema } from '@rapiq/core';
+import {
+    ErrorCode, SchemaError, SchemaRegistry, defineSchema,
+} from '@rapiq/core';
 import { camelCase } from 'change-case';
 import { DataSource, EntityMetadata } from 'typeorm';
 import type { EntityTarget } from 'typeorm';
@@ -127,7 +129,10 @@ export function defineSchemaWithEntity<
         schemaOptions = dataSourceOrOptions as EntitySchemaOptions<RECORD> | undefined;
     } else {
         if (!(dataSourceOrOptions instanceof DataSource)) {
-            throw new Error('A data source is required to resolve the metadata of an entity target.');
+            throw new SchemaError({
+                message: 'A data source is required to resolve the metadata of an entity target.',
+                code: ErrorCode.INPUT_INVALID,
+            });
         }
 
         metadata = dataSourceOrOptions.getMetadata(target);

--- a/packages/adapter-typeorm/src/schema/module.ts
+++ b/packages/adapter-typeorm/src/schema/module.ts
@@ -11,7 +11,10 @@ import type {
     SchemaOptions,
 } from '@rapiq/core';
 import {
-    ErrorCode, SchemaError, SchemaRegistry, defineSchema,
+    ErrorCode, 
+    SchemaError, 
+    SchemaRegistry, 
+    defineSchema,
 } from '@rapiq/core';
 import { camelCase } from 'change-case';
 import { DataSource, EntityMetadata } from 'typeorm';

--- a/packages/adapter-typeorm/src/schema/module.ts
+++ b/packages/adapter-typeorm/src/schema/module.ts
@@ -176,7 +176,10 @@ export function defineSchemaRegistryWithDataSource(
 
         const name = buildEntitySchemaName(metadata);
         if (names.has(name)) {
-            throw new Error(`The derived schema name "${name}" is not unique across the data source entities.`);
+            throw new SchemaError({
+                message: `The derived schema name "${name}" is not unique across the data source entities.`,
+                code: ErrorCode.SCHEMA_NAME_INVALID,
+            });
         }
 
         names.add(name);
@@ -184,7 +187,10 @@ export function defineSchemaRegistryWithDataSource(
         // an already registered schema (e.g. hand-written) takes precedence.
         if (registry.get(name)) {
             if (schemasOptions.has(name)) {
-                throw new Error(`The schemas option key "${name}" cannot be applied, since the schema is already registered.`);
+                throw new SchemaError({
+                    message: `The schemas option key "${name}" cannot be applied, since the schema is already registered.`,
+                    code: ErrorCode.INPUT_INVALID,
+                });
             }
 
             continue;
@@ -195,7 +201,10 @@ export function defineSchemaRegistryWithDataSource(
 
     for (const name of schemasOptions.keys()) {
         if (!names.has(name)) {
-            throw new Error(`The schemas option key "${name}" does not match any entity of the data source.`);
+            throw new SchemaError({
+                message: `The schemas option key "${name}" does not match any entity of the data source.`,
+                code: ErrorCode.INPUT_INVALID,
+            });
         }
     }
 

--- a/packages/adapter-typeorm/test/unit/schema/assert.spec.ts
+++ b/packages/adapter-typeorm/test/unit/schema/assert.spec.ts
@@ -7,7 +7,11 @@
 
 import type { SchemaOptions } from '@rapiq/core';
 import {
-    ErrorCode, SchemaError, and, defineSchema, eq,
+    ErrorCode, 
+    SchemaError, 
+    and, 
+    defineSchema, 
+    eq,
 } from '@rapiq/core';
 import type { DataSource } from 'typeorm';
 import {

--- a/packages/adapter-typeorm/test/unit/schema/assert.spec.ts
+++ b/packages/adapter-typeorm/test/unit/schema/assert.spec.ts
@@ -6,7 +6,9 @@
  */
 
 import type { SchemaOptions } from '@rapiq/core';
-import { and, defineSchema, eq } from '@rapiq/core';
+import {
+    ErrorCode, SchemaError, and, defineSchema, eq,
+} from '@rapiq/core';
 import type { DataSource } from 'typeorm';
 import {
     SchemaEntityMismatchError,
@@ -193,5 +195,17 @@ describe('src/schema/assert.ts', () => {
         });
         expect(grabError(() => assertSchemaMatchesEntity(invalid, User, dataSource)).keys)
             .toEqual(['renamedAway']);
+    });
+
+    it('should throw typed when an entity target comes without a data source', () => {
+        const schema = defineSchema({ name: 'target-no-source' });
+
+        try {
+            assertSchemaMatchesEntity(schema, User, undefined as unknown as DataSource);
+            expect.fail('should have thrown');
+        } catch (e) {
+            expect(e).toBeInstanceOf(SchemaError);
+            expect((e as SchemaError).code).toBe(ErrorCode.INPUT_INVALID);
+        }
     });
 });

--- a/packages/core/src/errors/code.ts
+++ b/packages/core/src/errors/code.ts
@@ -24,6 +24,8 @@ export enum ErrorCode {
 
     KEY_VALIDATE_REJECTED = 'keyValidateRejected',
 
+    LIMIT_EXCEEDED = 'limitExceeded',
+
     OPERATOR_UNSUPPORTED = 'operatorUnsupported',
 
     FEATURE_UNSUPPORTED = 'featureUnsupported',

--- a/packages/core/src/parameter/filters/collection/module.ts
+++ b/packages/core/src/parameter/filters/collection/module.ts
@@ -96,26 +96,34 @@ export class Filters<
 
     /**
      * Wrap & inject (immutable): the receiver becomes a child of a new
-     * AND group holding the given conditions. Injected conditions can
-     * therefore never be displaced by a later merge().
+     * AND group holding the given conditions. The result is never a
+     * flat root-AND, so injected conditions cannot be displaced by a
+     * later merge() — an empty receiver therefore wraps the injected
+     * conditions in a nested group instead of adopting them directly.
      */
     and(...conditions: ICondition[]) : IFilters {
-        if (this.value.length === 0) {
-            return new Filters(FilterCompoundOperator.AND, conditions);
-        }
-
-        return new Filters(FilterCompoundOperator.AND, [this, ...conditions]);
+        return this.wrap(FilterCompoundOperator.AND, conditions);
     }
 
     /**
      * Wrap & inject (immutable), OR variant of {@link Filters.and}.
      */
     or(...conditions: ICondition[]) : IFilters {
-        if (this.value.length === 0) {
-            return new Filters(FilterCompoundOperator.OR, conditions);
+        return this.wrap(FilterCompoundOperator.OR, conditions);
+    }
+
+    protected wrap(operator: string, conditions: ICondition[]) : IFilters {
+        if (conditions.length === 0) {
+            return this;
         }
 
-        return new Filters(FilterCompoundOperator.OR, [this, ...conditions]);
+        if (this.value.length === 0) {
+            return new Filters(operator, [
+                new Filters(operator, conditions),
+            ]);
+        }
+
+        return new Filters(operator, [this, ...conditions]);
     }
 }
 

--- a/packages/core/src/parser/parameter/pagination/error.ts
+++ b/packages/core/src/parser/parameter/pagination/error.ts
@@ -5,10 +5,13 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { ParseError } from '../../../errors';
+import { ErrorCode, ParseError } from '../../../errors';
 
 export class PaginationParseError extends ParseError {
     static limitExceeded(limit: number) {
-        return new this({ message: `The pagination limit must not exceed the value of ${limit}.` });
+        return new this({
+            code: ErrorCode.LIMIT_EXCEEDED,
+            message: `The pagination limit must not exceed the value of ${limit}.`,
+        });
     }
 }

--- a/packages/core/test/unit/parameter/merge.spec.ts
+++ b/packages/core/test/unit/parameter/merge.spec.ts
@@ -170,16 +170,42 @@ describe('src/parameter/filters/collection/module.ts combinators', () => {
         expect(() => scoped.merge(hostile)).toThrowError(MergeError);
     });
 
-    it('should start a fresh group when the receiver is empty', () => {
+    it('should start a nested group when the receiver is empty', () => {
         const query = defineQuery();
 
+        // the injected conditions land in a nested group so the result
+        // is never a flat root-AND — merge-refusal holds even when the
+        // client sent no filters at all.
         const scoped = query.filters.and(eq('realm.id', 'master'));
         expect(scoped.operator).toBe(FilterCompoundOperator.AND);
-        expect(conditions(scoped)).toEqual([['realm.id', 'eq', 'master']]);
+        expect(scoped.value).toHaveLength(1);
+        expect(scoped.value[0]).toBeInstanceOf(Filters);
+        expect(conditions(scoped.value[0] as Filters)).toEqual([['realm.id', 'eq', 'master']]);
 
         const alternatives = query.filters.or(eq('name', 'a'), eq('name', 'b'));
         expect(alternatives.operator).toBe(FilterCompoundOperator.OR);
-        expect(alternatives.value).toHaveLength(2);
+        expect(alternatives.value).toHaveLength(1);
+        expect((alternatives.value[0] as Filters).value).toHaveLength(2);
+    });
+
+    it('should not allow a replace-merge to displace a condition injected onto an empty receiver', () => {
+        const scoped = new Query({ filters: defineQuery().filters.and(eq('realm.id', 'master')) });
+        const hostile = defineQuery<User>({ filters: { 'realm.id': 'evil' } });
+
+        try {
+            mergeQueries(hostile, scoped);
+            expect.fail('should have thrown');
+        } catch (e) {
+            expect(e).toBeInstanceOf(MergeError);
+            expect((e as MergeError).code).toBe(ErrorCode.FILTERS_NOT_FLAT);
+        }
+    });
+
+    it('should return the receiver when no conditions are injected', () => {
+        const query = defineQuery<User>({ filters: { name: 'John' } });
+
+        expect(query.filters.and()).toBe(query.filters);
+        expect(query.filters.or()).toBe(query.filters);
     });
 
     it('should wrap an existing tree when or() adds alternatives', () => {

--- a/packages/docs/.vitepress/config.mjs
+++ b/packages/docs/.vitepress/config.mjs
@@ -2,9 +2,10 @@ import { defineConfig } from 'vitepress';
 
 export default defineConfig({
     title: 'Rapiq',
-    description: 'One query language between client & server — JSON:API-style queries, a typed AST, schema allow-lists and composable SQL/TypeORM adapters.',
+    description: 'One query language between client & server: JSON:API-style queries, a typed AST, schema allow-lists and composable adapters for SQL, TypeORM, Prisma, Drizzle and in-memory data.',
     base: '/',
     lastUpdated: true,
+    srcExclude: ['README.md'],
 
     head: [
         ['link', {
@@ -83,8 +84,12 @@ export default defineConfig({
                 {
                     text: 'Recipes',
                     items: [
-                        { text: 'REST API with Express & TypeORM', link: '/guide/recipes/express-typeorm' },
+                        { text: 'Overview', link: '/guide/recipes/' },
                         { text: 'Type-Safe Frontend Queries', link: '/guide/recipes/frontend' },
+                        { text: 'REST API with Express & TypeORM', link: '/guide/recipes/express-typeorm' },
+                        { text: 'Swapping the Backend: Prisma & Drizzle', link: '/guide/recipes/prisma-drizzle' },
+                        { text: 'MongoDB-Style Search Endpoint', link: '/guide/recipes/mongo-search' },
+                        { text: 'Testing with the Memory Adapter', link: '/guide/recipes/testing-memory' },
                         { text: 'Authorization & Scoping', link: '/guide/recipes/authorization' },
                     ],
                 },

--- a/packages/docs/.vitepress/theme/components/CodeTabs.vue
+++ b/packages/docs/.vitepress/theme/components/CodeTabs.vue
@@ -9,26 +9,21 @@ interface Tab {
 const tabs: Tab[] = [
     {
         label: 'Install',
-        code: `# client side — build & encode queries
+        code: `# client side: build & encode queries
 npm install @rapiq/core @rapiq/codec-url
 
-# server side — parse, validate & translate
+# server side: parse, validate & translate
 npm install @rapiq/core @rapiq/parser-simple @rapiq/adapter-sql`,
     },
     {
         label: 'Build (client)',
-        code: `import {
-    Filter, FilterCompoundOperator, FilterFieldOperator,
-    Filters, Pagination, Query, Sort, Sorts,
-} from '@rapiq/core';
+        code: `import { defineQuery } from '@rapiq/core';
 import { createURLCodec } from '@rapiq/codec-url';
 
-const query = new Query({
-    filters: new Filters(FilterCompoundOperator.AND, [
-        new Filter(FilterFieldOperator.GREATER_THAN_EQUAL, 'age', 18),
-    ]),
-    sorts: new Sorts([new Sort('age', 'DESC')]),
-    pagination: new Pagination(25, 0),
+const query = defineQuery<User>({
+    filters: { age: { $gte: 18 } },
+    sort: '-age',
+    pagination: { limit: 25 },
 });
 
 const codec = createURLCodec();
@@ -66,7 +61,7 @@ const copy = async (code: string) => {
         await navigator.clipboard.writeText(code);
     } catch {
         // Clipboard API can reject in insecure contexts or on permission
-        // denial — leave `copied` false so the button doesn't claim success.
+        // denial; leave `copied` false so the button doesn't claim success.
         return;
     }
     copied.value = true;

--- a/packages/docs/.vitepress/theme/components/FeatureGrid.vue
+++ b/packages/docs/.vitepress/theme/components/FeatureGrid.vue
@@ -9,32 +9,32 @@ const features: Feature[] = [
     {
         icon: '🌐',
         title: 'JSON:API-style',
-        detail: 'Fields, filters, relations, pagination & sort — one consistent query scheme based on the JSON:API specification.',
+        detail: 'Fields, filters, relations, pagination & sort: one consistent query scheme based on the JSON:API specification.',
     },
     {
         icon: '🌲',
         title: 'Typed query AST',
-        detail: 'Input parses into Query nodes that backends consume via the visitor pattern — new targets never touch core.',
+        detail: 'Input parses into Query nodes that backends consume via the visitor pattern; new targets never touch core.',
     },
     {
         icon: '🛡️',
         title: 'Schema allow-lists',
-        detail: 'Declare what clients may request — allowed keys, defaults, mappings. Disallowed input is dropped or throws.',
+        detail: 'Declare what clients may request: allowed keys, defaults, mappings. Disallowed input is dropped or throws.',
     },
     {
         icon: '🧩',
         title: 'Pluggable parsers',
-        detail: 'Parse plain objects or an expression language — both dialects produce the exact same Query AST.',
+        detail: 'Plain objects, expression strings or MongoDB-style documents: every dialect produces the exact same Query AST.',
     },
     {
         icon: '🗄️',
-        title: 'SQL & TypeORM',
-        detail: 'Render parameterized SQL for five dialects, or apply a Query straight to a TypeORM SelectQueryBuilder.',
+        title: 'Any backend',
+        detail: 'One AST, five adapters: parameterized SQL, a TypeORM SelectQueryBuilder, Prisma args, a Drizzle query config or plain functions over in-memory data.',
     },
     {
         icon: '🔒',
         title: 'TypeScript-first',
-        detail: 'Typed key paths via recursive NestedKeys<T> — allow-lists and defaults autocomplete against your records.',
+        detail: 'Typed key paths via recursive NestedKeys<T>: allow-lists and defaults autocomplete against your records.',
     },
 ];
 </script>

--- a/packages/docs/.vitepress/theme/components/Hero.vue
+++ b/packages/docs/.vitepress/theme/components/Hero.vue
@@ -60,7 +60,7 @@ const urlOutput = computed(() => {
         return '/users';
     }
 
-    // Decode only the structural delimiters (`[`, `]`, `,`) for readability —
+    // Decode only the structural delimiters (`[`, `]`, `,`) for readability;
     // never the value content, so encoded separators inside a value (`%26`,
     // `%3D`) stay encoded and the displayed URL keeps its real wire format.
     return `/users?${encoded
@@ -86,7 +86,7 @@ const sqlOutput = computed(() => {
         query.value.filters.accept(new FiltersVisitor(filtersAdapter));
         [where, params] = filtersAdapter.getQueryAndParameters();
     } catch (e) {
-        // a dialect preset may reject an operator entirely —
+        // a dialect preset may reject an operator entirely:
         // e.g. mssql throws for regexp, which "contains" lowers to.
         return {
             text: '',
@@ -146,8 +146,9 @@ const sqlOutput = computed(() => {
                 <p class="rq-hero-tagline">
                     One query language between client &amp; server.
                     Build JSON:API-style queries on the client, parse them into a typed
-                    AST against schema allow-lists on the server — and turn them into
-                    SQL or TypeORM queries with composable adapters.
+                    AST against schema allow-lists on the server, and execute them on
+                    any backend: composable adapters cover raw SQL, TypeORM, Prisma,
+                    Drizzle and in-memory data.
                 </p>
                 <div class="rq-hero-actions">
                     <a
@@ -259,7 +260,7 @@ const sqlOutput = computed(() => {
                     </div>
 
                     <p class="rq-hero-card-hint">
-                        Live — <code>@rapiq/parser-simple</code>, <code>@rapiq/codec-url</code>
+                        Live: <code>@rapiq/parser-simple</code>, <code>@rapiq/codec-url</code>
                         and <code>@rapiq/adapter-sql</code> are running in your browser.
                     </p>
                 </div>

--- a/packages/docs/.vitepress/theme/components/PackageLayers.vue
+++ b/packages/docs/.vitepress/theme/components/PackageLayers.vue
@@ -75,7 +75,7 @@ const layers: Layer[] = [
             </div>
         </div>
         <figcaption class="rq-layers-caption">
-            Each band depends only on the bands above it — internal
+            Each band depends only on the bands above it; internal
             dependencies are peer dependencies, so npm installs nothing
             you didn't ask for.
         </figcaption>

--- a/packages/docs/.vitepress/theme/components/PackageShowcase.vue
+++ b/packages/docs/.vitepress/theme/components/PackageShowcase.vue
@@ -12,7 +12,7 @@ const packages: PackageCard[] = [
         name: '@rapiq/core',
         accent: 'var(--rq-color-primary)',
         href: '/packages/core',
-        summary: 'The foundation — query AST, typed build layer and the schema system everything else builds on.',
+        summary: 'The foundation: query AST, typed build layer and the schema system everything else builds on.',
         bullets: [
             'defineQuery() + condition helpers (eq, and, or, …)',
             'defineSchema() + SchemaRegistry allow-lists',
@@ -23,7 +23,7 @@ const packages: PackageCard[] = [
         name: '@rapiq/parser-simple',
         accent: 'var(--rq-color-accent)',
         href: '/packages/parser-simple',
-        summary: 'Parses plain object/array input — the URL-query-like "simple" dialect.',
+        summary: 'Parses plain object/array input: the URL-query-like "simple" dialect.',
         bullets: [
             'Filters like { age: \'>=18\', name: \'~jo~\' }',
             'Schema validation while parsing',
@@ -56,7 +56,7 @@ const packages: PackageCard[] = [
         name: '@rapiq/codec-url',
         accent: 'var(--rq-color-warning)',
         href: '/packages/codec-url',
-        summary: 'URL query-string codec — the transport between caller and receiver.',
+        summary: 'URL query-string codec: the transport between caller and receiver.',
         bullets: [
             'Expression filters by default',
             'Legacy simple-filter decoding',
@@ -71,7 +71,7 @@ const packages: PackageCard[] = [
         bullets: [
             'Presets: Postgres, MySQL, SQLite, MSSQL, Oracle',
             'Dialects are option objects, not subclasses',
-            'Visitor-driven — fragments accumulate per parameter',
+            'Visitor-driven: fragments accumulate per parameter',
         ],
     },
     {
@@ -114,7 +114,7 @@ const packages: PackageCard[] = [
         summary: 'Evaluates the same Query against in-memory objects & arrays.',
         bullets: [
             'Filters compile to plain predicates',
-            'SQL-parity semantics — guards agree with the database',
+            'SQL-parity semantics: guards agree with the database',
             'Perfect for authorization checks & tests',
         ],
     },
@@ -129,7 +129,7 @@ const packages: PackageCard[] = [
             </h2>
             <p class="rq-packages-sub">
                 rapiq is a family of focused, composable packages.
-                Install only what each side of your application needs —
+                Install only what each side of your application needs;
                 everything meets in the core query AST.
                 <a href="/packages/">Browse all packages →</a>
             </p>

--- a/packages/docs/.vitepress/theme/components/QueryHub.vue
+++ b/packages/docs/.vitepress/theme/components/QueryHub.vue
@@ -2,7 +2,7 @@
 /*
  * The "Query is the hub" figure for the Core Concepts page:
  * producers on the left, the shared AST in the middle, consumers on
- * the right — with the schema constraining what parsers let through.
+ * the right, with the schema constraining what parsers let through.
  */
 </script>
 
@@ -26,7 +26,7 @@
 
             <div class="rq-hub-schema">
                 <strong>Schema</strong>
-                <span>allow-list — constrains parsing</span>
+                <span>allow-list, constrains parsing</span>
             </div>
         </div>
 

--- a/packages/docs/.vitepress/theme/components/QueryPipeline.vue
+++ b/packages/docs/.vitepress/theme/components/QueryPipeline.vue
@@ -21,13 +21,13 @@
             </div>
 
             <div class="rq-pipe-arrow">
-                <span class="rq-pipe-arrow-label">encode — <code>URLCodec</code></span>
+                <span class="rq-pipe-arrow-label">encode · <code>URLCodec</code></span>
             </div>
         </div>
 
         <div class="rq-pipe-wire">
             <span class="rq-pipe-wire-label">HTTP</span>
-            <code>?filter[age]=&gt;=18&amp;include=realm&amp;sort=-age&amp;page[limit]=25</code>
+            <code>?codec=url-expression&amp;filter=gte(age,'18')&amp;include=realm&amp;sort=-age&amp;page[limit]=25</code>
         </div>
 
         <div
@@ -37,13 +37,13 @@
             <span class="rq-pipe-zone-label">Receiver</span>
 
             <div class="rq-pipe-arrow">
-                <span class="rq-pipe-arrow-label">decode — <code>URLCodec</code> / parsers</span>
+                <span class="rq-pipe-arrow-label">decode · <code>URLCodec</code> / parsers</span>
             </div>
 
             <div class="rq-pipe-node">
                 <span class="rq-pipe-node-title">Validate</span>
                 <span class="rq-pipe-node-sub">
-                    checked against the <strong>Schema</strong> allow-list —
+                    checked against the <strong>Schema</strong> allow-list;
                     anything not permitted is dropped or rejected
                 </span>
             </div>
@@ -52,11 +52,11 @@
 
             <div class="rq-pipe-node rq-pipe-node-query">
                 <span class="rq-pipe-node-title">Query</span>
-                <span class="rq-pipe-node-sub">the shared, typed AST — same shape on both sides</span>
+                <span class="rq-pipe-node-sub">the shared, typed AST: same shape on both sides</span>
             </div>
 
             <div class="rq-pipe-arrow">
-                <span class="rq-pipe-arrow-label">execute — <code>accept(visitor)</code></span>
+                <span class="rq-pipe-arrow-label">execute · <code>accept(visitor)</code></span>
             </div>
 
             <div class="rq-pipe-adapters">

--- a/packages/docs/.vitepress/theme/components/TypeormSection.vue
+++ b/packages/docs/.vitepress/theme/components/TypeormSection.vue
@@ -20,15 +20,15 @@ const [entities, total] = await queryBuilder.getManyAndCount();`;
                     Straight into TypeORM
                 </h2>
                 <p class="rq-typeorm-tagline">
-                    Apply a parsed Query directly to a SelectQueryBuilder —
+                    Apply a parsed Query directly to a SelectQueryBuilder:
                     the adapter walks the AST and mutates the builder, nothing
                     is stringified twice.
                 </p>
                 <ul class="rq-typeorm-list">
-                    <li><strong>TypeormAdapter</strong> — wraps any SelectQueryBuilder</li>
-                    <li><strong>Visitor-driven</strong> — reuses the @rapiq/adapter-sql visitors</li>
-                    <li><strong>Relations → joins</strong> — allowed relations join automatically</li>
-                    <li><strong>Parameterized</strong> — filter values bind as parameters, never interpolated</li>
+                    <li><strong>TypeormAdapter</strong>: wraps any SelectQueryBuilder</li>
+                    <li><strong>Visitor-driven</strong>: reuses the @rapiq/adapter-sql visitors</li>
+                    <li><strong>Relations → joins</strong>: allowed relations join automatically</li>
+                    <li><strong>Parameterized</strong>: filter values bind as parameters, never interpolated</li>
                 </ul>
                 <a
                     class="rq-btn rq-btn-primary"

--- a/packages/docs/.vitepress/theme/index.ts
+++ b/packages/docs/.vitepress/theme/index.ts
@@ -9,7 +9,7 @@ import './style.css';
 
 /*
  * VitePress theme entry. The landing page (index.md) composes the
- * marketing components from ./components/ — they are imported there
+ * marketing components from ./components/; they are imported there
  * directly. The diagram components below are used across guide pages,
  * so they register globally.
  */

--- a/packages/docs/.vitepress/theme/style.css
+++ b/packages/docs/.vitepress/theme/style.css
@@ -3,11 +3,11 @@
  *
  * Every color used by the landing-page components resolves through
  * these custom properties, which are bound to VitePress's own theme
- * variables — so light/dark mode works without per-component variants.
+ * variables, so light/dark mode works without per-component variants.
  */
 
 :root {
-    /* brand — violet → cyan, echoing the rapiq 🌈 rainbow */
+    /* brand: violet → cyan, echoing the rapiq 🌈 rainbow */
     --vp-c-brand-1: #7c3aed;
     --vp-c-brand-2: #8b5cf6;
     --vp-c-brand-3: #8b5cf6;

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -21,4 +21,4 @@ npm run dev --workspace=packages/docs     # local dev server
 npm run build --workspace=packages/docs   # production build (runs in CI)
 ```
 
-Content lives in `getting-started/`, `guide/`, `packages/` and `integrations/`; navigation and sidebar are configured in `.vitepress/config.mjs`.
+Content lives in `guide/` and `packages/`; `getting-started/` and `integrations/` hold redirect stubs for legacy URLs. Navigation and sidebar are configured in `.vitepress/config.mjs`.

--- a/packages/docs/guide/building-queries.md
+++ b/packages/docs/guide/building-queries.md
@@ -1,6 +1,6 @@
 # Building Queries
 
-`defineQuery` builds a [`Query`](/guide/query-ast) directly from typed input — no string round-trip, no parsing, no schema. It is the caller-side entry point: construct the query, hand it to the [URL codec](/guide/wire) for transport, or to an [adapter](/guide/executing-queries) directly.
+`defineQuery` builds a [`Query`](/guide/query-ast) directly from typed input: no string round-trip, no parsing, no schema. It is the caller-side entry point: construct the query, hand it to the [URL codec](/guide/wire) for transport, or to an [adapter](/guide/executing-queries) directly.
 
 ```typescript
 import { defineQuery } from '@rapiq/core';
@@ -16,7 +16,7 @@ const query = defineQuery<User>({
 
 Supplying a record generic (`defineQuery<User>`) types every field path (`'realm.name'`, …) with autocomplete; without one, plain strings are accepted.
 
-The input types recurse through nested records up to a default depth of 5. For self-recursive record types (`type Category = { children: Category[] }`) the inferred input type can outgrow what the compiler will serialize — pass an explicit depth as the second generic to bound it: `defineQuery<Category, 2>(...)`, `QueryBuildInput<Category, 2>`.
+The input types recurse through nested records up to a default depth of 5. For self-recursive record types (`type Category = { children: Category[] }`) the inferred input type can outgrow what the compiler will serialize; pass an explicit depth as the second generic to bound it: `defineQuery<Category, 2>(...)`, `QueryBuildInput<Category, 2>`.
 
 ::: info No validation here
 The build layer constructs the query verbatim. What a client *may* request is decided on the receiving side, where parsers validate against a [Schema](/guide/schemas). Keeping the two concerns apart is deliberate: the caller doesn't need the schema, and the receiver never trusts the caller.
@@ -29,11 +29,11 @@ Four equivalent notations, freely mixable:
 | Notation | Example | Meaning |
 |---|---|---|
 | scalar | `{ name: 'John' }` | equals |
-| bare array | `{ 'realm.id': [1, null] }` | *in* list — `null` is a legal element; backends rewrite it to `… OR IS NULL` |
+| bare array | `{ 'realm.id': [1, null] }` | *in* list; `null` is a legal element and backends rewrite it to `… OR IS NULL` |
 | operator object | `{ age: { $gte: 18, $lt: 65 } }` | explicit operators, combined with **and** |
 | condition helpers | `or(gte('age', 18), eq('deleted_at', null))` | arbitrary condition trees |
 
-Multiple keys combine with **and** (a flat root-AND). A relation reads either fully nested (`{ realm: { name: 'master' } }`) or as a dot-path (`{ 'realm.name': 'master' }`) — the two are interchangeable but not mixable within one key (write `{ 'realm.x.y': v }`, not `{ realm: { 'x.y': v } }`); keeping them disjoint bounds the inferred input type for deeply/cyclically related records. A bare `RegExp` value builds a `regex` condition.
+Multiple keys combine with **and** (a flat root-AND). A relation reads either fully nested (`{ realm: { name: 'master' } }`) or as a dot-path (`{ 'realm.name': 'master' }`); the two are interchangeable but not mixable within one key (write `{ 'realm.x.y': v }`, not `{ realm: { 'x.y': v } }`); keeping them disjoint bounds the inferred input type for deeply/cyclically related records. A bare `RegExp` value builds a `regex` condition.
 
 ### Operator objects
 
@@ -60,7 +60,7 @@ defineQuery<User>({
 });
 ```
 
-Operator keys that are present but `undefined` are skipped — conditional spreads like `{ $contains: search || undefined }` simply contribute no condition. Unknown `$` keys throw a `BuildError` (`ErrorCode.OPERATOR_UNSUPPORTED`) — input is never guessed at.
+Operator keys that are present but `undefined` are skipped: conditional spreads like `{ $contains: search || undefined }` simply contribute no condition. Unknown `$` keys throw a `BuildError` (`ErrorCode.OPERATOR_UNSUPPORTED`); input is never guessed at.
 
 ::: warning Reserved: `$and` / `$or`
 Compound object keys belong to the [MongoDB-style parser dialect](/packages/parser-mongo) and are deliberately **not** part of the build layer. Compound trees are written with the condition helpers instead: `filters: or(...)`.
@@ -68,7 +68,7 @@ Compound object keys belong to the [MongoDB-style parser dialect](/packages/pars
 
 ### Condition helpers
 
-Typed constructors for single conditions and compound trees — one per operator, mirroring the [expression dialect](/packages/parser-expression) one-to-one (`eq('name', 'John')` in code ≙ `eq(name, 'John')` on the wire):
+Typed constructors for single conditions and compound trees: one per operator, mirroring the [expression dialect](/packages/parser-expression) one-to-one (`eq('name', 'John')` in code ≙ `eq(name, 'John')` on the wire):
 
 ```typescript
 import { and, eq, gte, inArray, or } from '@rapiq/core';
@@ -81,15 +81,15 @@ const query = defineQuery<User>({
 });
 ```
 
-`eq` `ne` `lt` `lte` `gt` `gte` `inArray` `nin` `startsWith` `notStartsWith` `endsWith` `notEndsWith` `contains` `notContains` `regex` `mod` `size` `exists` `elemMatch` — plus the `and` / `or` / `not` compounds. `not(condition)` is the exact complement of its interior (see [Negation](/guide/filters#negation)); multiple arguments negate their conjunction.
+`eq` `ne` `lt` `lte` `gt` `gte` `inArray` `nin` `startsWith` `notStartsWith` `endsWith` `notEndsWith` `contains` `notContains` `regex` `mod` `size` `exists` `elemMatch`, plus the `and` / `or` / `not` compounds. `not(condition)` is the exact complement of its interior (see [Negation](/guide/filters#negation)); multiple arguments negate their conjunction.
 
 A few helpers deviate from the uniform `(field, value)` signature:
 
 ```typescript
 mod('age', 4, 0);                    // (field, divisor, remainder)
-size('tags', 2);                     // (field, length) — array length
+size('tags', 2);                     // (field, length): array length
 exists('email');                     // (field, value = true)
-elemMatch('items', eq('name', 'x')); // (field, condition) — condition
+elemMatch('items', eq('name', 'x')); // (field, condition): condition
                                      // field paths are element-relative
 elemMatch('scores', gt(ITSELF, 5));  // ITSELF addresses the element
                                      // itself (scalar arrays)
@@ -109,14 +109,14 @@ The URL codec writes the [expression dialect](/packages/codec-url#expression-dia
 
 | Parameter | Input forms |
 |---|---|
-| `fields` | array of keys with optional `+`/`-` prefix (`['id', '+email', '-password']`), per-relation record (`{ realm: ['id'] }`), or tuple `[keys, record]` — see [Fields](/guide/fields) |
-| `sort` | key with optional `-` prefix (`'-created_at'`), array of such keys, or record (`{ created_at: 'DESC', realm: { name: 'ASC' } }`) — see [Sort](/guide/sort) |
-| `relations` | dot-path names (`['realm', 'items.user']`) or record (`{ realm: true, items: { user: true } }`) — see [Relations](/guide/relations) |
-| `pagination` | `{ limit?, offset? }` — see [Pagination](/guide/pagination) |
+| `fields` | array of keys with optional `+`/`-` prefix (`['id', '+email', '-password']`), per-relation record (`{ realm: ['id'] }`), or tuple `[keys, record]`; see [Fields](/guide/fields) |
+| `sort` | key with optional `-` prefix (`'-created_at'`), array of such keys, or record (`{ created_at: 'DESC', realm: { name: 'ASC' } }`); see [Sort](/guide/sort) |
+| `relations` | dot-path names (`['realm', 'items.user']`) or record (`{ realm: true, items: { user: true } }`); see [Relations](/guide/relations) |
+| `pagination` | `{ limit?, offset? }`; see [Pagination](/guide/pagination) |
 
 ## Fragments
 
-Each parameter has its own factory — `defineFields`, `defineFilters`, `definePagination`, `defineRelations`, `defineSorts` — returning a fragment that assigns directly into `defineQuery` input. Useful when query parts travel as data (props, composables, function arguments) before being assembled:
+Each parameter has its own factory (`defineFields`, `defineFilters`, `definePagination`, `defineRelations`, `defineSorts`) returning a fragment that assigns directly into `defineQuery` input. Useful when query parts travel as data (props, composables, function arguments) before being assembled:
 
 ```typescript
 import { defineFilters, defineQuery } from '@rapiq/core';
@@ -133,6 +133,6 @@ Fragments and raw input mix freely; already-built AST nodes pass through unchang
 
 ## Next steps
 
-- [Merging & Composition](/guide/merging-queries) — combining queries from multiple sources.
-- [Queries over the Wire](/guide/wire) — encoding what you built.
-- [Recipes: Type-safe frontend queries](/guide/recipes/frontend) — fragments and merging in a real list view.
+- [Merging & Composition](/guide/merging-queries): combining queries from multiple sources.
+- [Queries over the Wire](/guide/wire): encoding what you built.
+- [Recipes: Type-safe frontend queries](/guide/recipes/frontend): fragments and merging in a real list view.

--- a/packages/docs/guide/concepts.md
+++ b/packages/docs/guide/concepts.md
@@ -1,12 +1,12 @@
 # Core Concepts
 
-rapiq has four moving parts — **Query**, **Schema**, **Parser**, **Adapter**. Everything else in the package family is a variation of one of them. Understanding these four once makes every other page in these docs a detail.
+rapiq has four moving parts: **Query**, **Schema**, **Parser**, **Adapter**. Everything else in the package family is a variation of one of them. Understanding these four once makes every other page in these docs a detail.
 
 Everything meets in the middle:
 
 <QueryHub />
 
-## Query — the shared language
+## Query: the shared language
 
 A `Query` is a small, typed object tree (an AST) with one collection per parameter:
 
@@ -20,7 +20,7 @@ class Query {
 }
 ```
 
-It is the **only** thing the packages share — parsers produce it, codecs transport it, schemas constrain it, adapters consume it. That single meeting point is what makes the pieces swappable: the TypeORM adapter neither knows nor cares whether a query arrived as a URL, an expression string, a MongoDB-style document or was built in code.
+It is the **only** thing the packages share: parsers produce it, codecs transport it, schemas constrain it, adapters consume it. That single meeting point is what makes the pieces swappable: the TypeORM adapter neither knows nor cares whether a query arrived as a URL, an expression string, a MongoDB-style document or was built in code.
 
 There are three ways to obtain one:
 
@@ -58,9 +58,9 @@ codec=url-expression&filter=and(gte(age, '18'), contains(name, 'jo'))
 
 Dialects are input syntax only; semantics live in the AST.
 
-## Schema — the server's contract
+## Schema: the server's contract
 
-A `Schema<RECORD>` declares what a client *may* request, per parameter — allowed keys, defaults, alias mappings, a pagination cap:
+A `Schema<RECORD>` declares what a client *may* request, per parameter: allowed keys, defaults, alias mappings, a pagination cap:
 
 ```typescript
 const userSchema = defineSchema<User>({
@@ -76,29 +76,29 @@ const userSchema = defineSchema<User>({
 
 Parsers consult the schema *while* parsing: disallowed input is dropped by default, or throws when `throwOnFailure` is set. A `SchemaRegistry` stores schemas by name so relation paths (`realm.name`) validate against the *related* record's schema. Details in [Schemas & Validation](/guide/schemas).
 
-## Parser — from input to Query
+## Parser: from input to Query
 
 Parsers turn raw, untrusted input into a validated `Query`. Each speaks one input *dialect*:
 
-- [`SimpleParser`](/packages/parser-simple) — plain objects/arrays, URL-query-like (`{ age: '>=18' }`)
-- [`ExpressionParser`](/packages/parser-expression) — expression strings (`and(eq(name, 'John'), gte(age, '18'))`)
-- [`MongoParser`](/packages/parser-mongo) — MongoDB-style documents (`{ age: { $gte: 18 } }`)
+- [`SimpleParser`](/packages/parser-simple): plain objects/arrays, URL-query-like (`{ age: '>=18' }`)
+- [`ExpressionParser`](/packages/parser-expression): expression strings (`and(eq(name, 'John'), gte(age, '18'))`)
+- [`MongoParser`](/packages/parser-mongo): MongoDB-style documents (`{ age: { $gte: 18 } }`)
 
 Parsers are transport-agnostic: they read canonical parameter keys (`fields`, `filters`, …) and don't know about URLs. The [`URLCodec`](/guide/wire) façade maps URL wire names (`filter`, `page`, `include`, …) onto the matching parser and performs the reverse trip. It hides expression/simple dialect dispatch from callers.
 
-## Adapter — from Query to results
+## Adapter: from Query to results
 
 Adapters execute a `Query` against a backend:
 
-- [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) — mutates a TypeORM `SelectQueryBuilder`
-- [`@rapiq/adapter-sql`](/packages/adapter-sql) — renders parameterized SQL fragments for any driver
-- [`@rapiq/adapter-prisma`](/packages/adapter-prisma) — serializes the query into a Prisma `findMany` args object
-- [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) — serializes the query into a drizzle relational-queries `findMany` config
-- [`@rapiq/adapter-memory`](/packages/adapter-memory) — compiles the query into plain functions over in-memory data
+- [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm): mutates a TypeORM `SelectQueryBuilder`
+- [`@rapiq/adapter-sql`](/packages/adapter-sql): renders parameterized SQL fragments for any driver
+- [`@rapiq/adapter-prisma`](/packages/adapter-prisma): serializes the query into a Prisma `findMany` args object
+- [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle): serializes the query into a drizzle relational-queries `findMany` config
+- [`@rapiq/adapter-memory`](/packages/adapter-memory): compiles the query into plain functions over in-memory data
 
-They all consume the same AST: the SQL-facing pair walk it through the **visitor pattern** (every node has `accept(visitor)`), prisma and drizzle serialize it into plain config values, and memory compiles it into functions. New backends never require changes to core — see [The Query AST](/guide/query-ast) if you want to build one.
+They all consume the same AST: the SQL-facing pair walk it through the **visitor pattern** (every node has `accept(visitor)`), prisma and drizzle serialize it into plain config values, and memory compiles it into functions. New backends never require changes to core; see [The Query AST](/guide/query-ast) if you want to build one.
 
-## Composition — queries are values
+## Composition: queries are values
 
 Because queries are plain immutable-ish values, they compose *after* construction, regardless of where each part came from:
 

--- a/packages/docs/guide/errors.md
+++ b/packages/docs/guide/errors.md
@@ -1,30 +1,30 @@
 # Error Handling
 
-Every error rapiq throws extends `BaseError` and carries a machine-readable `code` from `ErrorCode` — no raw `Error`s, no string matching. This page maps the hierarchy, the codes, and how to translate them into HTTP responses.
+Every error rapiq throws extends `BaseError` and carries a machine-readable `code` from `ErrorCode`: no raw `Error`s, no string matching. This page maps the hierarchy, the codes, and how to translate them into HTTP responses.
 
 ## The hierarchy
 
 ```txt
 BaseError { code: ErrorCode }
-├── BuildError            defineQuery / helpers — malformed build input
-├── MergeError            mergeQueries / node merge — non-flat trees, discarded field gates
-├── ParseError            parsers & decoders — invalid client input
+├── BuildError            defineQuery / helpers: malformed build input
+├── MergeError            mergeQueries / node merge: non-flat trees, discarded field gates
+├── ParseError            parsers & decoders: invalid client input
 │   ├── FieldsParseError
 │   ├── FiltersParseError
 │   ├── PaginationParseError
 │   ├── RelationsParseError
 │   └── SortParseError
-├── AdapterError          backends & encoders — query exceeds the target's subset
-├── CodecError            codec registry — unresolvable dialect
-└── SchemaError           schema registry — misconfigured or unresolvable schema
-    └── SchemaEntityMismatchError   @rapiq/adapter-typeorm — schema keys unknown to the entity
+├── AdapterError          backends & encoders: query exceeds the target's subset
+├── CodecError            codec registry: unresolvable dialect
+└── SchemaError           schema registry: misconfigured or unresolvable schema
+    └── SchemaEntityMismatchError   @rapiq/adapter-typeorm: schema keys unknown to the entity
 ```
 
 ## Where errors come from
 
 ### Build time (caller bug)
 
-`defineQuery` and the condition helpers throw `BuildError` on malformed input — an unknown `$` operator, an invalid key, a bad value shape. These indicate a programming error, not bad user input:
+`defineQuery` and the condition helpers throw `BuildError` on malformed input: an unknown `$` operator, an invalid key, a bad value shape. These indicate a programming error, not bad user input:
 
 | Code | Trigger |
 |---|---|
@@ -35,7 +35,7 @@ BaseError { code: ErrorCode }
 
 ### Merge time (caller bug)
 
-`MergeError` with `FILTERS_NOT_FLAT` — a replace-merge met a compound filter tree. See [Merging & Composition](/guide/merging-queries#merge--per-field-replace).
+`MergeError` with `FILTERS_NOT_FLAT`: a replace-merge met a compound filter tree. See [Merging & Composition](/guide/merging-queries#merge-per-field-replace).
 
 `MergeError` with `FIELDS_CONDITION_DISCARDED`: a fields merge collision would drop a [row-scoped visibility gate](/guide/fields#row-scoped-fields). Keep the gated query as the receiver instead of merging it underneath an ungated one.
 
@@ -47,33 +47,35 @@ Most parser parameters throw subclasses of `ParseError` when `throwOnFailure` is
 |---|---|
 | `KEY_NOT_ALLOWED` | key outside the schema's allow-list |
 | `KEY_PATH_NOT_ALLOWED` | relation path rejected by an allow-list or the relations context |
-| `KEY_VALIDATE_REJECTED` | key rejected by a schema [`validate` hook](/guide/schemas#validate-hooks--parse-context) |
+| `KEY_VALIDATE_REJECTED` | key rejected by a schema [`validate` hook](/guide/schemas#validate-hooks-parse-context) |
 | `KEY_INVALID` | syntactically invalid key under an open schema |
 | `KEY_PATH_INVALID` | unresolvable relation path |
 | `KEY_VALUE_INVALID` | malformed value for an operator |
+| `LIMIT_EXCEEDED` | `page[limit]` above the schema's `maxLimit` |
+| `OPERATOR_UNSUPPORTED` | a recognized dialect operator with no AST counterpart (MongoDB-style parser: known operators like `$type` / `$where` / `$text` / `$expr`, or `$not` over a bare `$regex`); a grammar error that throws regardless of the drop policy |
 | `SYNTAX_INVALID` | malformed expression / document grammar |
 | `INPUT_INVALID` | non-object top-level input |
 
-Two dialects are stricter than the drop policy for grammar: **grammar errors always throw**, regardless of schema settings — a malformed expression string ([expression parser](/packages/parser-expression)) or a broken `$`-operator document ([MongoDB-style parser](/packages/parser-mongo)) has no silent-drop reading.
+Two dialects are stricter than the drop policy for grammar: **grammar errors always throw**, regardless of schema settings. A malformed expression string ([expression parser](/packages/parser-expression)) or a broken `$`-operator document ([MongoDB-style parser](/packages/parser-mongo)) has no silent-drop reading.
 
 ### Encode/apply time (query exceeds the target)
 
-`AdapterError` — the query is valid, but the target can't express it:
+`AdapterError`: the query is valid, but the target can't express it:
 
 | Code | Trigger |
 |---|---|
 | `OPERATOR_UNSUPPORTED` | e.g. `regex` on a dialect without regex support; `regex`/`mod`/`exists`/`elemMatch` on a URL wire |
 | `FEATURE_UNSUPPORTED` | e.g. `or(...)` over the simple URL dialect; values that wouldn't survive the wire round trip; a query whose `Field` carries a [validate-hook condition](/guide/schemas#condition-verdicts) |
 
-The URL encoders throw these too — a codec never silently changes what a query means. See [What fits on the wire](/guide/wire#what-fits-on-the-wire).
+The URL encoders throw these too; a codec never silently changes what a query means. See [What fits on the wire](/guide/wire#what-fits-on-the-wire).
 
 ### Codec dispatch
 
-`CodecError` with `CODEC_UNRESOLVABLE` — a payload named a codec that isn't registered. See [@rapiq/codec-url](/packages/codec-url).
+`CodecError` with `CODEC_UNRESOLVABLE`: a payload named a codec that isn't registered. See [@rapiq/codec-url](/packages/codec-url).
 
 ### Schema registry (server bug)
 
-`SchemaError` — the `SchemaRegistry` was misused or misconfigured. Like `BuildError`, these indicate a programming error on the receiving side:
+`SchemaError`: the `SchemaRegistry` was misused or misconfigured. Like `BuildError`, these indicate a programming error on the receiving side:
 
 | Code | Trigger |
 |---|---|
@@ -81,7 +83,7 @@ The URL encoders throw these too — a codec never silently changes what a query
 | `SCHEMA_UNRESOLVABLE` | `registry.getOrFail()` for a name that isn't registered |
 | `SCHEMA_KEY_VALIDATOR_CONFLICT` | a `fields`/`relations`/`sort` sub-schema declares both [`validate` and `validateMany`](/guide/schemas#batched-validation-with-validatemany); thrown while the schema is constructed, since there is no sensible precedence between them |
 | `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER` | `parse()` (or a synchronous codec method) encountered an async validator (a filter validator or a key validation hook); use the corresponding `Async` method |
-| `SCHEMA_ENTITY_MISMATCH` | `assertSchemaMatchesEntity` (`@rapiq/adapter-typeorm`) found schema keys unknown to the entity — thrown as `SchemaEntityMismatchError`, which carries the offending `schema`, `entity` and `keys`; see [validating schemas against entities](/packages/adapter-typeorm#validating-schemas-against-entities) |
+| `SCHEMA_ENTITY_MISMATCH` | `assertSchemaMatchesEntity` (`@rapiq/adapter-typeorm`) found schema keys unknown to the entity; thrown as `SchemaEntityMismatchError`, which carries the offending `schema`, `entity` and `keys`; see [validating schemas against entities](/packages/adapter-typeorm#validating-schemas-against-entities) |
 
 ## Mapping to HTTP responses
 
@@ -109,8 +111,8 @@ app.get('/users', async (req, res) => {
 });
 ```
 
-- `ParseError` (with `throwOnFailure`) → **400** — the client broke the contract; `e.message` names the offending key.
-- `BuildError` / `MergeError` / `AdapterError` / `SchemaError` on the server → **500** — these mean *your* code produced or forwarded something invalid.
+- `ParseError` (with `throwOnFailure`) → **400**: the client broke the contract; `e.message` names the offending key.
+- `BuildError` / `MergeError` / `AdapterError` / `SchemaError` on the server → **500**: these mean *your* code produced or forwarded something invalid.
 - `AdapterError` on the caller (encode) → fix the query or switch wire dialect; it never leaves the caller.
 
 ## Adding failure modes of your own

--- a/packages/docs/guide/executing-queries.md
+++ b/packages/docs/guide/executing-queries.md
@@ -14,7 +14,7 @@ All five consume the same AST, and they agree on semantics: the records a query 
 
 ## TypeORM
 
-The most common server setup — the adapter applies filters as parameterized `WHERE` conditions, relations as joins, fields/sort/pagination as `select`/`orderBy`/`take`+`skip`:
+The most common server setup: the adapter applies filters as parameterized `WHERE` conditions, relations as joins, fields/sort/pagination as `select`/`orderBy`/`take`+`skip`:
 
 ```typescript
 import { TypeormAdapter } from '@rapiq/adapter-typeorm';
@@ -31,7 +31,7 @@ const { pagination } = adapter.execute(query);
 const [entities, total] = await queryBuilder.getManyAndCount();
 ```
 
-`execute` returns the applied pagination — handy for the response `meta` block. Existing builder state is preserved: rapiq filters are appended with `AND` (under namespaced parameter bindings), and a query without sorts or pagination leaves a caller-owned `ORDER BY`/`take`/`skip` untouched — so tenant or authorization scopes applied before `execute` cannot be erased. Options (join types, the `onJoin` hook, alias conventions) are on the [package page](/packages/adapter-typeorm).
+`execute` returns the applied pagination, handy for the response `meta` block. Existing builder state is preserved: rapiq filters are appended with `AND` (under namespaced parameter bindings), and a query without sorts or pagination leaves a caller-owned `ORDER BY`/`take`/`skip` untouched, so tenant or authorization scopes applied before `execute` cannot be erased. Options (join types, the `onJoin` hook, alias conventions) are on the [package page](/packages/adapter-typeorm).
 
 ## Prisma
 
@@ -99,11 +99,11 @@ const fragments = adapter.execute(query);
 // }
 ```
 
-Values are always bound as parameters — never interpolated into the SQL string. Composing the final `SELECT` (in particular `FROM`/`JOIN`) stays your job, because it needs knowledge of your table layout. Details: [@rapiq/adapter-sql](/packages/adapter-sql).
+Values are always bound as parameters, never interpolated into the SQL string. Composing the final `SELECT` (in particular `FROM`/`JOIN`) stays your job, because it needs knowledge of your table layout. Details: [@rapiq/adapter-sql](/packages/adapter-sql).
 
 ## In memory
 
-`@rapiq/adapter-memory` compiles the same query into plain functions — for authorization guards that must agree with the database, filtering already-loaded collections, or mock backends in tests:
+`@rapiq/adapter-memory` compiles the same query into plain functions: for authorization guards that must agree with the database, filtering already-loaded collections, or mock backends in tests:
 
 ```typescript
 import { applyQuery, compileQuery } from '@rapiq/adapter-memory';
@@ -117,23 +117,25 @@ compiled.matches(user);   // filters as a predicate -> boolean
 compiled.apply(users);    // whole query against a collection
 ```
 
-Semantics (null handling, string matching, join-row binding) mirror the SQL adapters — see [@rapiq/adapter-memory](/packages/adapter-memory).
+Semantics (null handling, string matching, join-row binding) mirror the SQL adapters; see [@rapiq/adapter-memory](/packages/adapter-memory).
 
 ## One adapter instance per request
 
-SQL and TypeORM adapters accumulate per-call state. Construct them **per request** — the shareable, long-lived part is the options object, not the adapter instance:
+SQL and TypeORM adapters accumulate per-call state. Construct them **per request**; the shareable, long-lived part is the options object, not the adapter instance:
 
 ```typescript
-// module scope — the reusable config
+// module scope: the reusable config
 const config = { relations: { joinAndSelect: true } };
 
 // per request
 new TypeormAdapter({ ...config, queryBuilder }).execute(query);
 ```
 
+The prisma and drizzle serializers, by contrast, are stateless: one shared instance serves every request, as shown above.
+
 ## Applying a single parameter
 
-A `Query` with only some parameters set applies just those — the rest are empty and become no-ops:
+A `Query` with only some parameters set applies just those; the rest are empty and become no-ops:
 
 ```typescript
 import { Query } from '@rapiq/core';
@@ -141,10 +143,11 @@ import { Query } from '@rapiq/core';
 adapter.execute(new Query({ filters: query.filters }));
 ```
 
-Each backend also exposes per-parameter building blocks (sub-adapters, `compile*` helpers) — see the package pages.
+Each backend also exposes per-parameter building blocks (sub-adapters, `compile*` helpers); see the package pages.
 
 ## Next steps
 
-- [Recipes: REST API with Express & TypeORM](/guide/recipes/express-typeorm) — the full endpoint.
-- [Recipes: Authorization & scoping](/guide/recipes/authorization) — injected filters + memory-guard parity.
-- [The Query AST](/guide/query-ast) — implement an adapter for a new backend.
+- [Recipes: REST API with Express & TypeORM](/guide/recipes/express-typeorm): the full endpoint.
+- [Recipes: Swapping the Backend: Prisma & Drizzle](/guide/recipes/prisma-drizzle): the same endpoint on the serializer adapters.
+- [Recipes: Authorization & scoping](/guide/recipes/authorization): injected filters + memory-guard parity.
+- [The Query AST](/guide/query-ast): implement an adapter for a new backend.

--- a/packages/docs/guide/fields.md
+++ b/packages/docs/guide/fields.md
@@ -1,6 +1,6 @@
 # Fields
 
-Select which resource fields are returned — or extend/shrink the server's default selection.
+Select which resource fields are returned, or extend/shrink the server's default selection.
 
 | | |
 |---|---|
@@ -13,9 +13,12 @@ Select which resource fields are returned — or extend/shrink the server's defa
 ```txt
 fields=id,name,email          one list for the root resource
 fields[items]=id,name         per-relation lists
+fields[$root]=id,name         root list when combined with per-relation lists
 fields=+email                 extend the default selection
 fields=-name                  shrink it
 ```
+
+A lone root list keeps the bare `fields=` form. As soon as root and relation fieldsets travel together, the [URL codec](/guide/wire) spells the root group with the reserved `$root` token (`fields[$root]=id,name&fields[items]=id`); a bare `fields=` cannot be combined with `fields[...]=` groups in the same URL.
 
 The equivalent parser input shapes (what [`SimpleParser`](/packages/parser-simple) and the [URL decoder](/guide/wire) accept):
 
@@ -33,11 +36,11 @@ A field name can carry a prefix that changes how it combines with the schema's `
 | Syntax | Meaning |
 |---|---|
 | `name` | Select this field (replaces the default selection). |
-| `+name` | **Include** — extends the default selection instead of replacing it. |
-| `-name` | **Exclude** — removes the field from the selection. |
+| `+name` | **Include**: extends the default selection instead of replacing it. |
+| `-name` | **Exclude**: removes the field from the selection. |
 
 ```typescript
-// schema default is ['id', 'name'] —
+// schema default is ['id', 'name']
 { fields: '+email' }   // → id, name, email
 { fields: '-name' }    // → id
 ```
@@ -46,7 +49,7 @@ In the AST, the prefix becomes `Field.operator` (`FieldOperator.INCLUDE` / `Fiel
 
 ## Building in code
 
-The same shapes work as typed [build input](/guide/building-queries) — field paths checked against the record type:
+The same shapes work as typed [build input](/guide/building-queries); field paths are checked against the record type:
 
 ```typescript
 defineQuery<User>({ fields: ['id', '+email'] });
@@ -56,7 +59,7 @@ defineFields<User>(['id', 'name']);   // standalone fragment
 
 ## Fields of related records
 
-Fields of a relation use the relation name as key (or a `relation.field` path) and validate against the **related** schema, resolved through [`schemaMapping`](/guide/schemas#the-registry--relations). The relation itself must be allowed and requested via [relations](/guide/relations).
+Fields of a relation use the relation name as key (or a `relation.field` path) and validate against the **related** schema, resolved through [`schemaMapping`](/guide/schemas#the-registry-relations). The relation itself must be allowed and requested via [relations](/guide/relations).
 
 ```typescript
 {
@@ -84,7 +87,7 @@ defineSchema<User>({
 | `allowed` | Selectable field names. Omit to allow all; `[]` blocks the parameter. |
 | `default` | Selection when the client sends nothing (or only `+`/`-` modifiers). |
 | `mapping` | Alias → field translation applied before validation. |
-| `validate` / `validateMany` | Per-request [key hooks](/guide/schemas#validate-hooks--parse-context): accept, reject, or gate a field per actor. |
+| `validate` / `validateMany` | Per-request [key hooks](/guide/schemas#validate-hooks-parse-context): accept, reject, or gate a field per actor. |
 
 ## Row-scoped fields
 

--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -38,7 +38,7 @@ Every dialect maps onto the same operator set (`FilterFieldOperator`):
 
 Backend support varies per [adapter](/guide/executing-queries). `EXISTS` works everywhere. `REGEX` and `MOD` evaluate in [`@rapiq/adapter-memory`](/packages/adapter-memory) and render through [`@rapiq/adapter-sql`](/packages/adapter-sql) / [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) (`regex` needs a regex-capable dialect; the mssql and sqlite presets throw a typed error instead). [`@rapiq/adapter-prisma`](/packages/adapter-prisma) and [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) raise a typed `AdapterError` (`FEATURE_UNSUPPORTED`) for `regex`, `mod`, `size`, the `ITSELF` marker and `elemMatch` on a to-one relation instead of approximating; see the limitations section of each package page. Before accepting `regex` from untrusted input, read the [trust model](#regex-trust-model) below.
 
-`SIZE` matches arrays with exactly the given number of elements (a non-negative integer); missing or non-array values never match, and there is no negated form. It evaluates in [`@rapiq/adapter-memory`](/packages/adapter-memory) only: the SQL adapters throw a typed `featureUnsupported` until dialect-level JSON-array support lands, and the prisma/drizzle serializers have no array-length filter to target.
+`SIZE` matches arrays with exactly the given number of elements (a non-negative integer); missing or non-array values never match, and there is no negated leaf twin (`not(size(…))` stays a [negated group](#negation)). It evaluates in [`@rapiq/adapter-memory`](/packages/adapter-memory) only: the SQL adapters throw a typed `featureUnsupported` until dialect-level JSON-array support lands, and the prisma/drizzle serializers have no array-length filter to target.
 
 Inside an `elemMatch` interior, the reserved `ITSELF` marker (wire spelling `$this`) may take the field position of a condition to address the array element itself: `elemMatch('scores', gt(ITSELF, 5))` matches when some score is greater than five. `@rapiq/adapter-memory` evaluates it element-wise; every other adapter throws a typed `featureUnsupported` (for the SQL adapters a joined relation row is not a scalar column, and prisma/drizzle cannot address the element itself). Anywhere outside an `elemMatch` interior the marker is a typed error.
 
@@ -138,7 +138,7 @@ same verdict `@rapiq/adapter-memory` produces.
 | `inArray(field, [a, null])` | `field IN (…) OR field IS NULL` |
 | `exists(field)` | `field IS NOT NULL` |
 
-Negated operators (`ne`, `nin`, `notContains`, `notStartsWith`, `notEndsWith`) are **exact complements** of their positive twins: they also match records where the field is `NULL`/absent. Adapters render them null-inclusively, e.g. `ne(field, a)` → `(field <> ? OR field IS NULL)`.
+Negated operators (`ne`, `nin`, `notContains`, `notStartsWith`, `notEndsWith`) are **exact complements** of their positive twins: for values that don't name `null` themselves, they also match records where the field is `NULL`/absent, e.g. `ne(field, a)` → `(field <> ? OR field IS NULL)`. When the negated value does name `null`, the complement excludes those records instead: `nin(field, [a, null])` matches neither `a` nor `NULL`/absent, precisely because `inArray(field, [a, null])` matches both.
 
 The same complement law governs [`not(...)`](#negation) over whole trees: `not(c)` selects exactly the records `c` does not, on every backend.
 

--- a/packages/docs/guide/filters.md
+++ b/packages/docs/guide/filters.md
@@ -1,6 +1,6 @@
 # Filters
 
-Narrow the collection by conditions on fields — from a simple equality to arbitrary `and`/`or` trees.
+Narrow the collection by conditions on fields: from a simple equality to arbitrary `and`/`or` trees.
 
 | | |
 |---|---|
@@ -28,17 +28,19 @@ Every dialect maps onto the same operator set (`FilterFieldOperator`):
 | `NOT_ENDS_WITH` | not suffix | `$notEndsWith` | `notEndsWith` | `!~jo` |
 | `CONTAINS` | substring | `$contains` | `contains` | `~jo~` |
 | `NOT_CONTAINS` | not substring | `$notContains` | `notContains` | `!~jo~` |
-| `REGEX` | pattern | `$regex` | `regex` | — |
-| `MOD` | divisible remainder | `$mod` | `mod` | — |
-| `SIZE` | array length | `$size` | `size` | — |
-| `EXISTS` | is not null | `$exists` | `exists` | — |
-| `ELEM_MATCH` | array element match | `$elemMatch` | `elemMatch` | — |
+| `REGEX` | pattern | `$regex` | `regex` | (none) |
+| `MOD` | divisible remainder | `$mod` | `mod` | (none) |
+| `SIZE` | array length | `$size` | `size` | (none) |
+| `EXISTS` | is not null | `$exists` | `exists` | (none) |
+| `ELEM_MATCH` | array element match | `$elemMatch` | `elemMatch` | (none) |
 
-`REGEX`, `MOD` and `EXISTS` have no representation in the URL dialects — they work in code, via the [MongoDB-style parser](/packages/parser-mongo), and in every [adapter](/guide/executing-queries). Before accepting `regex` from untrusted input, read the [trust model](#regex-trust-model) below. `ELEM_MATCH` and `SIZE` travel in the [expression dialect](/packages/parser-expression) only.
+`REGEX`, `MOD` and `EXISTS` have no representation in the URL dialects; they work in code and via the [MongoDB-style parser](/packages/parser-mongo). `ELEM_MATCH` and `SIZE` travel in the [expression dialect](/packages/parser-expression) only.
 
-`SIZE` matches arrays with exactly the given number of elements (a non-negative integer); missing or non-array values never match, and there is no negated form. It evaluates in [`@rapiq/adapter-memory`](/packages/adapter-memory) — the SQL adapters throw a typed `featureUnsupported` until dialect-level JSON-array support lands.
+Backend support varies per [adapter](/guide/executing-queries). `EXISTS` works everywhere. `REGEX` and `MOD` evaluate in [`@rapiq/adapter-memory`](/packages/adapter-memory) and render through [`@rapiq/adapter-sql`](/packages/adapter-sql) / [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) (`regex` needs a regex-capable dialect; the mssql and sqlite presets throw a typed error instead). [`@rapiq/adapter-prisma`](/packages/adapter-prisma) and [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) raise a typed `AdapterError` (`FEATURE_UNSUPPORTED`) for `regex`, `mod`, `size`, the `ITSELF` marker and `elemMatch` on a to-one relation instead of approximating; see the limitations section of each package page. Before accepting `regex` from untrusted input, read the [trust model](#regex-trust-model) below.
 
-Inside an `elemMatch` interior, the reserved `ITSELF` marker (wire spelling `$this`) may take the field position of a condition to address the array element itself: `elemMatch('scores', gt(ITSELF, 5))` matches when some score is greater than five. `@rapiq/adapter-memory` evaluates it element-wise; the SQL adapters throw a typed `featureUnsupported` (a joined relation row is not a scalar column). Anywhere outside an `elemMatch` interior the marker is a typed error.
+`SIZE` matches arrays with exactly the given number of elements (a non-negative integer); missing or non-array values never match, and there is no negated form. It evaluates in [`@rapiq/adapter-memory`](/packages/adapter-memory) only: the SQL adapters throw a typed `featureUnsupported` until dialect-level JSON-array support lands, and the prisma/drizzle serializers have no array-length filter to target.
+
+Inside an `elemMatch` interior, the reserved `ITSELF` marker (wire spelling `$this`) may take the field position of a condition to address the array element itself: `elemMatch('scores', gt(ITSELF, 5))` matches when some score is greater than five. `@rapiq/adapter-memory` evaluates it element-wise; every other adapter throws a typed `featureUnsupported` (for the SQL adapters a joined relation row is not a scalar column, and prisma/drizzle cannot address the element itself). Anywhere outside an `elemMatch` interior the marker is a typed error.
 
 ## On the wire (expression dialect)
 
@@ -48,7 +50,7 @@ The URL codec writes one expression by default, preserving compound structure an
 codec=url-expression&filter=and(gte(age,'18'),or(eq(status,'active'),eq(status,'pending')))
 ```
 
-The function names mirror the condition helpers in the table above. Values are single-quoted; quote characters escape by doubling (`'it''s'`).
+Most function names match the condition helpers in the table above; `in` keeps its wire spelling (`inArray` is only the code helper name). The negated leaf operators are the exception: `nin` has its own keyword, but `ne`, `notContains`, `notStartsWith` and `notEndsWith` are not expression keywords. On the wire they are spelled `not(...)` around the positive form, e.g. `not(eq(name,'John'))` for `ne`; decoding normalizes such a single twin-able leaf back to its negated twin (see [Negation](#negation)). Values are single-quoted; quote characters escape by doubling (`'it''s'`).
 
 ## Legacy simple input
 
@@ -66,7 +68,7 @@ filter[email]=!null           not null
 The v2 codec continues to decode this shape for existing clients. Multiple keys combine with **and**. Scalar coercion applies on decode: `'18'` → `18`, `'true'` → `true`, `'null'` → `null`.
 
 ::: info Wire strings vs. code
-The `!`/`<`/`~` prefixes are the *wire* format. In code, use typed operator objects (`{ age: { $gte: 18 } }`) or condition helpers — never magic strings.
+The `!`/`<`/`~` prefixes are the *wire* format. In code, use typed operator objects (`{ age: { $gte: 18 } }`) or condition helpers, never magic strings.
 :::
 
 ## Building in code
@@ -93,13 +95,13 @@ defineQuery<User>({
 
 The simple object/wire dialect only expresses flat **and** sets. For `or`, `not` and nested groups:
 
-- **in code** — condition helpers: `or(...)`, `and(...)`, `not(...)`, arbitrarily nested;
-- **over a URL** — the [expression codec](/packages/codec-url#expression-dialect): `filter=or(gte(age,'18'),eq(status,'active'))`;
-- **in a request body** — the [MongoDB-style parser](/packages/parser-mongo): `{ $or: [...] }`.
+- **in code**: condition helpers `or(...)`, `and(...)`, `not(...)`, arbitrarily nested;
+- **over a URL**: the [expression codec](/packages/codec-url#expression-dialect), `filter=or(gte(age,'18'),eq(status,'active'))`;
+- **in a request body**: the [MongoDB-style parser](/packages/parser-mongo), `{ $or: [...] }`.
 
 ### Negation
 
-`not(condition)` matches exactly the records its interior does **not** match — the
+`not(condition)` matches exactly the records its interior does **not** match, the
 [complement law](#null-semantics) extended from the negated leaf operators to arbitrary trees:
 
 ```typescript
@@ -111,19 +113,19 @@ defineQuery<User>({
 ```
 
 Where a negated leaf operator exists, `not` is the same condition (`not(eq(…))` ≡ `ne(…)`);
-its value is negating conditions **without** a negated twin — ordering comparisons
+its value is negating conditions **without** a negated twin: ordering comparisons
 (`not(gt(…))`), `size`, `elemMatch` and whole groups. Multiple arguments negate their
 conjunction: `not(a, b)` ≡ `not(and(a, b))`.
 
 On the wire, the expression dialect carries it as `filter=not(gt(age,'65'))`; the legacy
 simple dialect cannot express it (encoding throws a typed error). SQL adapters render the
 negation **null-inclusively** (a `CASE` wrapper collapses SQL's three-valued `UNKNOWN` to
-false), so a record with `age = NULL` matches `not(gt('age', 65))` on every backend — the
+false), so a record with `age = NULL` matches `not(gt('age', 65))` on every backend, the
 same verdict `@rapiq/adapter-memory` produces.
 
 ## Nested fields
 
-`relation.field` keys filter on related records. The relation must be permitted and requested via [relations](/guide/relations), and the field validates against the related schema through [`schemaMapping`](/guide/schemas#the-registry--relations).
+`relation.field` keys filter on related records. The relation must be permitted and requested via [relations](/guide/relations), and the field validates against the related schema through [`schemaMapping`](/guide/schemas#the-registry-relations).
 
 ## Null semantics
 
@@ -136,19 +138,19 @@ same verdict `@rapiq/adapter-memory` produces.
 | `inArray(field, [a, null])` | `field IN (…) OR field IS NULL` |
 | `exists(field)` | `field IS NOT NULL` |
 
-Negated operators (`ne`, `nin`, `notContains`, `notStartsWith`, `notEndsWith`) are **exact complements** of their positive twins — they also match records where the field is `NULL`/absent. Adapters render them null-inclusively, e.g. `ne(field, a)` → `(field <> ? OR field IS NULL)`.
+Negated operators (`ne`, `nin`, `notContains`, `notStartsWith`, `notEndsWith`) are **exact complements** of their positive twins: they also match records where the field is `NULL`/absent. Adapters render them null-inclusively, e.g. `ne(field, a)` → `(field <> ? OR field IS NULL)`.
 
 The same complement law governs [`not(...)`](#negation) over whole trees: `not(c)` selects exactly the records `c` does not, on every backend.
 
 ## Case sensitivity
 
-String matching is **case-insensitive by default**, uniformly across every adapter — the same query matches the same records whether it runs on Postgres, MySQL, in memory, or through TypeORM:
+String matching is **case-insensitive by default**, uniformly across every adapter: the same query matches the same records whether it runs on Postgres, MySQL, in memory, or through TypeORM:
 
 - The **equality family** (`eq`, `ne`, `in`, `nin`) compares string values case-insensitively: `eq('name', 'super hero')` matches `Super Hero`. Non-string values (numbers, booleans, dates, `null`) are unaffected.
 - The **anchored operators** (`contains`, `startsWith`, `endsWith` and their negations) match case-insensitively as well.
-- **Range comparisons** (`lt`/`lte`/`gt`/`gte`) and `sort` follow the backend's collation — rapiq does not fold string ordering.
+- **Range comparisons** (`lt`/`lte`/`gt`/`gte`) and `sort` follow the backend's collation; rapiq does not fold string ordering.
 
-Opt out per field with the `caseSensitive` schema option where exactness matters — identifiers, tokens, enum-like codes:
+Opt out per field with the `caseSensitive` schema option where exactness matters (identifiers, tokens, enum-like codes):
 
 ```typescript
 const schema = defineSchema<User>({
@@ -169,13 +171,13 @@ adapter.execute(query, { caseSensitive: schema.filters.caseSensitive });
 applyQuery(query, data, { caseSensitive: schema.filters.caseSensitive });
 ```
 
-The key is the same on every backend: `@rapiq/adapter-prisma` and `@rapiq/adapter-drizzle` accept `caseSensitive` in their constructor options.
+The key is the same on every backend: `@rapiq/adapter-prisma` and `@rapiq/adapter-drizzle` accept `caseSensitive` in their constructor options, and their `execute()` options take a per-call override of the adapter-level setting.
 
 Passing `caseSensitive: true` instead of a list opts **every** field out of the fold at once: for condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies. The collation caveat below applies unchanged: on the MySQL/MSSQL presets equality delegates to the column collation either way, so a `*_ci` collated column still matches case-insensitively.
 
-Under the hood, `@rapiq/adapter-sql` folds both sides of the comparison — `lower(field) = lower(?)` — and only when the filter value is a string. Dialects whose plain `=` already compares case-insensitively under their default collation (the MySQL and MSSQL presets) skip the folding through the `caseFold` dialect option, so plain indexes stay usable. On folding dialects (Postgres, SQLite, Oracle), add an expression index for hot string filter columns — `CREATE INDEX ON "user" (lower(name))` — or list the column in `caseSensitive`.
+Under the hood, `@rapiq/adapter-sql` folds both sides of the comparison (`lower(field) = lower(?)`), and only when the filter value is a string. Dialects whose plain `=` already compares case-insensitively under their default collation (the MySQL and MSSQL presets) skip the folding through the `caseFold` dialect option, so plain indexes stay usable. On folding dialects (Postgres, SQLite, Oracle), add an expression index for hot string filter columns (`CREATE INDEX ON "user" (lower(name))`) or list the column in `caseSensitive`.
 
-The TypeORM adapter goes one step further: it resolves each filtered field against the entity metadata and folds **only string-typed columns**. Numeric, date, uuid or enum columns never pay the `lower()` cost — even when the value arrives as an untyped wire string like `filter[age]=18`.
+The TypeORM adapter goes one step further: it resolves each filtered field against the entity metadata and folds **only string-typed columns**. Numeric, date, uuid or enum columns never pay the `lower()` cost, even when the value arrives as an untyped wire string like `filter[age]=18`.
 
 ::: warning Collation wins on MySQL/MSSQL
 On the MySQL/MSSQL presets, equality delegates to the column collation: `caseSensitive` cannot force exactness onto a `*_ci` collated column. Use a `*_bin`/`*_cs` collation for such columns, or override `caseFold` with a `lower()`-wrapping implementation.
@@ -202,12 +204,12 @@ defineSchema<User>({
 | `allowed` | Filterable field names. Omit to allow all; `[]` blocks the parameter. |
 | `default` | Condition applied when the client sends no filters. |
 | `mapping` | Alias → field translation applied before validation. |
-| `validate` | Sync or async per-filter hook — inspect a parsed `Filter`, replace it with any condition, or reject it. Receives the [parse context](/guide/schemas#validate-hooks--parse-context) as its second argument. |
+| `validate` | Sync or async per-filter hook: inspect a parsed `Filter`, replace it with any condition, or reject it. Receives the [parse context](/guide/schemas#validate-hooks-parse-context) as its second argument. |
 | `caseSensitive` | Fields whose equality comparisons stay exact instead of the [case-insensitive default](#case-sensitivity). |
 
-`validate` runs after key resolution, mapping and value coercion, and receives the caller-supplied [`context`](/guide/schemas#validate-hooks--parse-context) (e.g. the authenticated actor) as its second argument. Return the original filter to accept it, another condition to replace it, or `undefined` to reject that leaf — an inspect-only hook must still `return` the filter, otherwise every leaf is rejected. The replacement may be any condition, including a compound: an authorization decision like "you may filter on `realm_id`, but only within your realms" stays attached to the leaf that triggered it, `and(filter, inArray('realm_id', actor.realmIds))`, instead of being injected separately after the parse. `$elemMatch` conditions are validated inside-out: every interior leaf passes the hook, then the `elemMatch` filter itself. The return value may also be a Promise of any of those results. On the server, [schema-aware encoding](/packages/codec-url) re-runs the schema-bound decoder, so a validator that is not idempotent (e.g. one that appends to the value) transforms a filter twice between a schema-aware `encode()` and the receiving `decode()` — keep validators idempotent.
+`validate` runs after key resolution, mapping and value coercion, and receives the caller-supplied [`context`](/guide/schemas#validate-hooks-parse-context) (e.g. the authenticated actor) as its second argument. Return the original filter to accept it, another condition to replace it, or `undefined` to reject that leaf; an inspect-only hook must still `return` the filter, otherwise every leaf is rejected. The replacement may be any condition, including a compound: an authorization decision like "you may filter on `realm_id`, but only within your realms" stays attached to the leaf that triggered it, `and(filter, inArray('realm_id', actor.realmIds))`, instead of being injected separately after the parse. `$elemMatch` conditions are validated inside-out: every interior leaf passes the hook, then the `elemMatch` filter itself. The return value may also be a Promise of any of those results. On the server, [schema-aware encoding](/packages/codec-url) re-runs the schema-bound decoder, so a validator that is not idempotent (e.g. one that appends to the value) transforms a filter twice between a schema-aware `encode()` and the receiving `decode()`: keep validators idempotent.
 
-Two consequences of a compound replacement mirror [`and()` injection](/guide/merging-queries#and--or--wrap--inject). The tree is no longer flat, so a later replace-merge throws instead of displacing the injected scoping (that refusal is a feature). And the legacy simple URL dialect cannot express compounds: a schema-aware `encode()` through that dialect throws a typed `FEATURE_UNSUPPORTED` for a query whose validator produced one; the default expression dialect encodes it fine.
+Two consequences of a compound replacement mirror [`and()` injection](/guide/merging-queries#and-or-wrap-inject). The tree is no longer flat, so a later replace-merge throws instead of displacing the injected scoping (that refusal is a feature). And the legacy simple URL dialect cannot express compounds: a schema-aware `encode()` through that dialect throws a typed `FEATURE_UNSUPPORTED` for a query whose validator produced one; the default expression dialect encodes it fine.
 
 Use the synchronous `parse()` / `decode()` / schema-aware `encode()` methods when every validator is synchronous. Use their `Async` counterparts when a validator may be asynchronous:
 
@@ -221,18 +223,18 @@ The async path awaits validators sequentially in filter-tree order. Calling a sy
 
 ## Regex trust model
 
-The `regex` operator's pattern is **passed through to the consuming engine** — rapiq does not analyze, rewrite or sandbox it:
+The `regex` operator's pattern is **passed through to the consuming engine**; rapiq does not analyze, rewrite or sandbox it:
 
-- [`@rapiq/adapter-sql`](/packages/adapter-sql) and [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) hand the pattern to the database engine to interpret and validate — the engine's own syntax checks, limits and timeouts govern it.
-- [`@rapiq/adapter-memory`](/packages/adapter-memory) compiles the pattern with JavaScript's backtracking `RegExp` engine and evaluates it against every record — a crafted pattern (nested quantifiers such as `(a+)+$`) over long field values can burn CPU (ReDoS). Compilation rejects invalid syntax, not pathological patterns.
+- [`@rapiq/adapter-sql`](/packages/adapter-sql) and [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) hand the pattern to the database engine to interpret and validate: the engine's own syntax checks, limits and timeouts govern it.
+- [`@rapiq/adapter-memory`](/packages/adapter-memory) compiles the pattern with JavaScript's backtracking `RegExp` engine and evaluates it against every record; a crafted pattern (nested quantifiers such as `(a+)+$`) over long field values can burn CPU (ReDoS). Compilation rejects invalid syntax, not pathological patterns.
 
 Whether a hostile pattern can reach an evaluator depends on the input dialect:
 
-- The **URL dialects cannot carry one** — `regex` has no wire spelling, so queries decoded by [`@rapiq/codec-url`](/packages/codec-url) never contain a regex condition.
+- The **URL dialects cannot carry one**: `regex` has no wire spelling, so queries decoded by [`@rapiq/codec-url`](/packages/codec-url) never contain a regex condition.
 - The **[MongoDB-style parser](/packages/parser-mongo) accepts `$regex`** (a pattern string or `RegExp`) from client documents.
 
 ::: warning Gate `$regex` for untrusted clients
-An application that parses untrusted mongo-style filter documents and evaluates them in-process with `@rapiq/adapter-memory` must gate the operator — the `allowed` list does not help, since `$regex` applies to allowed fields.
+An application that parses untrusted mongo-style filter documents and evaluates them in-process with `@rapiq/adapter-memory` must gate the operator; the `allowed` list does not help, since `$regex` applies to allowed fields.
 :::
 
 The [`validate` hook](#schema-options) sees every parsed leaf and can reject regex conditions:
@@ -255,7 +257,7 @@ const schema = defineSchema<User>({
 });
 ```
 
-A leaf rejected by `validate` is silently dropped, independent of the `throwOnFailure` policy — throw from the hook to turn a client-submitted regex into an error response instead. Softer gates work the same way: cap the pattern's source length or match it against a vetted list, and return the filter when it passes.
+A leaf rejected by `validate` is silently dropped, independent of the `throwOnFailure` policy; throw from the hook to turn a client-submitted regex into an error response instead. Softer gates work the same way: cap the pattern's source length or match it against a vetted list, and return the filter when it passes.
 
 ## On violation
 

--- a/packages/docs/guide/index.md
+++ b/packages/docs/guide/index.md
@@ -1,6 +1,6 @@
 # What is rapiq?
 
-Rapiq (**R**est **Api** **Q**uery) gives the two sides of an HTTP API **one shared query language** for list endpoints — filtering, sorting, pagination, sparse field selection and relation loading, modeled after the [JSON:API](https://jsonapi.org/format/) query parameters.
+Rapiq (**R**est **Api** **Q**uery) gives the two sides of an HTTP API **one shared query language** for list endpoints: filtering, sorting, pagination, sparse field selection and relation loading, modeled after the [JSON:API](https://jsonapi.org/format/) query parameters.
 
 The caller builds a **typed query**, sends it as an ordinary URL query string, and the receiving application validates it against an **allow-list schema** before turning it into a database query. No hand-rolled `req.query` parsing, no string concatenation, no guessing which parameters a client may touch.
 
@@ -10,7 +10,7 @@ The caller builds a **typed query**, sends it as an ordinary URL query string, a
 
 ## The 30-second tour
 
-**Caller** — build a query against your record type and encode it:
+**Caller**: build a query against your record type and encode it:
 
 ```typescript
 import { defineQuery } from '@rapiq/core';
@@ -26,7 +26,7 @@ const query = defineQuery<User>({
 const response = await fetch(`/users?${createURLCodec().encode(query)}`);
 ```
 
-**Receiver** — decode it against a schema that says what clients may request, then hand it to your database:
+**Receiver**: decode it against a schema that says what clients may request, then hand it to your database:
 
 ```typescript
 import { SchemaRegistry, defineSchema } from '@rapiq/core';
@@ -43,6 +43,10 @@ registry.add(defineSchema<User>({
 }));
 
 const query = createURLCodec(registry).decode(req.query, { schema: 'user' });
+if (!query) {
+    // null for non-object input
+    return res.status(400).end();
+}
 
 new TypeormAdapter({ queryBuilder }).execute(query);
 const [entities, total] = await queryBuilder.getManyAndCount();
@@ -52,14 +56,14 @@ Everything a client sends is constrained before it reaches the database. Most pa
 
 ## How it works
 
-A query passes through four stages — and every rapiq package plays exactly one role in one of them:
+A query passes through four stages, and every rapiq package plays exactly one role in one of them:
 
 <QueryPipeline />
 
-1. **Build** — the caller describes what it wants with [`defineQuery`](/guide/building-queries), typed against the record.
-2. **Send** — a [codec](/guide/wire) turns the query into an ordinary URL query string, and back.
-3. **Validate** — the receiver parses against a [schema](/guide/schemas): the allow-list decides what survives.
-4. **Execute** — an [adapter](/guide/executing-queries) translates the validated query for your backend.
+1. **Build**: the caller describes what it wants with [`defineQuery`](/guide/building-queries), typed against the record.
+2. **Send**: a [codec](/guide/wire) turns the query into an ordinary URL query string, and back.
+3. **Validate**: the receiver parses against a [schema](/guide/schemas); the allow-list decides what survives.
+4. **Execute**: an [adapter](/guide/executing-queries) translates the validated query for your backend.
 
 Because the pieces only meet in the [`Query`](/guide/query-ast), they compose freely: swap the wire dialect without touching the database code, add a new backend without touching the parsers, or skip the wire entirely and evaluate a query in memory.
 
@@ -75,11 +79,11 @@ Because the pieces only meet in the [`Query`](/guide/query-ast), they compose fr
 
 ## The package family
 
-Install only what each side of your application needs — `@rapiq/core` is the shared foundation.
+Install only what each side of your application needs; `@rapiq/core` is the shared foundation.
 
 | Role | Packages |
 |---|---|
-| **Build & compose** | [@rapiq/core](/packages/core) — the query AST, `defineQuery`, condition helpers, schemas |
+| **Build & compose** | [@rapiq/core](/packages/core): the query AST, `defineQuery`, condition helpers, schemas |
 | **Parse input** | [@rapiq/parser-simple](/packages/parser-simple) · [@rapiq/parser-expression](/packages/parser-expression) · [@rapiq/parser-mongo](/packages/parser-mongo) |
 | **Cross the wire** | [@rapiq/codec-url](/packages/codec-url) |
 | **Execute** | [@rapiq/adapter-typeorm](/packages/adapter-typeorm) · [@rapiq/adapter-sql](/packages/adapter-sql) · [@rapiq/adapter-prisma](/packages/adapter-prisma) · [@rapiq/adapter-drizzle](/packages/adapter-drizzle) · [@rapiq/adapter-memory](/packages/adapter-memory) |
@@ -90,9 +94,9 @@ See the [package overview](/packages/) for the full map and a "which packages do
 
 - Your API exposes **list endpoints** and clients need to filter, sort, paginate or shape the result.
 - You want the query surface **declared, typed and enforced** instead of scattered across handlers.
-- You want the **same query semantics** everywhere — SQL, TypeORM, Prisma, Drizzle, in-memory guards, tests.
+- You want the **same query semantics** everywhere: SQL, TypeORM, Prisma, Drizzle, in-memory guards, tests.
 
-It deliberately does **not** define the response format, replace your ORM, or generate endpoints — it only standardizes what a query *is* and what a client *may* ask for.
+It deliberately does **not** define the response format, replace your ORM, or generate endpoints; it only standardizes what a query *is* and what a client *may* ask for.
 
 ::: warning Version 2
 These docs cover the upcoming **version 2**, which splits the former single `rapiq` package into focused `@rapiq/*` packages. The v1 documentation lives on the [v1 branch](https://github.com/tada5hi/rapiq/tree/v1); see [Migration from v1](/guide/migration-v1).
@@ -100,6 +104,6 @@ These docs cover the upcoming **version 2**, which splits the former single `rap
 
 ## Next steps
 
-- [Installation](/guide/installation) — add the packages for your side of the wire.
-- [Quick Start](/guide/quick-start) — caller to database in one walkthrough.
-- [Core Concepts](/guide/concepts) — the four moving parts, explained once.
+- [Installation](/guide/installation): add the packages for your side of the wire.
+- [Quick Start](/guide/quick-start): caller to database in one walkthrough.
+- [Core Concepts](/guide/concepts): the four moving parts, explained once.

--- a/packages/docs/guide/installation.md
+++ b/packages/docs/guide/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-All packages are published independently — install only what your side of the wire needs. `@rapiq/core` is a peer dependency of every other package, so it is always part of the mix.
+All packages are published independently; install only what your side of the wire needs. `@rapiq/core` is a peer dependency of every other package, so it is always part of the mix.
 
 ## Caller (client) side
 
@@ -14,7 +14,7 @@ That's everything a frontend needs. If you only build queries and hand them to a
 
 ## Receiver (server) side
 
-To decode and validate incoming URL query input — a raw query string or a pre-parsed object like express' `req.query`:
+To decode and validate incoming URL query input (a raw query string or a pre-parsed object like express' `req.query`):
 
 ```sh
 npm install @rapiq/core @rapiq/codec-url
@@ -53,15 +53,15 @@ npm install @rapiq/adapter-memory
 | [@rapiq/parser-simple](/packages/parser-simple) | non-URL input already uses canonical parameter keys (`filters`, `pagination`, …) |
 | [@rapiq/parser-expression](/packages/parser-expression) | non-URL input contains function-call filter expressions like `and(eq(name, 'John'), gte(age, '18'))` |
 | [@rapiq/parser-mongo](/packages/parser-mongo) | you want to accept MongoDB-style filter documents like `{ age: { $gte: 18 } }` |
-| [@rapiq/adapter-memory](/packages/adapter-memory) | you want to evaluate a `Query` against in-memory objects — e.g. authorization guards or mock backends |
+| [@rapiq/adapter-memory](/packages/adapter-memory) | you want to evaluate a `Query` against in-memory objects, e.g. authorization guards or mock backends |
 
 Not sure which combination you need? The [package overview](/packages/) walks through the decision.
 
 ## Requirements
 
 - **Node.js ≥ 22** for the server-side packages; the client-side packages run in any modern bundler/browser environment.
-- **TypeScript** is optional but strongly recommended — typed field paths are a core feature.
+- **TypeScript** is optional but strongly recommended: typed field paths are a core feature.
 
 ## Next steps
 
-- [Quick Start](/guide/quick-start) — wire everything together in one walkthrough.
+- [Quick Start](/guide/quick-start): wire everything together in one walkthrough.

--- a/packages/docs/guide/merging-queries.md
+++ b/packages/docs/guide/merging-queries.md
@@ -1,8 +1,8 @@
 # Merging & Composition
 
-Real queries rarely come from one place. A list view combines **user input** (a search box), **component state** (the current page), **props** (a parent-imposed scope) and **application defaults** — and the server may add conditions of its own. rapiq composes all of these on the `Query` itself, so every construction path (built, decoded, parsed by any dialect) combines the same way.
+Real queries rarely come from one place. A list view combines **user input** (a search box), **component state** (the current page), **props** (a parent-imposed scope) and **application defaults**, and the server may add conditions of its own. rapiq composes all of these on the `Query` itself, so every construction path (built, decoded, parsed by any dialect) combines the same way.
 
-## `mergeQueries` — left priority
+## `mergeQueries`: left priority
 
 ```typescript
 import { mergeQueries } from '@rapiq/core';
@@ -10,7 +10,7 @@ import { mergeQueries } from '@rapiq/core';
 const query = mergeQueries(searchQuery, paginationQuery, propsQuery, defaultsQuery);
 ```
 
-The first argument wins conflicts. All operations are **immutable**: inputs stay untouched, new instances are returned — safe for reactivity systems and shared default fragments.
+The first argument wins conflicts. All operations are **immutable**: inputs stay untouched and new instances are returned, safe for reactivity systems and shared default fragments.
 
 Per-parameter semantics:
 
@@ -18,7 +18,7 @@ Per-parameter semantics:
 |---|---|
 | `fields` / `relations` / `sorts` | keyed by name, left-priority replace; order = first occurrence |
 | `pagination` | per-property left priority (`limit` and `offset` merge independently) |
-| `filters` | per-field replace via `Filters.merge` — see below |
+| `filters` | per-field replace via `Filters.merge` (see below) |
 
 One guard applies to `fields`: a name collision that would discard a [row-scoped visibility gate](/guide/fields#row-scoped-fields) (`Field.condition`) throws a `MergeError` (`ErrorCode.FIELDS_CONDITION_DISCARDED`) instead of silently un-gating the column. A gate only ever arises server-side, from a schema hook; keep that parsed query as the receiver and its gates survive every collision.
 
@@ -26,7 +26,7 @@ One guard applies to `fields`: a name collision that would discard a [row-scoped
 
 Filters get two distinct operations, because a single "merge" would silently break one of the two use cases.
 
-### `merge()` — per-field replace
+### `merge()`: per-field replace
 
 A condition on a field **replaces** the other side's conditions on the same field (it is *not* and-ed). This is the list-view case: user search input overrides a default on the same field, while unrelated defaults survive:
 
@@ -44,11 +44,11 @@ mergeQueries(searchQ, defaultsQ).filters;
 mergeQueries(flatQ, defineQuery({ filters: or(...) })); // throws MergeError
 ```
 
-An empty side passes the other side through unchanged — compound defaults survive as long as nothing needs replacing.
+An empty side passes the other side through unchanged: compound defaults survive as long as nothing needs replacing.
 
-### `and()` / `or()` — wrap & inject
+### `and()` / `or()`: wrap & inject
 
-Always defined, for combining condition trees. The receiver is wrapped as a child of a new group, so injected conditions become part of the tree rather than candidates for replacement:
+Always defined, for combining condition trees. The receiver becomes a child of a new group holding the injected conditions, so they are part of the tree rather than candidates for replacement. On an empty receiver the injected conditions land in a nested group of their own; either way, the result is **never a flat root-AND**. Calling `and()` / `or()` with no conditions returns the receiver unchanged.
 
 ```typescript
 import { Query, eq } from '@rapiq/core';
@@ -60,13 +60,13 @@ const scoped = new Query({
 });
 ```
 
-The adapter output now contains the injected condition regardless of what the client sent — and since the wrapped tree is no longer flat, a later `merge()` throws instead of silently displacing the scoping condition. That failure mode is a feature: injected security conditions cannot be merged away. See the [authorization recipe](/guide/recipes/authorization).
+The adapter output now contains the injected condition regardless of what the client sent, even when the client sent no filters at all. And because the resulting tree is never flat, a later `merge()` cannot displace the injected condition: an empty other side passes the tree through untouched, and anything else throws a `MergeError` (`ErrorCode.FILTERS_NOT_FLAT`) instead of silently displacing the scoping condition. That refusal is unconditional, and it is a feature: injected security conditions cannot be merged away. See the [authorization recipe](/guide/recipes/authorization).
 
 ## Why not deep-merge input objects?
 
-Generic object merging (smob, deepmerge, spread) on query *input* cannot express these semantics — same-field replace, null-preserving `in` arrays, injected conditions that resist displacement. Merge on the query instead: build fragments with [`defineQuery` / `define*`](/guide/building-queries#fragments), compose with `mergeQueries`, then encode or execute the result.
+Generic object merging (smob, deepmerge, spread) on query *input* cannot express these semantics: same-field replace, null-preserving `in` arrays, injected conditions that resist displacement. Merge on the query instead: build fragments with [`defineQuery` / `define*`](/guide/building-queries#fragments), compose with `mergeQueries`, then encode or execute the result.
 
 ## Next steps
 
-- [Recipes: Type-safe frontend queries](/guide/recipes/frontend) — merging user input, props and defaults in a list view.
-- [Recipes: Authorization & scoping](/guide/recipes/authorization) — `and()` injection end-to-end.
+- [Recipes: Type-safe frontend queries](/guide/recipes/frontend): merging user input, props and defaults in a list view.
+- [Recipes: Authorization & scoping](/guide/recipes/authorization): `and()` injection end-to-end.

--- a/packages/docs/guide/migration-typeorm-extension.md
+++ b/packages/docs/guide/migration-typeorm-extension.md
@@ -1,12 +1,12 @@
 # Migration from typeorm-extension
 
-`@rapiq/adapter-typeorm` succeeds typeorm-extension's `applyQuery`/`applyQueryParseOutput` pipeline. The contract is deliberately close — but a few defaults flipped, and the ones that did are security-relevant.
+`@rapiq/adapter-typeorm` succeeds typeorm-extension's `applyQuery`/`applyQueryParseOutput` pipeline. The contract is deliberately close, but a few defaults flipped, and the ones that did are security-relevant.
 
 ## API mapping
 
 | typeorm-extension | rapiq v2 |
 |---|---|
-| `applyQuery(qb, req.query, options)` | `codec.decode(req.query, { schema })` + `new TypeormAdapter({ queryBuilder: qb }).execute(query)` — see the [Express recipe](/guide/recipes/express-typeorm) |
+| `applyQuery(qb, req.query, options)` | `codec.decode(req.query, { schema })` + `new TypeormAdapter({ queryBuilder: qb }).execute(query)` (see the [Express recipe](/guide/recipes/express-typeorm)) |
 | per-call `allowed`/`default` options | a named [`Schema`](/guide/schemas) in a `SchemaRegistry` |
 | returned parse output (pagination) | `adapter.execute(query)` returns the applied pagination |
 | `relations.onJoin` hook | `relations.onJoin` on the [adapter options](/packages/adapter-typeorm#options) |
@@ -33,11 +33,11 @@ typeorm-extension used inner joins for relations; `@rapiq/adapter-typeorm` defau
 
 ### Join aliases are path-qualified
 
-typeorm-extension aliased joins by the relation path's **last segment** (`role.realm` joined as `realm`), so relation paths ending in the same segment collided. `@rapiq/adapter-typeorm` uses the collision-free `buildRelationAlias(path)` helper (`realm` → `r5_realm`, `role.realm` → `r4_role_5_realm`) — see the [alias convention](/packages/adapter-typeorm#options). This surfaces in code that references join aliases directly, e.g. hand-written `andWhere` clauses; `onJoin` hooks keep working because they receive the derived alias. A custom derivation can be injected via `relations: { relationAlias }`, but it must stay collision-free.
+typeorm-extension aliased joins by the relation path's **last segment** (`role.realm` joined as `realm`), so relation paths ending in the same segment collided. `@rapiq/adapter-typeorm` uses the collision-free `buildRelationAlias(path)` helper (`realm` → `r5_realm`, `role.realm` → `r4_role_5_realm`); see the [alias convention](/packages/adapter-typeorm#options). This surfaces in code that references join aliases directly, e.g. hand-written `andWhere` clauses; `onJoin` hooks keep working because they receive the derived alias. A custom derivation can be injected via `relations: { relationAlias }`, but it must stay collision-free.
 
 ### Defaults that carried over
 
-- `joinAndSelect` behavior matches `leftJoinAndSelect` — set `relations: { joinAndSelect: true }`.
+- `joinAndSelect` behavior matches `leftJoinAndSelect`: set `relations: { joinAndSelect: true }`.
 - `execute` returns the applied pagination, mirroring `applyQuery`'s parse-output contract.
 
 ## Suggested migration path

--- a/packages/docs/guide/migration-v1.md
+++ b/packages/docs/guide/migration-v1.md
@@ -1,6 +1,6 @@
 # Migration from v1
 
-v2 splits the single `rapiq` package into focused `@rapiq/*` packages and replaces string-building with a typed query AST. This page is a running log of the intentional changes — it is assembled into a full step-by-step guide as v2 stabilizes.
+v2 splits the single `rapiq` package into focused `@rapiq/*` packages and replaces string-building with a typed query AST. This page is a running log of the intentional changes; it is assembled into a full step-by-step guide as v2 stabilizes.
 
 ::: info v1 docs
 The v1 documentation lives on the [v1 branch](https://github.com/tada5hi/rapiq/tree/v1).
@@ -10,7 +10,7 @@ The v1 documentation lives on the [v1 branch](https://github.com/tada5hi/rapiq/t
 
 | v1 | v2 |
 |---|---|
-| `rapiq` (everything) | `@rapiq/core` + the packages for your side of the wire — see [Installation](/guide/installation) |
+| `rapiq` (everything) | `@rapiq/core` + the packages for your side of the wire (see [Installation](/guide/installation)) |
 
 ## API mapping
 
@@ -24,19 +24,19 @@ The v1 documentation lives on the [v1 branch](https://github.com/tada5hi/rapiq/t
 
 ### Filters: `~` prefix position (breaking)
 
-In v1, `~text` meant *starts with* (`text%`) — the only LIKE form the dialect had. v2 uses a richer, position-based mapping:
+In v1, `~text` meant *starts with* (`text%`): the only LIKE form the dialect had. v2 uses a richer, position-based mapping:
 
 | Wire value | v1 | v2 |
 |---|---|---|
-| `text~` | — | starts with (`text%`) |
+| `text~` | (none) | starts with (`text%`) |
 | `~text` | starts with (`text%`) | ends with (`%text`) |
-| `~text~` | — | contains (`%text%`) |
+| `~text~` | (none) | contains (`%text%`) |
 
-**v1 clients sending `~text` change meaning from starts-with to ends-with.** Rewrite them to `text~` — or move to typed [condition helpers](/guide/building-queries#condition-helpers) / the [expression dialect](/packages/codec-url#expression-dialect), which have no positional magic.
+**v1 clients sending `~text` change meaning from starts-with to ends-with.** Rewrite them to `text~`, or move to typed [condition helpers](/guide/building-queries#condition-helpers) / the [expression dialect](/packages/codec-url#expression-dialect), which have no positional magic.
 
 ### Filters: magic value strings are wire-only
 
-v1 accepted `'>=18'`, `'~jo~'`, `'!null'` as *build input*. In v2, the string prefixes remain part of the wire format only — build input uses operator objects (`{ $gte: 18 }`, `{ $contains: 'jo' }`, `{ $ne: null }`) or condition helpers.
+v1 accepted `'>=18'`, `'~jo~'`, `'!null'` as *build input*. In v2, the string prefixes remain part of the wire format only; build input uses operator objects (`{ $gte: 18 }`, `{ $contains: 'jo' }`, `{ $ne: null }`) or condition helpers.
 
 ### Expression dialect: quoted values are never comma-split
 
@@ -52,7 +52,7 @@ The v2 URL codec writes stamped expression filters by default. Its decoder still
 
 ### Filters: string equality is case-insensitive (breaking)
 
-In v1, `eq`/`in` on strings delegated case behavior to the database — the same query matched `Super Hero` for `super hero` on MySQL (`*_ci` collation) but not on Postgres. v2 normalizes the whole equality family (`eq`, `ne`, `in`, `nin`) **and** the anchored operators (`contains`, `startsWith`, `endsWith`) to case-insensitive string matching on every backend; `@rapiq/adapter-sql` renders `lower(field) = lower(?)` on case-sensitive dialects. Opt identifier/token fields out with the schema's [`caseSensitive`](/guide/filters#case-sensitivity) list.
+In v1, `eq`/`in` on strings delegated case behavior to the database: the same query matched `Super Hero` for `super hero` on MySQL (`*_ci` collation) but not on Postgres. v2 normalizes the whole equality family (`eq`, `ne`, `in`, `nin`) **and** the anchored operators (`contains`, `startsWith`, `endsWith`) to case-insensitive string matching on every backend; `@rapiq/adapter-sql` renders `lower(field) = lower(?)` on case-sensitive dialects. Opt identifier/token fields out with the schema's [`caseSensitive`](/guide/filters#case-sensitivity) list.
 
 ## Coming from typeorm-extension?
 

--- a/packages/docs/guide/pagination.md
+++ b/packages/docs/guide/pagination.md
@@ -1,6 +1,6 @@
 # Pagination
 
-Limit and offset the collection — with a server-side cap.
+Limit and offset the collection, with a server-side cap.
 
 | | |
 |---|---|
@@ -25,7 +25,7 @@ Parser input shape:
 }
 ```
 
-Both keys are optional. Values are coerced to integers; `limit` must be positive, `offset` non-negative.
+Both keys are optional. Values are coerced to integers; `limit` must be positive, `offset` non-negative. When a limit applies (requested, or set via `maxLimit`) and no offset was sent, the offset defaults to `0`.
 
 ## Building in code
 
@@ -62,4 +62,4 @@ res.json({ data, meta: { total, ...pagination } });
 
 ## On violation
 
-Out-of-range values are clamped/dropped silently; with [`throwOnFailure`](/guide/schemas#failure-behavior-drop-vs-throw), exceeding `maxLimit` throws `PaginationParseError.limitExceeded()` instead of clamping.
+Out-of-range values are clamped/dropped silently. With [`throwOnFailure`](/guide/schemas#failure-behavior-drop-vs-throw), an invalid `limit` or `offset` throws `PaginationParseError.keyValueInvalid()` and exceeding `maxLimit` throws `PaginationParseError.limitExceeded()` instead of clamping.

--- a/packages/docs/guide/query-ast.md
+++ b/packages/docs/guide/query-ast.md
@@ -1,22 +1,22 @@
 # The Query AST
 
-Under every rapiq feature sits one data structure: the `Query` — a tree of node objects from `@rapiq/core`. Parsers produce it, schemas constrain it, adapters consume it. You rarely touch it directly, but understanding it is the key to extending rapiq with your own parsers and backends.
+Under every rapiq feature sits one data structure: the `Query`, a tree of node objects from `@rapiq/core`. Parsers produce it, schemas constrain it, adapters consume it. You rarely touch it directly, but understanding it is the key to extending rapiq with your own parsers and backends.
 
 ## Nodes
 
 | Collection node | Record node | Holds |
 |---|---|---|
-| `Fields` | `Field` | `name`, optional `operator` (`FieldOperator.INCLUDE` / `EXCLUDE`) |
+| `Fields` | `Field` | `name`, optional `operator` (`FieldOperator.INCLUDE` / `EXCLUDE`), optional `condition` (`ICondition`, a [row-scoped visibility gate](/guide/fields#row-scoped-fields)) |
 | `Filters` | `Filter` | compound (`and` / `or` / `not`) tree of `{ operator, field, value }` conditions |
 | `Relations` | `Relation` | `name` (dot-notation for nested paths) |
 | `Sorts` | `Sort` | `name`, `operator` (`'ASC'` / `'DESC'`) |
-| `Pagination` | — | `limit`, `offset` |
+| `Pagination` | *(none)* | `limit`, `offset` |
 
 `Filters` is the only recursive node: its children are either leaf `Filter` conditions or nested `Filters`, so arbitrary `and`/`or` combinations compose naturally.
 
 ## Hand-constructing a query
 
-Rarely necessary — [`defineQuery`](/guide/building-queries) builds the same tree from typed input — but instructive:
+Rarely necessary ([`defineQuery`](/guide/building-queries) builds the same tree from typed input) but instructive:
 
 ```typescript
 import {
@@ -40,11 +40,11 @@ const query = new Query({
 });
 ```
 
-Every constructor argument is optional — omitted parameters default to empty collections, which adapters treat as no-ops.
+Every constructor argument is optional: omitted parameters default to empty collections, which adapters treat as no-ops.
 
 ## The visitor pattern
 
-Nodes are consumed via double dispatch — every node has `accept(visitor)`, and backends implement visitor interfaces for the nodes they care about:
+Nodes are consumed via double dispatch. Every node has `accept(visitor)`, and backends implement visitor interfaces for the nodes they care about:
 
 ```typescript
 interface IFiltersVisitor { visitFilters(filters: IFilters): unknown }
@@ -58,7 +58,7 @@ query.accept(myQueryVisitor);           // whole query
 query.filters.accept(myFiltersVisitor); // single parameter
 ```
 
-This is how all three adapters work — [`@rapiq/adapter-sql`](/packages/adapter-sql) accumulates SQL fragments, [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) writes into a query builder, [`@rapiq/adapter-memory`](/packages/adapter-memory) returns compiled functions (`R = Predicate`). New backends are added by implementing visitors; core never changes.
+This is how all five adapters consume the query. Three are interpreter-style: [`@rapiq/adapter-sql`](/packages/adapter-sql) accumulates SQL fragments, [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) writes into a query builder, [`@rapiq/adapter-memory`](/packages/adapter-memory) returns compiled functions (`R = Predicate`). The two serializer adapters, [`@rapiq/adapter-prisma`](/packages/adapter-prisma) and [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle), implement the same `IQueryVisitor` entry point but consume filter conditions through the plan layer (`planCondition` plus `distributeNegation` feeding a pure renderer) instead of accumulating fragments, serializing the query into a plain `findMany` argument object. New backends are added by implementing visitors; core never changes.
 
 ## Type guards
 
@@ -81,11 +81,11 @@ function toQuery<T extends Record<string, any>>(
 }
 ```
 
-`isParameterNode` is the generic escape hatch — it accepts *any* AST node (everything carrying an `accept` method) without identifying its kind, separating built fragments from plain build input.
+`isParameterNode` is the generic escape hatch: it accepts *any* AST node (everything carrying an `accept` method) without identifying its kind, separating built fragments from plain build input.
 
 ## Writing a custom parser: ResolutionScope
 
-Parsers resolve raw client keys through a `ResolutionScope` — an immutable handle on *one parameter of one schema under one failure policy*. It owns alias mapping, allow-list verdicts, relation traversal through the registry (`schemaMapping`-aware) and the throw-vs-drop policy, so a custom parser doesn't reimplement any of it:
+Parsers resolve raw client keys through a `ResolutionScope`: an immutable handle on *one parameter of one schema under one failure policy*. It owns alias mapping, allow-list verdicts, relation traversal through the registry (`schemaMapping`-aware) and the throw-vs-drop policy, so a custom parser doesn't reimplement any of it:
 
 ```typescript
 import { Parameter, ResolutionScope } from '@rapiq/core';
@@ -101,9 +101,9 @@ scope.resolveKey('secret');
 
 `resolveKey()` resolves a local, aliased or dotted key and reports the outcome as a discriminated union (or throws the parameter's error class when `throwOnFailure` applies). `descend('items')` enters a relation segment and returns a child scope bound to the related schema. Scopes created without any schema input are *unbound* and impose no constraints.
 
-Custom parsers extend `BaseParser<OPTIONS, OUTPUT>` from core — the shipped parsers ([simple](/packages/parser-simple), [expression](/packages/parser-expression), [mongo](/packages/parser-mongo)) are reference implementations, each composing one sub-parser per parameter.
+Custom parsers extend `BaseParser<OPTIONS, OUTPUT>` from core; the shipped parsers ([simple](/packages/parser-simple), [expression](/packages/parser-expression), [mongo](/packages/parser-mongo)) are reference implementations, each composing one sub-parser per parameter.
 
 ## Next steps
 
-- [Error Handling](/guide/errors) — the error contract extensions should follow.
-- [Package overview](/packages/) — where each shipped implementation lives.
+- [Error Handling](/guide/errors): the error contract extensions should follow.
+- [Package overview](/packages/): where each shipped implementation lives.

--- a/packages/docs/guide/quick-start.md
+++ b/packages/docs/guide/quick-start.md
@@ -21,7 +21,7 @@ type User = {
 
 ## 1. Build a query (caller)
 
-`defineQuery` builds a typed query — the record generic checks every field path against `User`:
+`defineQuery` builds a typed query: the record generic checks every field path against `User`:
 
 ```typescript
 import { defineQuery } from '@rapiq/core';
@@ -41,7 +41,7 @@ const queryString = createURLCodec().encode(query);
 const response = await fetch(`/users?${queryString}`);
 ```
 
-Filters accept scalars (`{ name: 'John' }`), arrays (`{ id: [1, null] }` — an *in* list), `$`-operator objects and condition helpers like `or(gte('age', 18), eq('email', null))`. The full grammar lives in [Building Queries](/guide/building-queries).
+Filters accept scalars (`{ name: 'John' }`), arrays (`{ id: [1, null] }`, an *in* list), `$`-operator objects and condition helpers like `or(gte('age', 18), eq('email', null))`. The full grammar lives in [Building Queries](/guide/building-queries).
 
 ## 2. Declare what clients may request (server)
 
@@ -92,7 +92,7 @@ Fields, relations, sort and pagination follow the schema's drop-vs-throw policy.
 
 ## 4. Execute (server)
 
-With TypeORM, the adapter applies the query to a `SelectQueryBuilder` — filters become parameterized `WHERE` conditions, relations become joins:
+With TypeORM, the adapter applies the query to a `SelectQueryBuilder`: filters become parameterized `WHERE` conditions, relations become joins:
 
 ```typescript
 import { TypeormAdapter } from '@rapiq/adapter-typeorm';
@@ -114,18 +114,18 @@ res.json({
 });
 ```
 
-No TypeORM? [`@rapiq/adapter-sql`](/packages/adapter-sql) renders parameterized SQL fragments for any driver, and [`@rapiq/adapter-memory`](/packages/adapter-memory) evaluates the same query against plain arrays.
+No TypeORM? [`@rapiq/adapter-prisma`](/packages/adapter-prisma) and [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) serialize the same query into ORM-native argument objects, [`@rapiq/adapter-sql`](/packages/adapter-sql) renders parameterized SQL fragments for any driver, and [`@rapiq/adapter-memory`](/packages/adapter-memory) evaluates it against plain arrays. All five are compared in [Executing Queries](/guide/executing-queries).
 
 ## What just happened
 
-1. The caller expressed *intent* in a typed structure — no hand-built query strings.
+1. The caller expressed *intent* in a typed structure: no hand-built query strings.
 2. The wire carried a self-described expression filter alongside JSON:API-style parameters.
 3. The server enforced its contract *before* anything touched the database.
-4. The adapter translated the validated query mechanically — values are always bound as parameters, never interpolated.
+4. The adapter translated the validated query mechanically: values are always bound as parameters, never interpolated.
 
 ## Next steps
 
-- [Core Concepts](/guide/concepts) — the four moving parts behind these steps.
-- [Building Queries](/guide/building-queries) — the full client-side grammar.
-- [Schemas & Validation](/guide/schemas) — defaults, aliases, strict mode, failure policy.
-- [Recipes: REST API with Express & TypeORM](/guide/recipes/express-typeorm) — the complete endpoint with error handling.
+- [Core Concepts](/guide/concepts): the four moving parts behind these steps.
+- [Building Queries](/guide/building-queries): the full client-side grammar.
+- [Schemas & Validation](/guide/schemas): defaults, aliases, strict mode, failure policy.
+- [Recipes: REST API with Express & TypeORM](/guide/recipes/express-typeorm): the complete endpoint with error handling.

--- a/packages/docs/guide/recipes/authorization.md
+++ b/packages/docs/guide/recipes/authorization.md
@@ -1,15 +1,17 @@
 # Authorization & Scoping
 
+*Chapter 7 of the [recipes storyline](/guide/recipes/), the cross-cutting layer: gates and scopes that apply to every previous chapter's endpoint. Previous: [Testing with the Memory Adapter](/guide/recipes/testing-memory).*
+
 Four recurring authorization problems, one query language:
 
-1. **Gating the request** — a client may only *ask for* what its actor is permitted to see: including a relation must require the permission to read the related entity.
-2. **Scoping a collection** — a user may only ever see records of their own realm, no matter what they ask for.
+1. **Gating the request**: a client may only *ask for* what its actor is permitted to see; including a relation must require the permission to read the related entity.
+2. **Scoping a collection**: a user may only ever see records of their own realm, no matter what they ask for.
 3. **Scoping a column**: a field is readable, but only on *some* of the rows the actor is otherwise allowed to see.
 4. **Guarding a single record**: an ability like *"may edit users where `realm_id = X`"* must be checked against one object in memory, and must agree exactly with what the database query would return.
 
 ## Gating: per-actor checks at decode time
 
-Schema allow-lists say what *any* client may request. The [validate hooks](/guide/schemas#validate-hooks--parse-context) say what *this* actor may request: pass the actor as the parse `context`, and let the schema run a permission check per requested relation (or field, or sort key):
+Schema allow-lists say what *any* client may request. The [validate hooks](/guide/schemas#validate-hooks-parse-context) say what *this* actor may request: pass the actor as the parse `context`, and let the schema run a permission check per requested relation (or field, or sort key):
 
 ```typescript
 type Actor = { can: (permission: string) => Promise<boolean> };
@@ -34,15 +36,15 @@ app.get('/client-permissions', async (req, res) => {
 });
 ```
 
-Hooks run against the **target schema** of each path segment — `include=client.realm` checks `client` on this schema and `realm` on the client schema — so an include can never widen access past the related schema's own gate. Rejections follow the schema failure policy: dropped by default, thrown (`ErrorCode.KEY_VALIDATE_REJECTED`) with `throwOnFailure`. An absent context reaches the hook as `undefined`, so a permission hook written like the one above fails closed.
+Hooks run against the **target schema** of each path segment (`include=client.realm` checks `client` on this schema and `realm` on the client schema), so an include can never widen access past the related schema's own gate. Rejections follow the schema failure policy: dropped by default, thrown (`ErrorCode.KEY_VALIDATE_REJECTED`) with `throwOnFailure`. An absent context reaches the hook as `undefined`, so a permission hook written like the one above fails closed.
 
-The `relations` hook is not scoped to `include=`. A dotted `filter[client.name]`, `fields[client]` or `sort=client.name` forces the same join, so the hook runs for those too — evaluated once per distinct relation across the query. An actor denied `client` cannot slip the join in through another parameter.
+The `relations` hook is not scoped to `include=`. A dotted `filter[client.name]`, `fields[client]` or `sort=client.name` forces the same join, so the hook runs for those too, evaluated once per distinct relation across the query. An actor denied `client` cannot slip the join in through another parameter.
 
 ::: warning Authorization happens at the parse/decode boundary
-The gate runs while **parsing untrusted input** — `parse()` / `decode()` and the per-parameter `decode*` helpers. It is a property of that boundary, not of the `Query` object itself: a query you assemble server-side with the schema-free [build layer](/guide/building-queries) (`defineQuery`, condition helpers) and hand straight to an adapter is **not** re-checked — the adapter joins what the query names. Feed client input through a parser/codec with a schema and `context`; keep server-authored queries (and schema `default`s) as the trusted baseline. See [Scoping](#scoping-inject-conditions-the-client-cant-displace) for pinning server conditions the client can't displace.
+The gate runs while **parsing untrusted input**: `parse()` / `decode()` and the per-parameter `decode*` helpers. It is a property of that boundary, not of the `Query` object itself: a query you assemble server-side with the schema-free [build layer](/guide/building-queries) (`defineQuery`, condition helpers) and hand straight to an adapter is **not** re-checked; the adapter joins what the query names. Feed client input through a parser/codec with a schema and `context`; keep server-authored queries (and schema `default`s) as the trusted baseline. See [Scoping](#scoping-inject-conditions-the-client-cannot-displace) for pinning server conditions the client cannot displace.
 :::
 
-## Scoping: inject conditions the client can't displace
+## Scoping: inject conditions the client cannot displace
 
 After decoding the client's query, wrap its filters with your scope condition via `and()`:
 
@@ -66,10 +68,10 @@ app.get('/users', async (req, res) => {
 });
 ```
 
-Why `and()` and not a merge? `and()` **wraps** the client's tree as a sibling of the injected condition — the condition becomes structure, not data:
+Why `and()` and not a merge? `and()` **wraps** the client's tree as a sibling of the injected condition; the condition becomes structure, not data:
 
 - A client filter on `realm_id` narrows *within* the scope; it can never widen it.
-- The wrapped tree is no longer flat, so a later [`merge()`](/guide/merging-queries#merge--per-field-replace) throws `MergeError` instead of silently displacing the scope condition. The failure mode defends the invariant.
+- The wrapped tree is never flat, so a later [`merge()`](/guide/merging-queries#merge-per-field-replace) throws `MergeError` instead of silently displacing the scope condition. The failure mode defends the invariant. This holds unconditionally: even when the client sent no filters at all, the injected condition lands in a nested group rather than a flat root-AND.
 
 Belt and suspenders: also leave `realm_id` out of the schema's `filters.allowed` list, and clients can't even *mention* it.
 
@@ -126,6 +128,8 @@ const rows = await queryBuilder.getMany();
 res.json(applyFieldConditions(query.fields, rows));
 ```
 
+The serializer adapters are in the same position. `@rapiq/adapter-prisma` and `@rapiq/adapter-drizzle` keep the gated column selected and force-project the columns the gate reads as select-only entries (in drizzle, an operand that addresses a relation hydrates through `with` instead), so the fetched rows carry everything `applyFieldConditions` needs; nothing enforces the gate in the database. `PrismaAdapter.findMany()` even refuses a query carrying field conditions with a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`) rather than shipping rows unredacted: serialize with `execute()`, run the args yourself, then apply the pass above. The drizzle adapter has no runner at all, so the same post-fetch pass applies to whatever `db.query.<table>.findMany(config)` returns.
+
 This is fail-open by construction. If the column must never reach the process at all, reject the field (`return false`) instead of gating it.
 :::
 
@@ -156,7 +160,7 @@ const scoped = new Query({
 });
 ```
 
-`@rapiq/adapter-memory` aims for **SQL parity** — null handling, string matching and relation-path binding match what the SQL/TypeORM adapters produce — so the guard and the query cannot drift apart. Semantics details: [@rapiq/adapter-memory](/packages/adapter-memory#filter-semantics).
+`@rapiq/adapter-memory` aims for **SQL parity** (null handling, string matching and relation-path binding match what the SQL/TypeORM adapters produce), so the guard and the query cannot drift apart. Semantics details: [@rapiq/adapter-memory](/packages/adapter-memory#filter-semantics).
 
 For whole-query checks (fields, sort, pagination included), compile once and reuse:
 
@@ -180,5 +184,5 @@ compiled.apply(users);     // apply the full query to loaded data
 
 ## Next steps
 
-- [Merging & Composition](/guide/merging-queries) — why injected trees resist merging.
-- [@rapiq/adapter-memory](/packages/adapter-memory) — the full in-memory semantics contract.
+- [Merging & Composition](/guide/merging-queries): why injected trees resist merging.
+- [@rapiq/adapter-memory](/packages/adapter-memory): the full in-memory semantics contract.

--- a/packages/docs/guide/recipes/express-typeorm.md
+++ b/packages/docs/guide/recipes/express-typeorm.md
@@ -1,5 +1,7 @@
 # REST API with Express & TypeORM
 
+*Chapter 3 of the [recipes storyline](/guide/recipes/): the server baseline of the realm/user API, receiving what [the frontend chapter](/guide/recipes/frontend) sends. Next: [swapping the backend for Prisma or Drizzle](/guide/recipes/prisma-drizzle).*
+
 The complete, production-shaped list endpoint: schemas in one module, a decoder shared across handlers, per-request adapters, a `meta` block in the response and clean `400`s for contract violations.
 
 ## Project layout
@@ -56,7 +58,7 @@ import { registry } from './schema';
 export const codec = createURLCodec(registry);
 ```
 
-The codec is stateless between calls — share one instance across all routes.
+The codec is stateless between calls; share one instance across all routes.
 
 ## 3. The endpoint
 
@@ -110,12 +112,12 @@ export async function getUsers(req: Request, res: Response) {
 GET /users                                            defaults: id+name, sorted -id, limit 50
 GET /users?filter[age]=>=18&sort=-age                 filtered & sorted
 GET /users?include=realm&fields[realm]=name           relation + sparse fields
-GET /users?page[limit]=10&page[offset]=20             paged, capped at 50
-GET /users?filter[secret]=x                           400 — key not allowed
+GET /users?page[limit]=10&page[offset]=20             paged; a limit above 50 is a 400
+GET /users?filter[secret]=x                           400: key not allowed
 ```
 
 ## Variations
 
-- **Scope by the authenticated user** — inject filters the client can't displace: [Authorization & scoping](/guide/recipes/authorization).
-- **No TypeORM** — swap the adapter for [`@rapiq/adapter-sql`](/packages/adapter-sql) fragments; the decode half stays identical.
-- **Migrate old clients gradually** — the codec writes expressions but continues to recognize legacy bracket-filter input; see [Queries over the Wire](/guide/wire).
+- **Scope by the authenticated user**: inject filters the client cannot displace; see [Authorization & Scoping](/guide/recipes/authorization).
+- **No TypeORM**: the next chapter, [Swapping the Backend: Prisma & Drizzle](/guide/recipes/prisma-drizzle), keeps the contract, codec and routes of this recipe and changes only the execute layer. For raw SQL, swap the adapter for [`@rapiq/adapter-sql`](/packages/adapter-sql) fragments; the decode half stays identical either way.
+- **Migrate old clients gradually**: the codec writes expressions but continues to recognize legacy bracket-filter input; see [Queries over the Wire](/guide/wire).

--- a/packages/docs/guide/recipes/frontend.md
+++ b/packages/docs/guide/recipes/frontend.md
@@ -1,12 +1,14 @@
 # Type-Safe Frontend Queries
 
-A list component typically owes its query to three sources at once: **defaults** it ships with, a **scope** its parent imposes via props, and **user input** from search/sort/pagination controls. This recipe composes the three declaratively — typed against the record, merged by rank, encoded on demand.
+*Chapter 2 of the [recipes storyline](/guide/recipes/): the client layer of the realm/user API, where queries are built, composed and encoded. Next: the server baseline in [REST API with Express & TypeORM](/guide/recipes/express-typeorm).*
 
-Works the same in Vue, React or plain TypeScript — rapiq has no framework dependency.
+A list component typically owes its query to three sources at once: **defaults** it ships with, a **scope** its parent imposes via props, and **user input** from search/sort/pagination controls. This recipe composes the three declaratively: typed against the record, merged by rank, encoded on demand.
+
+Works the same in Vue, React or plain TypeScript; rapiq has no framework dependency.
 
 ## Shared types
 
-Share the record types (and nothing else) between frontend and backend — a types-only package or a generated client:
+Share the record types (and nothing else) between frontend and backend, via a types-only package or a generated client:
 
 ```typescript
 export type User = {
@@ -29,20 +31,20 @@ import type { User } from 'my-api-types';
 
 const codec = createURLCodec();
 
-// 1. component defaults — shipped with the list
+// 1. component defaults: shipped with the list
 const defaults = defineQuery<User>({
     fields: ['id', 'name', 'email'],
     sort: '-id',
     pagination: { limit: 25 },
 });
 
-// 2. parent-imposed scope — realmId arrives as a prop / argument
+// 2. parent-imposed scope: realmId arrives as a prop / argument
 //    (fragments are plain values, so they travel well as data)
 function scopeFor(realmId: string) {
     return defineFilters<User>({ 'realm.id': realmId });
 }
 
-// 3. user input — from the search box & pager
+// 3. user input: from the search box & pager
 function buildQuery(realmId: string, search: string, page: number) {
     const userInput = defineQuery<User>({
         filters: { name: { $contains: search || undefined } },
@@ -62,9 +64,9 @@ async function fetchUsers(realmId: string, search: string, page: number) {
 
 Three details doing quiet work here:
 
-- `{ $contains: search || undefined }` — an `undefined` operator value contributes **no condition**, so the empty search box simply doesn't filter. No `if`-shuffling around the query object.
+- `{ $contains: search || undefined }`: an `undefined` operator value contributes **no condition**, so the empty search box simply doesn't filter. No `if`-shuffling around the query object.
 - The merge is **per-field** for filters: the user's `name` filter never disturbs the scope's `realm.id` condition, and both survive alongside the defaults' sort and fields.
-- Everything is **immutable** — merging never mutates its inputs, so `defaults` is safe as a module constant and fragments like the realm scope are safe to pass around as props.
+- Everything is **immutable**: merging never mutates its inputs, so `defaults` is safe as a module constant and fragments like the realm scope are safe to pass around as props.
 
 ## Framework flavors
 
@@ -114,9 +116,9 @@ Because the encoded string is derived state, it also makes a perfect cache key f
 
 The default expression dialect carries nested `or(...)` trees and repeated-field conditions. Operators without a URL grammar still throw a typed error rather than sending something with different semantics. Legacy simple encoding is available only as an explicit migration option; see the [URL codec reference](/packages/codec-url#legacy-simple-dialect).
 
-Optionally, encode against the server's schema for early feedback — see [schema-aware transport](/guide/wire#schema-aware-transport).
+Optionally, encode against the server's schema for early feedback; see [schema-aware transport](/guide/wire#schema-aware-transport).
 
 ## Next steps
 
-- [Merging & Composition](/guide/merging-queries) — exact merge semantics.
-- [Building Queries](/guide/building-queries) — the full input grammar.
+- [Merging & Composition](/guide/merging-queries): exact merge semantics.
+- [Building Queries](/guide/building-queries): the full input grammar.

--- a/packages/docs/guide/recipes/index.md
+++ b/packages/docs/guide/recipes/index.md
@@ -1,0 +1,53 @@
+# Recipes
+
+*Chapter 1 of the recipes storyline: the map. One small API is built through every layer of rapiq; start here, then read in order or jump to the layer you want to swap. Next: [Type-Safe Frontend Queries](/guide/recipes/frontend).*
+
+The recipes tell one continuous story over one running example: a realm/user API whose clients list, filter, sort, page and expand `/users`. Each chapter owns exactly one layer of the pipeline, so the section reads front to back, but every chapter also stands alone if you arrive with a specific problem.
+
+## The running example
+
+Two record types, shared by all chapters:
+
+```typescript
+export type Realm = {
+    id: string,
+    name: string,
+};
+
+export type User = {
+    id: number,
+    name: string,
+    email: string,
+    age: number,
+    realm: Realm,
+};
+```
+
+The server declares what clients may request in a schema module (`src/schema.ts`) and shares one URL codec (`src/codec.ts`). Both are defined once in [chapter 3](/guide/recipes/express-typeorm) and reused verbatim by every later chapter: that reuse is the point of the story.
+
+## The pipeline
+
+```txt
+defineQuery<User>({ ... })            the caller builds a typed query     chapter 2
+        │  codec.encode()
+        ▼
+?codec=url-expression&filter=...      one ordinary URL query string
+        │  HTTP
+        ▼
+codec.decode(req.query, { schema })   validated against the contract      chapter 3
+        │                             (chapter 5 swaps in a mongo parser)
+        ▼
+adapter.execute(query)                your backend runs it                chapters 3, 4, 6
+```
+
+## The chapters
+
+1. **You are here.** The map and the running example.
+2. [Type-Safe Frontend Queries](/guide/recipes/frontend) owns the **client layer**: component defaults, parent-imposed scope and user input, composed with `defineQuery` and `mergeQueries` and encoded on demand.
+3. [REST API with Express & TypeORM](/guide/recipes/express-typeorm) is the **server baseline**: schemas as the contract, the shared codec, TypeORM execution, the response `meta` envelope and clean 400s.
+4. [Swapping the Backend: Prisma & Drizzle](/guide/recipes/prisma-drizzle) swaps the **execute layer**: same contract, same codec, same route shape; only the adapter changes.
+5. [MongoDB-Style Search Endpoint](/guide/recipes/mongo-search) swaps the **input dialect**: a POST search endpoint feeds MongoDB-style filter documents through `@rapiq/parser-mongo` into the same schema and the same adapter.
+6. [Testing with the Memory Adapter](/guide/recipes/testing-memory) replaces the database with **compiled functions**: `@rapiq/adapter-memory` runs the same contract against fixture arrays, so endpoint behavior is testable without infrastructure.
+7. [Authorization & Scoping](/guide/recipes/authorization) is the **cross-cutting chapter**: per-actor gates at decode time, injected scope conditions, row-scoped column access and in-memory guards, layered over everything the previous chapters built.
+
+New to rapiq? Read the [Quick Start](/guide/quick-start) first: the recipes assume the vocabulary introduced there.

--- a/packages/docs/guide/recipes/mongo-search.md
+++ b/packages/docs/guide/recipes/mongo-search.md
@@ -1,0 +1,116 @@
+# MongoDB-Style Search Endpoint
+
+*Chapter 5 of the [recipes storyline](/guide/recipes/): after [the previous chapter](/guide/recipes/prisma-drizzle) swapped the execute layer, this one swaps the input dialect; the contract from [chapter 3](/guide/recipes/express-typeorm) stays. Next: [Testing with the Memory Adapter](/guide/recipes/testing-memory).*
+
+URL query strings suit `GET` list endpoints, but filters do not always travel that way: complex search forms, saved filters, or a caller that already speaks the [MongoDB query language](https://www.mongodb.com/docs/manual/reference/operator/query/) all want structured JSON. [`@rapiq/parser-mongo`](/packages/parser-mongo) parses a MongoDB-style filter document into the same [`Query`](/guide/query-ast) as every other dialect, validated against the same schema. The server does **not** run MongoDB; the dialect is input syntax only.
+
+This chapter adds `POST /users/search` next to chapter 3's `GET /users`. The contract module (`src/schema.ts`) and the execution half are untouched; only the parse step changes.
+
+## The endpoint
+
+```typescript
+// src/routes/users-search.ts
+import type { Request, Response } from 'express';
+import { ParseError } from '@rapiq/core';
+import { MongoParser } from '@rapiq/parser-mongo';
+import { TypeormAdapter } from '@rapiq/adapter-typeorm';
+import { dataSource } from '../data-source';
+import { registry } from '../schema';
+import { User } from '../entities';
+
+const parser = new MongoParser(registry);
+
+export async function searchUsers(req: Request, res: Response) {
+    let query;
+    try {
+        query = parser.parse(req.body, { schema: 'user' });
+    } catch (e) {
+        if (e instanceof ParseError) {
+            return res.status(400).json({ error: e.message, code: e.code });
+        }
+        throw e;
+    }
+
+    const queryBuilder = dataSource.getRepository(User).createQueryBuilder('user');
+
+    const adapter = new TypeormAdapter({
+        relations: { joinAndSelect: true },
+        queryBuilder,
+    });
+    const { pagination } = adapter.execute(query);
+
+    const [entities, total] = await queryBuilder.getManyAndCount();
+
+    return res.json({
+        data: entities,
+        meta: {
+            total,
+            limit: pagination.limit,
+            offset: pagination.offset,
+        },
+    });
+}
+```
+
+Wire it up with a JSON body parser: `app.use(express.json())` and `app.post('/users/search', searchUsers)`. Like the codec, the parser is stateless between calls; share one instance across routes. Unlike `codec.decode`, `parser.parse` never returns `null`: it returns a `Query`, and everything invalid throws.
+
+## What clients send
+
+```json
+{
+    "filters": {
+        "$or": [
+            { "name": { "$contains": "ada" } },
+            { "age": { "$gte": 18, "$lt": 65 } }
+        ],
+        "realm.id": "a"
+    },
+    "relations": ["realm"],
+    "sort": "-age",
+    "pagination": { "limit": 25 }
+}
+```
+
+Multiple document entries combine with an implicit AND, a bare scalar means `$eq`, a bare array means `$in`, and dotted keys reach relation paths; the full operator table lives on the [package page](/packages/parser-mongo#the-dialect).
+
+Only `filters` is mongo-flavored. `fields`, `relations`, `sort` and `pagination` accept the same shapes as the [simple dialect](/packages/parser-simple) from chapter 3, and every schema constraint applies unchanged: the filter allow-list, the relations allow-list, the `maxLimit` of 50, the `-id` sort default when the client sends none.
+
+## Typed values, no wire grammar
+
+The URL dialects are untyped; every value crosses the wire as a string and the wire grammar coerces it back. A JSON body carries real types, so nothing is coerced:
+
+```txt
+filter[age]=>=18                 URL simple: a string, operator and value share one token
+filter=gte(age,'18')             URL expression: value quoted as a string, coerced on decode
+{ "age": { "$gte": 18 } }        JSON body: a real number reaches the AST untouched
+```
+
+That buys three things the URL dialects cannot express:
+
+- **Numbers and booleans stay themselves.** `18` is a number, `true` is a boolean; there is no string-form ambiguity.
+- **`null` is a real null.** `{ "field": null }` is an is-null test (see [null semantics](/guide/filters#null-semantics)), never the string `'null'`.
+- **Operators without a URL grammar become reachable.** `$regex` (as a pattern string, optionally with `$options`), `$mod`, `$size`, `$elemMatch` and `$all` have no expression spelling but parse fine from a document. When calling `parse()` in-process, `Date` and `RegExp` instances pass through as-is; over JSON, an ISO date string stays a string and is **not** coerced to a `Date`.
+
+::: warning Untrusted `$regex`
+This is the only dialect that lets a client submit a regular expression. Here the pattern is handed to the database engine; if the same queries are ever evaluated in-process with [`@rapiq/adapter-memory`](/packages/adapter-memory) (next chapter), a crafted pattern can burn CPU. Gate the operator with the schema's `filters.validate` hook: see the [regex trust model](/guide/filters#regex-trust-model).
+:::
+
+## Grammar errors vs. contract violations
+
+The parser splits failures into two classes:
+
+- **Grammar errors always throw** `FiltersParseError`, no matter what the schema's failure policy says: unknown or misplaced `$`-operators, malformed operator values, invalid compound arrays. A `$`-prefixed key is never a field name, so a broken document has no silent-drop reading.
+- **Allow-list failures follow the schema policy.** This contract sets `throwOnFailure: true`, so an undeclared field key throws too; without it, the offending entry (an `$elemMatch` subtree included) would be dropped silently and the schema defaults would fill the gaps.
+
+```txt
+{ "filters": { "age": { "$type": "number" } } }    400, code operatorUnsupported (grammar, throws regardless)
+{ "filters": { "secret": "x" } }                   400, code keyNotAllowed (contract, throws via throwOnFailure)
+```
+
+`FiltersParseError` extends `ParseError`, so the handler's single `catch` branch maps both classes to a `400`. See the [failure model](/packages/parser-mongo#failure-model) for the full error-code table.
+
+## Variations
+
+- **Per-actor gating**: schemas with async `validate` hooks need `parser.parseAsync(req.body, { schema: 'user', context: req.actor })`; the hooks and context are the subject of [Authorization & Scoping](/guide/recipes/authorization).
+- **Different backend**: swap the execute half exactly as chapter 4 did for [Prisma & Drizzle](/guide/recipes/prisma-drizzle); the parse half stays identical.
+- **Filters only**: the standalone `MongoFiltersParser` returns just the `Filters` node, useful when a stored filter document must be revalidated without the other parameters.

--- a/packages/docs/guide/recipes/prisma-drizzle.md
+++ b/packages/docs/guide/recipes/prisma-drizzle.md
@@ -1,0 +1,205 @@
+# Swapping the Backend: Prisma & Drizzle
+
+*Chapter 4 of the recipes storyline: the execute layer. The contract and codec from [REST API with Express & TypeORM](/guide/recipes/express-typeorm) stay untouched; only the adapter changes. Next: [MongoDB-Style Search Endpoint](/guide/recipes/mongo-search).*
+
+Chapter 3 ended with a TypeORM endpoint. This chapter re-bases the same `/users` route on [`@rapiq/adapter-prisma`](/packages/adapter-prisma) and then on [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) to make a point: the schema, the codec, the route shape and the response envelope are backend-independent. Swapping the database layer is a one-file diff.
+
+## What stays
+
+```txt
+src/
+├── schema.ts        # unchanged: the contract from chapter 3
+├── codec.ts         # unchanged: the shared codec from chapter 3
+└── routes/users.ts  # the only file this chapter touches
+```
+
+Both adapters are **pure serializers**: `execute(query)` returns a plain value (a `findMany` argument object for Prisma, a relational query config for Drizzle) instead of mutating a builder. That flips two habits from the TypeORM route:
+
+- the adapter is **stateless**: construct one instance per model/table and share it across requests, instead of one per request;
+- a serializer does not inspect your database or entities, so the model facts arrive as options: `metadata` and `provider` are **required**.
+
+## The endpoint on Prisma
+
+```typescript
+// src/routes/users.ts
+import type { Request, Response } from 'express';
+import { Prisma } from '@prisma/client';
+import { ParseError } from '@rapiq/core';
+import { PrismaAdapter, defineMetadata } from '@rapiq/adapter-prisma';
+import { codec } from '../codec';
+import { prisma } from '../prisma';
+
+// stateless: one instance per model, shared across requests.
+// On Prisma 7 the runtime datamodel is pruned, so hand-write the
+// same shape there; see the metadata note below.
+const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
+    provider: 'postgresql',
+    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+});
+
+export async function getUsers(req: Request, res: Response) {
+    let query;
+    try {
+        query = codec.decode(req.query, { schema: 'user' });
+    } catch (e) {
+        if (e instanceof ParseError) {
+            return res.status(400).json({ error: e.message, code: e.code });
+        }
+        throw e;
+    }
+    if (!query) {
+        return res.status(400).json({ error: 'Invalid query input.' });
+    }
+
+    const { args, pagination } = adapter.execute(query);
+
+    const [data, total] = await Promise.all([
+        prisma.user.findMany(args),
+        // filters, but never the page window: the pre-pagination total
+        prisma.user.count({ where: args.where }),
+    ]);
+
+    return res.json({
+        data,
+        meta: {
+            total,
+            limit: pagination.limit,
+            offset: pagination.offset,
+        },
+    });
+}
+```
+
+The decode half, the 400s and the `meta` envelope are copied from chapter 3 unchanged. Note what is *absent*: the `joinAndSelect` knob from the TypeORM route is builder-specific; a serializer hydrates every included relation by construction (`include` on Prisma, `with` on Drizzle).
+
+`metadata` answers four questions (is a path a relation, is it to-many, can the column hold null, does it hold strings), and each one changes what a *valid* Prisma filter looks like, so the adapter refuses to run without it. `provider` decides whether `mode: 'insensitive'` may be emitted for the case-insensitive default. Both are required **by design**: a wrong guess would be a runtime validation error, not graceful degradation. Details: [model metadata](/packages/adapter-prisma#model-metadata) and [case sensitivity](/packages/adapter-prisma#case-sensitivity).
+
+::: tip Model-bound runners
+Constructed with a model delegate instead (`new PrismaAdapter({ model: prisma.user, metadata })`), the adapter can also run what it serialized: `adapter.findMany(query)` and `adapter.count(query)`. See [running the query](/packages/adapter-prisma#running-the-query).
+:::
+
+## The endpoint on Drizzle
+
+Drizzle's metadata is a hand-written datamodel in drizzle's own vocabulary (`dataType` as on a drizzle column, relations keyed the way `defineRelations` keys them); a bare string is shorthand for `{ dataType }`:
+
+```typescript
+// src/routes/users.ts
+import type { Request, Response } from 'express';
+import { ParseError } from '@rapiq/core';
+import { DrizzleAdapter, defineMetadata } from '@rapiq/adapter-drizzle';
+import { codec } from '../codec';
+import { db } from '../db';
+
+// stateless: one instance per table, shared across requests
+const adapter = new DrizzleAdapter({
+    provider: 'pg',
+    metadata: defineMetadata({
+        users: {
+            columns: {
+                id: { dataType: 'number', nullable: false },
+                name: 'string',
+                email: 'string',
+                age: { dataType: 'number', nullable: false },
+            },
+            relations: {
+                realm: { target: 'realms', many: false },
+            },
+        },
+        realms: {
+            columns: {
+                id: { dataType: 'string', nullable: false },
+                name: 'string',
+            },
+        },
+    }, 'users'),
+});
+
+export async function getUsers(req: Request, res: Response) {
+    let query;
+    try {
+        query = codec.decode(req.query, { schema: 'user' });
+    } catch (e) {
+        if (e instanceof ParseError) {
+            return res.status(400).json({ error: e.message, code: e.code });
+        }
+        throw e;
+    }
+    if (!query) {
+        return res.status(400).json({ error: 'Invalid query input.' });
+    }
+
+    const { config, pagination } = adapter.execute(query);
+
+    const data = await db.query.users.findMany(config);
+
+    // the relational API ships no count runner: reuse the produced
+    // where for an id-only query. An unsatisfiable filter surfaces
+    // as `limit: 0`, never in the where; the pagination echo tells
+    // it apart from a client-sent page[limit]=0, which still counts.
+    const impossible = config.limit === 0 && pagination.limit !== 0;
+    const total = impossible
+        ? 0
+        : (await db.query.users.findMany({
+            where: config.where,
+            columns: { id: true },
+        })).length;
+
+    return res.json({
+        data,
+        meta: {
+            total,
+            limit: pagination.limit,
+            offset: pagination.offset,
+        },
+    });
+}
+```
+
+Same story: only the execute layer moved. `provider` and `metadata` are required here for the same reason as on Prisma; the drizzle facts decide the shape of a *correct* filter object (relation presence tests, complement null arms, `ilike` folding). Details: [table metadata](/packages/adapter-drizzle#table-metadata) and [case sensitivity](/packages/adapter-drizzle#case-sensitivity).
+
+## The contract did not move
+
+Every wire request from chapter 3 works unchanged, on either backend:
+
+```txt
+GET /users?filter[age]=>=18&sort=-age                 filtered & sorted
+GET /users?include=realm&fields[realm]=name           include -> Prisma include / Drizzle with
+GET /users?filter[secret]=x                           still 400: key not allowed
+```
+
+And the semantics move with the query, not with the backend: null-inclusive complements for negated operators, the case-insensitive default, same-element binding on to-many paths. The adapters render them differently (Prisma gets explicit `OR` null arms, Drizzle gets `isNull` arms and `ilike`), but the result sets are pinned identical by engine-backed parity suites.
+
+## Scoping stays one option away
+
+Both adapters take a `base` option: an application-owned baseline that the client's conditions are conjoined with, never substituted for:
+
+```typescript
+const { args } = adapter.execute(query, {
+    base: { where: { realm_id: req.actor.realmId } },
+});
+
+// where: { AND: [ { realm_id: ... }, { ...client filters } ] }
+```
+
+The Drizzle form is identical with `config` in place of `args`. [Authorization & Scoping](/guide/recipes/authorization) treats scoping in depth.
+
+## What changed
+
+| | TypeORM (chapter 3) | Prisma / Drizzle |
+|---|---|---|
+| Adapter lifetime | per request, bound to a builder | one stateless instance, shared |
+| Output | mutates the query builder | a plain args / config value |
+| Model facts | read from entity metadata | `metadata` + `provider`, required options |
+| Total for `meta` | `getManyAndCount()` | `prisma.user.count()` / an id-only second query |
+
+What did **not** change: `schema.ts`, `codec.ts`, the wire format, the decode-then-400 route shape, and the `meta` envelope.
+
+## Honest limitations
+
+Operators these backends cannot express natively raise a typed `AdapterError` (`FEATURE_UNSUPPORTED`) instead of being approximated: `regex`, `mod`, `size` and the `$this` element marker, on both adapters. Drizzle additionally rejects ordering by a relation path; Prisma rejects `elemMatch` on a to-one relation. Loud beats a silent semantic downgrade; the full lists live at [Prisma limitations](/packages/adapter-prisma#limitations) and [Drizzle limitations](/packages/adapter-drizzle#limitations).
+
+## Next steps
+
+- [MongoDB-Style Search Endpoint](/guide/recipes/mongo-search): chapter 5 swaps the input dialect instead.
+- [@rapiq/adapter-prisma](/packages/adapter-prisma) / [@rapiq/adapter-drizzle](/packages/adapter-drizzle): the full adapter references.
+- [Executing Queries](/guide/executing-queries): the adapter surface shared by all backends.

--- a/packages/docs/guide/recipes/prisma-drizzle.md
+++ b/packages/docs/guide/recipes/prisma-drizzle.md
@@ -30,11 +30,33 @@ import { codec } from '../codec';
 import { prisma } from '../prisma';
 
 // stateless: one instance per model, shared across requests.
-// On Prisma 7 the runtime datamodel is pruned, so hand-write the
-// same shape there; see the metadata note below.
+// The datamodel is hand-written because it works on every Prisma
+// version; Prisma 7 prunes the runtime datamodel (`Prisma.dmmf`
+// included), so deriving it only works on 6.x classic builds.
+// See the metadata note below.
 const adapter = new PrismaAdapter<Prisma.UserFindManyArgs>({
     provider: 'postgresql',
-    metadata: defineMetadata(Prisma.dmmf.datamodel, 'User'),
+    metadata: defineMetadata({
+        models: [
+            {
+                name: 'User',
+                fields: [
+                    { name: 'id', kind: 'scalar', type: 'Int', isList: false, isRequired: true },
+                    { name: 'name', kind: 'scalar', type: 'String', isList: false, isRequired: true },
+                    { name: 'email', kind: 'scalar', type: 'String', isList: false, isRequired: true },
+                    { name: 'age', kind: 'scalar', type: 'Int', isList: false, isRequired: true },
+                    { name: 'realm', kind: 'object', type: 'Realm', isList: false, isRequired: true },
+                ],
+            },
+            {
+                name: 'Realm',
+                fields: [
+                    { name: 'id', kind: 'scalar', type: 'String', isList: false, isRequired: true },
+                    { name: 'name', kind: 'scalar', type: 'String', isList: false, isRequired: true },
+                ],
+            },
+        ],
+    }, 'User'),
 });
 
 export async function getUsers(req: Request, res: Response) {

--- a/packages/docs/guide/recipes/testing-memory.md
+++ b/packages/docs/guide/recipes/testing-memory.md
@@ -1,0 +1,128 @@
+# Testing with the Memory Adapter
+
+*Chapter 6 of the [recipes storyline](/guide/recipes/): the same contract as [the search endpoint](/guide/recipes/mongo-search) and its predecessors, executed without a database. Next: the cross-cutting [Authorization & Scoping](/guide/recipes/authorization).*
+
+Everything the previous chapters promised (allow-lists, defaults, the pagination envelope) lives in the schema and the parse pipeline, not in the database. [`@rapiq/adapter-memory`](/packages/adapter-memory) compiles a parsed `Query` into plain functions and applies it to arrays, with the same operator semantics the SQL backends render. That makes the whole contract testable in a unit test: decode real wire input through the real codec and registry, run it against fixtures, assert on the result. No engine, no Docker, no mocks.
+
+## Fixtures
+
+Plain objects standing in for the rows the endpoint would load; embedded `realm` objects stand in for the join:
+
+```typescript
+// test/fixtures.ts
+import type { User } from '../src/entities';
+
+export const users: User[] = [
+    { id: 1, name: 'Ada', email: 'ada@example.com', age: 34, realm: { id: 'a', name: 'Alpha' } },
+    { id: 2, name: 'Ben', email: 'ben@example.com', age: 17, realm: { id: 'a', name: 'Alpha' } },
+    { id: 3, name: 'Cleo', email: 'cleo@example.com', age: 28, realm: { id: 'b', name: 'Beta' } },
+];
+```
+
+## Contract tests
+
+`applyQuery(query, data)` filters, sorts, paginates and projects in one call and returns `{ data, total, pagination }`; `total` counts the matches *before* pagination, exactly what chapter 3's `meta` block reports. The decode step is the endpoint's own, so these tests pin the contract, not the implementation:
+
+```typescript
+// test/users.spec.ts
+import { describe, expect, it } from 'vitest';
+import { FiltersParseError } from '@rapiq/core';
+import { applyQuery } from '@rapiq/adapter-memory';
+import { codec } from '../src/codec';
+import { users } from './fixtures';
+
+const decode = (input: string) => {
+    const query = codec.decode(input, { schema: 'user' });
+    if (!query) {
+        throw new Error('invalid query input');
+    }
+
+    return query;
+};
+
+describe('GET /users contract', () => {
+    it('applies the schema defaults', () => {
+        const { data, total, pagination } = applyQuery(decode(''), users);
+
+        expect(total).toBe(3);
+        expect(pagination).toEqual({ limit: 50, offset: 0 });    // maxLimit doubles as the default
+        expect(data[0]).toEqual({ id: 3, name: 'Cleo' });        // default fields, sorted -id
+    });
+
+    it('filters, sorts and pages', () => {
+        const { data, total, pagination } = applyQuery(
+            decode("filter=gte(age,'18')&sort=-age&page[limit]=1&page[offset]=1"),
+            users,
+        );
+
+        expect(total).toBe(2);                                   // matches before pagination
+        expect(pagination).toEqual({ limit: 1, offset: 1 });
+        expect(data).toEqual([{ id: 3, name: 'Cleo' }]);
+    });
+
+    it('narrows an included relation to its fieldset', () => {
+        const { data } = applyQuery(decode('include=realm&fields[realm]=name'), users);
+
+        expect(data[0]).toEqual({ id: 3, name: 'Cleo', realm: { name: 'Beta' } });
+    });
+
+    it('rejects keys outside the contract', () => {
+        // the endpoint's 400 branch: throwOnFailure turns this into a typed throw
+        expect(() => decode('filter[secret]=x')).toThrow(FiltersParseError);
+    });
+});
+```
+
+Chapter 5's search endpoint tests the same way; only the parse step differs:
+
+```typescript
+import { MongoParser } from '@rapiq/parser-mongo';
+import { registry } from '../src/schema';
+
+const parser = new MongoParser(registry);
+
+it('parses a search document against the same contract', () => {
+    const query = parser.parse({
+        filters: { $or: [{ name: { $contains: 'ad' } }, { age: { $gte: 30 } }] },
+    }, { schema: 'user' });
+
+    expect(applyQuery(query, users).data).toEqual([{ id: 1, name: 'Ada' }]);
+});
+```
+
+## Guarding single records
+
+Filters compile to standalone predicates, so a condition can be asserted against one object; the [authorization chapter](/guide/recipes/authorization) builds its ability guards on exactly this:
+
+```typescript
+import { and, eq, gte } from '@rapiq/core';
+import { compileFilters, compileQuery } from '@rapiq/adapter-memory';
+
+// an ability, as data: "may edit adult users of realm a"
+const canEditAdults = and(eq('realm.id', 'a'), gte('age', 18));
+
+const guard = compileFilters(canEditAdults);
+guard(users[0]);    // true
+guard(users[1]);    // false: age 17
+
+// whole-query form: would this record be selected by the client's query?
+const compiled = compileQuery<User>(decode("filter=gte(age,'18')"));
+compiled.matches(users[0]);    // true
+compiled.matches(users[1]);    // false
+```
+
+`compileFilters` accepts any condition node (a leaf, a compound tree, a schema's `filters.default`), and compiling once amortizes the cost across many records.
+
+## Why this is a faithful double
+
+The memory adapter aims for [**SQL parity**](/packages/adapter-memory#filter-semantics): null and absent values behave like the single SQL `NULL` (positive operators never match them, negated operators are exact complements), string matching is [case-insensitive by default](/guide/filters#case-sensitivity), and dotted paths over arrays use the same-element join-row binding a SQL join produces. A test that passes here asserts the semantics the database query will have, not a mock's opinion of them.
+
+Two caveats keep it honest:
+
+- It is a *semantics* double, not a database. `relations` neither loads nor prunes anything; fixtures must already carry what the endpoint would join (the embedded `realm` above). Per-backend edge cases are listed in the [divergences table](/packages/adapter-memory#divergences).
+- Memory evaluates the full operator set, while the Prisma and Drizzle serializers refuse `regex`, `mod` and `size` with a typed error. A test suite for those backends should not rely on operators the production adapter rejects.
+
+## Next steps
+
+- [Authorization & Scoping](/guide/recipes/authorization): the same compiled predicates as permission guards, plus decode-time gating.
+- [@rapiq/adapter-memory](/packages/adapter-memory): the full semantics contract (null handling, case rules, `elemMatch` scopes, projection).

--- a/packages/docs/guide/relations.md
+++ b/packages/docs/guide/relations.md
@@ -74,8 +74,10 @@ defineSchema<User, Actor>({
     name: 'user',
     relations: {
         allowed: ['realm', 'items'],
-        // may THIS actor include THIS relation?
-        validate: (relation, actor) => actor.permissions.includes(`${relation}_read`),
+        // may THIS actor include THIS relation? A missing context
+        // must be rejected explicitly: it does not fail closed on
+        // its own.
+        validate: (relation, actor) => !!actor && actor.permissions.includes(`${relation}_read`),
     },
     schemaMapping: { items: 'item' },
 });

--- a/packages/docs/guide/relations.md
+++ b/packages/docs/guide/relations.md
@@ -1,12 +1,12 @@
 # Relations
 
-Load related resources alongside the primary one — and unlock their fields for [selection](/guide/fields), [filtering](/guide/filters) and [sorting](/guide/sort).
+Load related resources alongside the primary one, and unlock their fields for [selection](/guide/fields), [filtering](/guide/filters) and [sorting](/guide/sort).
 
 | | |
 |---|---|
 | URL key | `include` |
 | AST nodes | `Relations` / `Relation { name }` |
-| Schema options | `allowed`, `mapping` |
+| Schema options | `allowed`, `mapping`, `validate` / `validateMany` |
 
 ## On the wire
 
@@ -23,7 +23,7 @@ Parser input shapes:
 { relations: ['items.realm'] }      // nested paths
 ```
 
-Nested paths automatically include their parents — requesting `items.realm` also includes `items`.
+Nested paths automatically include their parents: requesting `items.realm` also includes `items`.
 
 ## Building in code
 
@@ -38,9 +38,9 @@ defineRelations<User>(['realm']);   // standalone fragment
 
 ## Validation
 
-Each requested relation is checked against the schema's `allowed` list. Nested paths resolve segment by segment through [`schemaMapping`](/guide/schemas#the-registry--relations): for `items.realm`, the `items` segment must be allowed on the root schema and `realm` on the schema registered for `items`.
+Each requested relation is checked against the schema's `allowed` list. Nested paths resolve segment by segment through [`schemaMapping`](/guide/schemas#the-registry-relations): for `items.realm`, the `items` segment must be allowed on the root schema and `realm` on the schema registered for `items`.
 
-Relation names must match `[a-zA-Z0-9_-]` segments separated by dots — anything else is dropped (or throws with `throwOnFailure`).
+Relation names must match `[a-zA-Z0-9_-]` segments separated by dots; anything else is dropped (or throws with `throwOnFailure`).
 
 ## Schema options
 
@@ -61,10 +61,38 @@ defineSchema<User>({
 |---|---|
 | `allowed` | Traversable relation names. Omit to allow all; `[]` blocks the parameter. |
 | `mapping` | Alias → relation translation applied before validation. |
+| `validate` / `validateMany` | Per-request [key hooks](/guide/schemas#validate-hooks-parse-context): may this actor traverse this relation? See below. |
+
+## Validate hooks
+
+Allow-lists are static; `validate` / `validateMany` decide **per request**. Every parse/decode call may carry a context (typically the authenticated actor), and the hook answers for each requested relation with that context in hand. The general contract (verdicts, the scope argument, batching, sync/async) lives at [Validate hooks and parse context](/guide/schemas#validate-hooks-parse-context).
+
+```typescript
+type Actor = { permissions: string[] };
+
+defineSchema<User, Actor>({
+    name: 'user',
+    relations: {
+        allowed: ['realm', 'items'],
+        // may THIS actor include THIS relation?
+        validate: (relation, actor) => actor.permissions.includes(`${relation}_read`),
+    },
+    schemaMapping: { items: 'item' },
+});
+
+const query = parser.parse(input, { schema: 'user', context: actor });
+```
+
+The hook runs on the canonical (alias-mapped) relation name against the schema that governs it: `include=items.realm` invokes the *user* schema's hook with `items` and the *item* schema's hook with `realm`. A relation is not a column, so an `ICondition` verdict has nothing to gate and counts as a rejection.
+
+Two rules make the gate hard to bypass:
+
+- **Traversal counts.** The hook also gates relations reached through dotted [filter](/guide/filters), [field](/guide/fields) and [sort](/guide/sort) keys (`filter[items.id]`, `fields[items]`, `sort=items.name`), which the backends would otherwise auto-join. It runs **once per distinct relation** across the whole query, so a join has a single authorization point regardless of which parameter forced it.
+- **Rejection prunes deep.** Rejecting a relation drops every deeper relation reached through it and every dependent key in every parameter, at parse time; the pruned branch never enters the AST. Under [`throwOnFailure`](/guide/schemas#failure-behavior-drop-vs-throw) the rejection throws a `RelationsParseError` (`ErrorCode.KEY_VALIDATE_REJECTED`) instead.
 
 ## Interaction with other parameters
 
-Parsed relations feed back into the other parameter parsers: fields, filters and sort input that addresses a relation (`items.id`, `realm.name`) is only accepted when the relation was requested and allowed. Request the relation first, then reference its fields.
+Parsed relations feed back into the other parameter parsers: fields, filters and sort input that addresses a relation (`items.id`, `realm.name`) is only accepted when the relation was requested and allowed. Request the relation first, then reference its fields. A [validate hook](#validate-hooks) participates in the same wiring: it also authorizes the relations those keys traverse.
 
 ## On violation
 

--- a/packages/docs/guide/schemas.md
+++ b/packages/docs/guide/schemas.md
@@ -270,11 +270,11 @@ A gate is server-side state and has no wire form, so a query carrying one cannot
 - **Rejection follows the failure policy.** Dropped by default, thrown (`ErrorCode.KEY_VALIDATE_REJECTED`) under [`throwOnFailure`](#failure-behavior-drop-vs-throw), naming the full client-facing path. A rejected relation also drops every deeper relation reached through it. A relation's authorization always follows the `relations` sub-schema's own policy, even when the relation was reached through a `filters`/`fields`/`sort` key.
 - **Client input only.** Schema `default`s are server-authored and bypass the hooks. For `sort`, a hook that empties the selection leaves it empty (no ORDER BY). For `fields`, an empty selection would be read by every backend as *project everything*, so a hook that empties it falls back to the input-less projection (defaults, or the allow-list expansion) **minus the rejected names**: a denial never resurrects, and it never widens the projection either. A schema that uses a deny-capable fields hook should declare `fields.default` so the fallback has something safe to land on.
 - **Sync/async mirrors the filters validator.** A hook returning a Promise requires the `parseAsync()`/`decodeAsync()` entry points; the sync paths refuse it with `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER`.
-- **The context is opaque**: typed at the definition site via `defineSchema<RECORD, CONTEXT>` (and `SchemaRegistry<CONTEXT>`), forwarded verbatim from the parse options. Hooks receive `undefined` when the caller supplies none, so permission hooks fail closed by construction.
+- **The context is opaque**: typed at the definition site via `defineSchema<RECORD, CONTEXT>` (and `SchemaRegistry<CONTEXT>`), forwarded verbatim from the parse options. Hooks receive `undefined` when the caller supplies none; there is no automatic fail-closed behavior, so a permission hook must guard the context itself and return `false` when it is missing rather than assume an actor is present.
 
 The [filters `validate` hook](/guide/filters#schema-options) participates too: it receives the same context as its second argument. It has its own signature (it inspects, replaces or rejects a parsed `Filter`) and is not part of the key-validation hook pair described above.
 
-## The registry & relations
+## The registry & relations {#the-registry-relations}
 
 The `SchemaRegistry` stores schemas by name and resolves relation paths through `schemaMapping`:
 

--- a/packages/docs/guide/schemas.md
+++ b/packages/docs/guide/schemas.md
@@ -42,7 +42,7 @@ const userSchema = defineSchema<User>({
 });
 ```
 
-Field keys are typed against `RECORD` via recursive key paths — `allowed` and `default` autocomplete and type-check. `null`/`undefined` are unwrapped before traversal, so nullable or optional relations (`realm: Realm | null`) type-check like their non-nullable counterparts. Index-signature records (JSON columns such as `data: Record<string, any>`) count as selectable/filterable leaf keys and are not traversed as nested branches.
+Field keys are typed against `RECORD` via recursive key paths: `allowed` and `default` autocomplete and type-check. `null`/`undefined` are unwrapped before traversal, so nullable or optional relations (`realm: Realm | null`) type-check like their non-nullable counterparts. Index-signature records (JSON columns such as `data: Record<string, any>`) count as selectable/filterable leaf keys and are not traversed as nested branches.
 
 ## Top-level options
 
@@ -59,32 +59,32 @@ Every sub-schema also accepts its own `throwOnFailure` and `strict`.
 
 | Parameter | Options |
 |---|---|
-| `fields` | `allowed`, `default`, `mapping` (alias → field), `validate` / `validateMany` ([per-key hooks](#validate-hooks--parse-context)) |
+| `fields` | `allowed`, `default`, `mapping` (alias to field), `validate` / `validateMany` ([per-key hooks](#validate-hooks-parse-context)) |
 | `filters` | `allowed`, `default` (a default condition), `mapping`, `validate` (per-filter validation hook), `caseSensitive` ([exact-equality opt-out](/guide/filters#case-sensitivity)) |
-| `relations` | `allowed`, `mapping`, `validate` / `validateMany` ([per-key hooks](#validate-hooks--parse-context)) |
-| `sort` | `allowed` (flat list, or list of lists to enforce exact multi-key combinations), `default`, `mapping`, `validate` / `validateMany` ([per-key hooks](#validate-hooks--parse-context)) |
+| `relations` | `allowed`, `mapping`, `validate` / `validateMany` ([per-key hooks](#validate-hooks-parse-context)) |
+| `sort` | `allowed` (flat list, or list of lists to enforce exact multi-key combinations), `default`, `mapping`, `validate` / `validateMany` ([per-key hooks](#validate-hooks-parse-context)) |
 | `pagination` | `maxLimit` |
 
-Standalone factories exist for each parameter — `defineFieldsSchema`, `defineFiltersSchema`, `defineRelationsSchema`, `defineSortSchema`, `definePaginationSchema` — useful when calling a single parameter parser directly.
+Standalone factories exist for each parameter (`defineFieldsSchema`, `defineFiltersSchema`, `defineRelationsSchema`, `defineSortSchema`, `definePaginationSchema`), useful when calling a single parameter parser directly.
 
 ::: tip Empty vs. absent
-`allowed: []` blocks the parameter entirely; **omitting** `allowed` permits everything — unless [strict mode](#strict-mode) is on. Be deliberate about which one you mean.
+`allowed: []` blocks the parameter entirely; **omitting** `allowed` permits everything, unless [strict mode](#strict-mode) is on. Be deliberate about which one you mean.
 :::
 
 ## Defaults
 
 Defaults fill the gaps when a client sends nothing (or nothing valid) for a parameter:
 
-- `fields.default` — the selection when no fields are requested; `+`/`-` modifiers in client input extend/shrink it instead of replacing it.
-- `filters.default` — a condition applied when the client sends no filters.
-- `sort.default` — the order applied when nothing valid was requested.
-- `pagination.maxLimit` — doubles as the applied limit when the client requests none.
+- `fields.default`: the selection when no fields are requested; `+`/`-` modifiers in client input extend/shrink it instead of replacing it.
+- `filters.default`: a condition applied when the client sends no filters.
+- `sort.default`: the order applied when nothing valid was requested.
+- `pagination.maxLimit`: doubles as the applied limit when the client requests none.
 
-A parameter absent from the input is still parsed, so defaults always apply — even when the client sends nothing at all.
+A parameter absent from the input is still parsed, so defaults always apply, even when the client sends nothing at all.
 
 ## Strict mode
 
-By default, a parameter whose schema declares no allow-list is **open**: any syntactically valid key passes. `strict: true` inverts that — a parameter accepts client input only for explicitly declared keys:
+By default, a parameter whose schema declares no allow-list is **open**: any syntactically valid key passes. `strict: true` inverts that: a parameter accepts client input only for explicitly declared keys:
 
 ```typescript
 const userSchema = defineSchema<User>({
@@ -103,21 +103,21 @@ Per parameter, "declared" means:
 | `filters` | `allowed` is set (a `default` condition alone still applies, but clients cannot filter) |
 | `sort` | `allowed` or `default` is set (the allow-list derives from the default's keys) |
 | `relations` | `allowed` is set |
-| `pagination` | always — `maxLimit` remains the only constraint |
+| `pagination` | always; `maxLimit` remains the only constraint |
 
 Schema defaults are unaffected: dropped client input falls back to `default` values exactly as if the parameter had been absent.
 
-`strict` can also be set per parse call, overriding the schema setting — including parsing **without** a schema, which then rejects every client-driven parameter:
+`strict` can also be set per parse call, overriding the schema setting, including parsing **without** a schema, which then rejects every client-driven parameter:
 
 ```typescript
 parser.parse(input, { schema: 'user', strict: true });
 ```
 
 ::: warning Migrating from typeorm-extension?
-typeorm-extension **disables** any parameter whose `allowed`/`default` options are missing. rapiq's default is the opposite (open). Enable `strict: true` to keep closed-by-default semantics — see the [migration guide](/guide/migration-typeorm-extension).
+typeorm-extension **disables** any parameter whose `allowed`/`default` options are missing. rapiq's default is the opposite (open). Enable `strict: true` to keep closed-by-default semantics; see the [migration guide](/guide/migration-typeorm-extension).
 :::
 
-## Validate hooks & parse context
+## Validate hooks and parse context {#validate-hooks-parse-context}
 
 Allow-lists are static, decided when the schema is defined. The `validate` hooks decide **per request**: every parse/decode call may carry an opaque `context` (typically the authenticated actor), and the `relations`, `fields` and `sort` sub-schemas may declare a hook that answers for each client-requested key with that context in hand:
 
@@ -241,9 +241,10 @@ Where the gate is actually applied depends on the backend:
 |---|---|
 | [`@rapiq/adapter-memory`](/packages/adapter-memory) | Honours `Field.condition` **while projecting**: the property is dropped from records that don't satisfy it. |
 | [`@rapiq/adapter-sql`](/packages/adapter-sql), [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) | Project the column **unconditionally**. A selection has to stay a bare `alias.property` for entity hydration, so the gate cannot be pushed into the statement; it is applied **after the fetch**. |
+| [`@rapiq/adapter-prisma`](/packages/adapter-prisma), [`@rapiq/adapter-drizzle`](/packages/adapter-drizzle) | Serialize plain argument objects, which cannot gate a value either; the gate is applied **after the fetch**. `PrismaAdapter.findMany()` refuses a gated query with a typed error instead of returning unredacted rows. |
 
-::: danger The SQL backends fail open
-On `@rapiq/adapter-sql` / `@rapiq/adapter-typeorm` the gated column is fetched for every row. Nothing is enforced until you apply the gate to the result; skip that step and the value ships to the client. Run the fetched rows through the post-fetch helper before serializing them:
+::: danger The database backends fail open
+On `@rapiq/adapter-sql` / `@rapiq/adapter-typeorm` (and on the prisma/drizzle serializers via `execute()`) the gated column is fetched for every row. Nothing is enforced until you apply the gate to the result; skip that step and the value ships to the client. Run the fetched rows through the post-fetch helper before serializing them:
 
 ```typescript
 import { hasFieldConditions } from '@rapiq/core';
@@ -253,7 +254,7 @@ const rows = await queryBuilder.getMany();
 const guarded = applyFieldConditions(query.fields, rows);
 ```
 
-`hasFieldConditions(query)` reports whether a decoded query carries any gate, so a response path can assert that no gated column ships unredacted. The SQL adapters and `@rapiq/adapter-prisma` force-project every column a gate reads, so the post-fetch pass always has its operands even under a sparse fieldset or a fieldset-narrowed include.
+`hasFieldConditions(query)` reports whether a decoded query carries any gate, so a response path can assert that no gated column ships unredacted. The SQL adapters and the prisma/drizzle serializers force-project every column a gate reads, so the post-fetch pass always has its operands even under a sparse fieldset or a fieldset-narrowed include.
 
 For genuinely secret columns on an entity that is also reachable as an include, prefer a condition over a plain `return false`: a boolean denial only removes the field from the *query*, while a fieldset-free include still hydrates the whole record, leaving nothing for the post-fetch pass to act on. A condition keeps the gate attached to the field, so `applyFieldConditions` strips the value per row wherever the row came from.
 :::
@@ -265,11 +266,11 @@ A gate is server-side state and has no wire form, so a query carrying one cannot
 ### Rules that apply to every hook
 
 - **Target-schema authorization.** Hooks run on the canonical (alias-resolved) key against the schema that governs it: `include=items.realm` invokes the *user* schema's hook with `items` and the *item* schema's hook with `realm` (resolved via `schemaMapping`). An include can never bypass the related schema's own gate.
-- **Relations are authorized wherever they are traversed, not only in `include=`.** A dotted `filters` / `fields` / `sort` key resolves through a relation the backends then auto-join (`filter[items.id]`, `fields[items]`, `sort=items.name`), so the `relations` hook runs for every relation *any* parameter reaches — evaluated **once per distinct relation** across the whole query (deduped with the include-driven checks). Rejecting the relation prunes every dependent key in every parameter together. There is a single authorization point for a join, regardless of which parameter forced it.
+- **Relations are authorized wherever they are traversed, not only in `include=`.** A dotted `filters` / `fields` / `sort` key resolves through a relation the backends then auto-join (`filter[items.id]`, `fields[items]`, `sort=items.name`), so the `relations` hook runs for every relation *any* parameter reaches, evaluated **once per distinct relation** across the whole query (deduped with the include-driven checks). Rejecting the relation prunes every dependent key in every parameter together. There is a single authorization point for a join, regardless of which parameter forced it.
 - **Rejection follows the failure policy.** Dropped by default, thrown (`ErrorCode.KEY_VALIDATE_REJECTED`) under [`throwOnFailure`](#failure-behavior-drop-vs-throw), naming the full client-facing path. A rejected relation also drops every deeper relation reached through it. A relation's authorization always follows the `relations` sub-schema's own policy, even when the relation was reached through a `filters`/`fields`/`sort` key.
 - **Client input only.** Schema `default`s are server-authored and bypass the hooks. For `sort`, a hook that empties the selection leaves it empty (no ORDER BY). For `fields`, an empty selection would be read by every backend as *project everything*, so a hook that empties it falls back to the input-less projection (defaults, or the allow-list expansion) **minus the rejected names**: a denial never resurrects, and it never widens the projection either. A schema that uses a deny-capable fields hook should declare `fields.default` so the fallback has something safe to land on.
 - **Sync/async mirrors the filters validator.** A hook returning a Promise requires the `parseAsync()`/`decodeAsync()` entry points; the sync paths refuse it with `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER`.
-- **The context is opaque** — typed at the definition site via `defineSchema<RECORD, CONTEXT>` (and `SchemaRegistry<CONTEXT>`), forwarded verbatim from the parse options. Hooks receive `undefined` when the caller supplies none, so permission hooks fail closed by construction.
+- **The context is opaque**: typed at the definition site via `defineSchema<RECORD, CONTEXT>` (and `SchemaRegistry<CONTEXT>`), forwarded verbatim from the parse options. Hooks receive `undefined` when the caller supplies none, so permission hooks fail closed by construction.
 
 The [filters `validate` hook](/guide/filters#schema-options) participates too: it receives the same context as its second argument. It has its own signature (it inspects, replaces or rejects a parsed `Filter`) and is not part of the key-validation hook pair described above.
 
@@ -296,12 +297,12 @@ const parser = new SimpleParser(registry);
 const query = parser.parse(input, { schema: 'user' });
 ```
 
-With the mapping above, input like `fields: { realm: ['name'] }` or `filters: { 'realm.name': 'master' }` is validated against the **realm** schema's allow-lists — each relation owner decides what may be requested of it.
+With the mapping above, input like `fields: { realm: ['name'] }` or `filters: { 'realm.name': 'master' }` is validated against the **realm** schema's allow-lists: each relation owner decides what may be requested of it.
 
 ## Describing a schema
 
 `schema.describe()` serializes the declared constraints into a JSON-safe
-`SchemaDescription` — the introspection surface an API can return to its
+`SchemaDescription`: the introspection surface an API can return to its
 consumers (e.g. under a response `meta` key), so the queryable vocabulary
 is discoverable without reading server code:
 
@@ -310,48 +311,48 @@ userSchema.describe();
 // {
 //     name: 'user',
 //     strict: false,
-//     fields: { default: ['id', 'name'], allowed: ['email'] },
-//     filters: { allowed: ['id', 'name'] },
+//     fields: { default: ['id', 'name'], allowed: ['id', 'name', 'email', 'age'] },
+//     filters: { allowed: ['id', 'name', 'age'] },
 //     pagination: { maxLimit: 50 },
 //     relations: {
 //         allowed: ['realm', 'items'],
 //         schemas: { realm: 'realm', items: 'item' },
 //     },
-//     sort: { allowed: ['id', 'name'], default: null },
+//     sort: { allowed: ['id', 'name', 'age'], default: { id: 'DESC' } },
 // }
 ```
 
-The shape is **normalized** — every schema describes identically, so
+The shape is **normalized**: every schema describes identically, so
 consumers can rely on a stable structure:
 
-- a parameter key is present iff the description covers that parameter —
+- a parameter key is present iff the description covers that parameter;
   pass `parameters` to mirror a surface that only processes some of them
   (e.g. a single-record read handling `fields` and `relations` only):
   `schema.describe({ parameters: [Parameter.FIELDS, Parameter.RELATIONS] })`.
   A covered parameter always carries every constraint key;
 - within a parameter, a **`null`** constraint was never declared, so the
   fallback semantics apply (syntactic property-name check, or a full
-  reject under [strict mode](#strict-mode) — `strict` is normalized to
+  reject under [strict mode](#strict-mode); `strict` is normalized to
   its effective default, `false`);
 - an **empty array** is an explicit "nothing allowed".
 
 Relation capabilities are not expanded inline: `relations.schemas` names
 the schema governing each relation (via `schemaMapping`; an unmapped
-relation maps to itself, mirroring registry resolution) — nested
+relation maps to itself, mirroring registry resolution); nested
 vocabulary is looked up on that schema's own description.
 
 Deliberately absent from the output: the filters `default` condition (a
 server-injected baseline, not client vocabulary) and the dynamic
-`validate`/`validateMany` hooks (e.g. per-actor authorization gates) —
+`validate`/`validateMany` hooks (e.g. per-actor authorization gates);
 the description is the **static upper bound** of what a client may send,
 not a per-request effective view. Arrays are cloned, so mutating a
 description never touches the schema.
 
 ## Failure behavior: drop vs. throw
 
-By default, parsers **drop** what the schema doesn't allow — the query still parses, minus the offending parts. That is the forgiving mode: old clients sending a removed field keep working.
+By default, parsers **drop** what the schema doesn't allow: the query still parses, minus the offending parts. That is the forgiving mode: old clients sending a removed field keep working.
 
-With `throwOnFailure: true` (top-level or per parameter), parsers **throw** instead — the strict mode for APIs that prefer a `400` over a silently narrowed answer:
+With `throwOnFailure: true` (top-level or per parameter), parsers **throw** instead: the strict mode for APIs that prefer a `400` over a silently narrowed answer:
 
 ```typescript
 import { FiltersParseError } from '@rapiq/core';
@@ -365,10 +366,10 @@ try {
 }
 ```
 
-Each parameter has its own error class — `FieldsParseError`, `FiltersParseError`, `PaginationParseError`, `RelationsParseError`, `SortParseError` — all extending `ParseError`. The codes and an HTTP-mapping guide live in [Error Handling](/guide/errors).
+Each parameter has its own error class (`FieldsParseError`, `FiltersParseError`, `PaginationParseError`, `RelationsParseError`, `SortParseError`), all extending `ParseError`. The codes and an HTTP-mapping guide live in [Error Handling](/guide/errors).
 
 ## Next steps
 
-- [Queries over the Wire](/guide/wire) — where schemas meet incoming requests.
-- [Query Parameters](/guide/fields) — per-parameter schema options in context.
-- [Error Handling](/guide/errors) — the full error hierarchy and codes.
+- [Queries over the Wire](/guide/wire): where schemas meet incoming requests.
+- [Query Parameters](/guide/fields): per-parameter schema options in context.
+- [Error Handling](/guide/errors): the full error hierarchy and codes.

--- a/packages/docs/guide/sort.md
+++ b/packages/docs/guide/sort.md
@@ -6,7 +6,7 @@ Order the collection by one or more keys, ascending or descending.
 |---|---|
 | URL key | `sort` |
 | AST nodes | `Sorts` / `Sort { name, operator: 'ASC' \| 'DESC' }` |
-| Schema options | `allowed`, `default`, `mapping` |
+| Schema options | `allowed`, `default`, `mapping`, `validate` / `validateMany` |
 
 ## On the wire
 
@@ -39,7 +39,7 @@ Keys are checked against the record type.
 
 ## Relation fields
 
-`relation.field` keys (or nested records) sort by a related record's field. The relation must be requested and allowed, and the field validates against the related schema via [`schemaMapping`](/guide/schemas#the-registry--relations).
+`relation.field` keys (or nested records) sort by a related record's field. The relation must be requested and allowed, and the field validates against the related schema via [`schemaMapping`](/guide/schemas#the-registry-relations).
 
 ## Schema options
 
@@ -55,9 +55,16 @@ defineSchema<User>({
 
 | Option | Description |
 |---|---|
-| `allowed` | Sortable field names. A nested list (`[['name', 'age']]`) only permits exactly those multi-key combinations — useful when only certain composite indexes exist. Omit to allow all; `[]` blocks the parameter. |
+| `allowed` | Sortable field names. A nested list (`[['name', 'age']]`) only permits exactly those multi-key combinations, useful when only certain composite indexes exist. Omit to allow all; `[]` blocks the parameter. |
 | `default` | Sort order applied when the client sends nothing valid. |
 | `mapping` | Alias → field translation applied before validation. |
+| `validate` / `validateMany` | Per-request [key hooks](/guide/schemas#validate-hooks-parse-context): accept or reject a sort key per actor. |
+
+## Validate hooks
+
+A `validate` / `validateMany` hook runs once per client-requested sort key, against the schema that governs it (the target schema for dotted keys such as `items.id`) and after tuple-group matching. Schema `default`s are server-authored and bypass the hook. The general contract (verdicts, the scope argument, batching, sync/async) lives at [Validate hooks and parse context](/guide/schemas#validate-hooks-parse-context).
+
+An ordering is not a row set, so there is nothing for an `ICondition` verdict to gate: a condition answer counts as a rejection for sort (only `fields` hooks may gate with a condition).
 
 ## On violation
 

--- a/packages/docs/guide/wire.md
+++ b/packages/docs/guide/wire.md
@@ -14,7 +14,7 @@ const queryString = codec.encode(query);
 await fetch(`/users?${queryString}`);
 ```
 
-New payloads use the expression filter dialect and carry `codec=url-expression`. Pass `{ stamp: false }` to omit the reserved stamp for receivers outside rapiq (e.g. strict JSON:API endpoints) — untagged output is still recognized structurally on decode. The remaining URL parameters use JSON:API-style names:
+New payloads use the expression filter dialect and carry `codec=url-expression`. Pass `{ stamp: false }` to omit the reserved stamp for receivers outside rapiq (e.g. strict JSON:API endpoints); untagged output is still recognized structurally on decode. The remaining URL parameters use JSON:API-style names:
 
 | Parameter | URL key | Example |
 |---|---|---|
@@ -52,7 +52,7 @@ If your input already uses canonical parameter keys (`filters`, `pagination`, �
 
 ### Decoding a subset of parameters
 
-Sometimes only part of a query should apply — a bulk delete, for example, must honor the request's filters but never its pagination. Pass `parameters` to decode only the listed parameters; everything else stays empty and, importantly, schema defaults such as `pagination.maxLimit` do **not** materialize for masked parameters:
+Sometimes only part of a query should apply: a bulk delete, for example, must honor the request's filters but never its pagination. Pass `parameters` to decode only the listed parameters; everything else stays empty and, importantly, schema defaults such as `pagination.maxLimit` do **not** materialize for masked parameters:
 
 ```typescript
 app.delete('/sessions', (req, res) => {
@@ -60,7 +60,7 @@ app.delete('/sessions', (req, res) => {
         schema: 'session',
         parameters: ['filters'],
     });
-    // query.pagination is empty — the schema's maxLimit cannot
+    // query.pagination is empty: the schema's maxLimit cannot
     // silently truncate the delete's row selection.
 });
 ```
@@ -71,7 +71,7 @@ The v2 codec follows a read-both/write-expression migration:
 
 1. A stamped payload dispatches to its named dialect.
 2. An unstamped non-empty string `filter` is parsed as an expression.
-3. Any other unstamped defined `filter` — bracket/object input, or an empty `filter=` — is parsed as legacy simple input.
+3. Any other unstamped defined `filter` (bracket/object input, or an empty `filter=`) is parsed as legacy simple input.
 4. An unknown stamped codec throws `CodecError` with `CODEC_UNRESOLVABLE`.
 
 This lets receiving applications upgrade before callers. Existing URLs such as `filter[age]=>=18` continue to decode, while upgraded callers begin producing expressions.
@@ -119,5 +119,5 @@ When validators are asynchronous, use `await codec.encodeAsync(...)` and `await 
 
 ## Next steps
 
-- [Executing Queries](/guide/executing-queries) — what the receiver does with the decoded query.
-- [@rapiq/codec-url](/packages/codec-url) — complete dialect, migration and extension reference.
+- [Executing Queries](/guide/executing-queries): what the receiver does with the decoded query.
+- [@rapiq/codec-url](/packages/codec-url): complete dialect, migration and extension reference.

--- a/packages/docs/index.md
+++ b/packages/docs/index.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: rapiq
-description: One query language between client & server — JSON:API-style queries, a typed AST, schema allow-lists and composable SQL/TypeORM adapters.
+description: 'One query language between client & server: JSON:API-style queries, a typed AST, schema allow-lists and composable adapters for SQL, TypeORM, Prisma, Drizzle and in-memory data.'
 ---
 
 <script setup>

--- a/packages/docs/integrations/url.md
+++ b/packages/docs/integrations/url.md
@@ -1,6 +1,13 @@
+---
+head:
+  - - meta
+    - http-equiv: refresh
+      content: '0; url=/packages/codec-url'
+---
+
 # Moved
 
 The URL integration now lives in one package and one reference page:
 
-- [@rapiq/codec-url](/packages/codec-url) — encoding, decoding, migration dispatch and both filter dialects
-- [Queries over the Wire](/guide/wire) — narrative usage guide
+- [@rapiq/codec-url](/packages/codec-url): encoding, decoding, migration dispatch and both filter dialects
+- [Queries over the Wire](/guide/wire): narrative usage guide

--- a/packages/docs/packages/adapter-drizzle.md
+++ b/packages/docs/packages/adapter-drizzle.md
@@ -160,6 +160,19 @@ defineSchema<User>({
 });
 ```
 
+The declaration is not consumed automatically: the receiving side forwards it to the adapter, mirroring the [shared contract](/guide/filters#case-sensitivity). The adapter takes `caseSensitive` as a top-level constructor option (a field list, or `true` to opt every field out), and `execute` accepts it as a per-call override:
+
+```typescript
+const adapter = new DrizzleAdapter({
+    provider: 'pg',
+    metadata,
+    caseSensitive: schema.filters.caseSensitive,
+});
+
+// per call, overriding the constructor value:
+adapter.execute(query, { caseSensitive: true });
+```
+
 ## Limitations
 
 Operators without a drizzle filter equivalent raise a typed `AdapterError` (`FEATURE_UNSUPPORTED`) instead of being approximated:

--- a/packages/docs/packages/adapter-memory.md
+++ b/packages/docs/packages/adapter-memory.md
@@ -82,7 +82,7 @@ applyQuery(query, users, { caseSensitive: ['id'] });
 compileFilters(eq('id', 'aBc'), { caseSensitive: ['id'] });
 ```
 
-`caseSensitive: true` keeps **every** equality comparison exact (byte-exact strings): for evaluating arbitrary condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies:
+`caseSensitive: true` keeps **every** equality comparison exact (plain string equality, no case folding): for evaluating arbitrary condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies:
 
 ```typescript
 compileFilters(condition, { caseSensitive: true });

--- a/packages/docs/packages/adapter-memory.md
+++ b/packages/docs/packages/adapter-memory.md
@@ -1,6 +1,6 @@
 # @rapiq/adapter-memory
 
-Evaluates a parsed [`Query`](/guide/query-ast) against **in-memory data** — plain JavaScript objects and arrays. It is the in-memory sibling of the [SQL](/packages/adapter-sql) and [TypeORM](/packages/adapter-typeorm) adapters: the same visitor-pattern surface, but instead of SQL fragments or a mutated query builder, the visitors compile the AST into plain functions.
+Evaluates a parsed [`Query`](/guide/query-ast) against **in-memory data**: plain JavaScript objects and arrays. It is the in-memory sibling of the [SQL](/packages/adapter-sql) and [TypeORM](/packages/adapter-typeorm) adapters: the same visitor-pattern surface, but instead of SQL fragments or a mutated query builder, the visitors compile the AST into plain functions.
 
 ```sh
 npm install @rapiq/core @rapiq/adapter-memory
@@ -18,9 +18,9 @@ import { applyQuery } from '@rapiq/adapter-memory';
 const { data, total, pagination } = applyQuery(query, users);
 ```
 
-- `data` — filtered → sorted → paginated → projected records.
-- `total` — the number of matches *before* pagination (for the response `meta` block, mirroring the TypeORM adapter's pagination echo).
-- `pagination` — the applied `{ limit, offset }`.
+- `data`: filtered → sorted → paginated → projected records.
+- `total`: the number of matches *before* pagination (for the response `meta` block, mirroring the TypeORM adapter's pagination echo).
+- `pagination`: the applied `{ limit, offset }`.
 
 Or compile once and reuse:
 
@@ -54,9 +54,9 @@ const projector = compileFields(query.fields);      // (input) => projected
 const slicer = compilePagination(query.pagination); // (data) => page
 ```
 
-Under the hood each `compile*` helper wraps a visitor class (`FiltersVisitor`, `SortsVisitor`, `FieldsVisitor`, `PaginationVisitor`, `QueryVisitor`) — subclass those for custom behavior. Compilation validates the AST (unknown operators throw); the compiled functions themselves never throw.
+Under the hood each `compile*` helper wraps a visitor class (`FiltersVisitor`, `SortsVisitor`, `FieldsVisitor`, `PaginationVisitor`, `QueryVisitor`); subclass those for custom behavior. Compilation validates the AST (unknown operators throw); the compiled functions themselves never throw.
 
-`compileFilters` accepts any condition node — a leaf `IFilter`, a compound `IFilters`, or the `ICondition` interface both implement. Conditions held abstractly (builder output, a schema's `filters.default`, a lowered authorization residual) pass straight through, no narrowing cast required.
+`compileFilters` accepts any condition node: a leaf `IFilter`, a compound `IFilters`, or the `ICondition` interface both implement. Conditions held abstractly (builder output, a schema's `filters.default`, a lowered authorization residual) pass straight through, no narrowing cast required.
 
 ## Filter semantics
 
@@ -66,14 +66,14 @@ The package aims for **SQL parity**: the same query should select the same recor
 
 `undefined`, missing properties and `null` are one absent value (SQL has a single `NULL`).
 
-- Positive operators (`eq`, `lt`, `lte`, `gt`, `gte`, `in`, `mod`, `size`, `contains`, `startsWith`, `endsWith`, `regex`) never match absent values — except `eq(field, null)`, `in` with a `null` element, and `exists(field, false)`.
+- Positive operators (`eq`, `lt`, `lte`, `gt`, `gte`, `in`, `mod`, `size`, `contains`, `startsWith`, `endsWith`, `regex`) never match absent values, except `eq(field, null)`, `in` with a `null` element, and `exists(field, false)`.
 - **Negated operators are exact complements**: `ne`, `nin`, `notContains`, `notStartsWith` and `notEndsWith` *do* match absent values. `ne('name', 'Peter')` matches a record without a name.
 - `exists` means *has a non-null value* (SQL `IS NOT NULL`), not Mongo's "property present".
-- Type mismatches evaluate to `false` — never to an error.
+- Type mismatches evaluate to `false`, never to an error.
 
 ### String matching
 
-`contains`, `startsWith`, `endsWith` (and their negations) are **case-insensitive** and treat the filter value as a literal — the same anchored regular expression the SQL adapter builds. Numbers are matched by their decimal string form; other value types never match.
+`contains`, `startsWith`, `endsWith` (and their negations) are **case-insensitive** and treat the filter value as a literal: the same anchored regular expression the SQL adapter builds. Numbers are matched by their decimal string form; other value types never match.
 
 String **equality** (`eq` / `ne` / `in` / `nin`) is [case-insensitive by default](/guide/filters#case-sensitivity) too. Opt fields out via the `caseSensitive` option, mirroring a schema's `filters.caseSensitive` list:
 
@@ -82,16 +82,16 @@ applyQuery(query, users, { caseSensitive: ['id'] });
 compileFilters(eq('id', 'aBc'), { caseSensitive: ['id'] });
 ```
 
-`caseSensitive: true` keeps **every** equality comparison exact (byte-exact strings) — for evaluating arbitrary condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies:
+`caseSensitive: true` keeps **every** equality comparison exact (byte-exact strings): for evaluating arbitrary condition trees whose field keys aren't known upfront, e.g. caller-supplied authorization policies:
 
 ```typescript
 compileFilters(condition, { caseSensitive: true });
 ```
 
-The boolean only governs the equality family — `contains`/`startsWith`/`endsWith` stay case-insensitive, exactly like the list form. `caseSensitive: false` equals the default.
+The boolean only governs the equality family: `contains`/`startsWith`/`endsWith` stay case-insensitive, exactly like the list form. `caseSensitive: false` equals the default.
 
 ::: warning Regex patterns run as-is
-The `regex` operator compiles the query's pattern with JavaScript's backtracking `RegExp` engine and evaluates it against every record — a crafted pattern (nested quantifiers) over long field values can burn CPU (ReDoS). Compilation only rejects invalid syntax. The URL dialects cannot carry a regex, but the [mongo dialect](/packages/parser-mongo) accepts `$regex` — when queries originate from untrusted input, gate the operator with the schema's `filters.validate` hook. See the [regex trust model](/guide/filters#regex-trust-model).
+The `regex` operator compiles the query's pattern with JavaScript's backtracking `RegExp` engine and evaluates it against every record: a crafted pattern (nested quantifiers) over long field values can burn CPU (ReDoS). Compilation only rejects invalid syntax. The URL dialects cannot carry a regex, but the [mongo dialect](/packages/parser-mongo) accepts `$regex`; when queries originate from untrusted input, gate the operator with the schema's `filters.validate` hook. See the [regex trust model](/guide/filters#regex-trust-model).
 :::
 
 ### Join-row binding
@@ -113,11 +113,11 @@ compileFilters(and(eq('items.id', 1), eq('items.active', true)))(user); // false
 compileFilters(elemMatch('items', and(eq('id', 1), eq('active', true))))(user); // false
 ```
 
-Every `elemMatch` node opens its **own quantifier scope**: its interior conditions share one element, but two `elemMatch` nodes on the same field — or an `elemMatch` beside a dotted condition — bind independently (Mongo `$elemMatch` semantics). Where SQL has no opinion — a *leaf* value that is an array, e.g. `tags: ['a', 'b']` — Mongo element semantics apply: `eq('tags', 'a')` is membership, `in` is intersection.
+Every `elemMatch` node opens its **own quantifier scope**: its interior conditions share one element, but two `elemMatch` nodes on the same field (or an `elemMatch` beside a dotted condition) bind independently (Mongo `$elemMatch` semantics). Where SQL has no opinion (a *leaf* value that is an array, e.g. `tags: ['a', 'b']`), Mongo element semantics apply: `eq('tags', 'a')` is membership, `in` is intersection.
 
 ### ITSELF (element-level conditions)
 
-Inside an `elemMatch` interior, the `ITSELF` marker addresses the array element itself — the shape the mongo parser produces for element-level `$elemMatch` and `$all`:
+Inside an `elemMatch` interior, the `ITSELF` marker addresses the array element itself: the shape the mongo parser produces for element-level `$elemMatch` and `$all`:
 
 ```typescript
 import { ITSELF, elemMatch, gt, eq, and } from '@rapiq/core';
@@ -125,14 +125,14 @@ import { ITSELF, elemMatch, gt, eq, and } from '@rapiq/core';
 // { scores: { $elemMatch: { $gt: 5 } } }
 compileFilters(elemMatch('scores', gt(ITSELF, 5)))({ scores: [3, 7] }); // true
 
-// { tags: { $all: ['a', 'b'] } } — one independent element match per value
+// { tags: { $all: ['a', 'b'] } }: one independent element match per value
 compileFilters(and(
     elemMatch('tags', eq(ITSELF, 'a')),
     elemMatch('tags', eq(ITSELF, 'b')),
 ))({ tags: ['a', 'b'] }); // true
 ```
 
-`ITSELF` conditions only match **real array elements** — a missing field, a scalar, a to-one object or an empty array never matches (no NULL-row fallback, mirroring Mongo's `$elemMatch`). Outside an `elemMatch` interior the marker is a typed error.
+`ITSELF` conditions only match **real array elements**: a missing field, a scalar, a to-one object or an empty array never matches (no NULL-row fallback, mirroring Mongo's `$elemMatch`). Outside an `elemMatch` interior the marker is a typed error.
 
 ### Divergences
 
@@ -146,11 +146,11 @@ compileFilters(and(
 
 ## Fields & relations projection
 
-The data is already in memory, so `relations` never *adds* anything — and it never prunes either (without entity metadata, an embedded value object is indistinguishable from a relation). Projection follows the TypeORM adapter:
+The data is already in memory, so `relations` never *adds* anything, and it never prunes either (without entity metadata, an embedded value object is indistinguishable from a relation). Projection follows the TypeORM adapter:
 
 - No selected fields → **identity**: records pass through untouched (same references).
 - Selected fields → only the picked properties survive; dotted picks (`items.title`) project into nested objects and arrays.
-- `-`-flagged entries are dropped, never subtracted — subtract-from-default is resolved at parse time by the schema.
+- `-`-flagged entries are dropped, never subtracted; subtract-from-default is resolved at parse time by the schema.
 - An **included relation without direct picks keeps its whole subtree** alongside a sparse field selection; a per-relation fieldset narrows the include to exactly those picks (TypeORM parity, [#847](https://github.com/tada5hi/rapiq/issues/847)). Picks belonging to a *deeper* relation never narrow the traversed prefix.
 
 ### Field visibility gates
@@ -187,4 +187,4 @@ Compilation throws a typed `AdapterError` for structural problems:
 - an unknown filter operator or compound operator → `ErrorCode.OPERATOR_UNSUPPORTED`,
 - a malformed `elemMatch` or `regex` value → `ErrorCode.FEATURE_UNSUPPORTED`.
 
-Evaluation itself never throws — a guard is `if (!predicate(input)) { ... }`.
+Evaluation itself never throws: a guard is `if (!predicate(input)) { ... }`.

--- a/packages/docs/packages/adapter-prisma.md
+++ b/packages/docs/packages/adapter-prisma.md
@@ -207,7 +207,7 @@ A record whose elements satisfy the two conditions only separately does not matc
 String comparison is [case-insensitive by default](/guide/filters#case-sensitivity) across all rapiq backends. Prisma expresses that with `mode: 'insensitive'`, which only some connectors accept, so the adapter takes a provider:
 
 ```typescript
-new PrismaAdapter({ provider: 'mysql' });
+new PrismaAdapter({ provider: 'mysql', metadata });
 ```
 
 | provider | behavior |
@@ -233,6 +233,19 @@ Opt individual fields out through the schema:
 defineSchema<User>({
     filters: { allowed: ['id', 'token'], caseSensitive: ['token'] },
 });
+```
+
+The declaration is not consumed automatically: the receiving side forwards it to the adapter, mirroring the [shared contract](/guide/filters#case-sensitivity). The adapter takes `caseSensitive` as a top-level constructor option (a field list, or `true` to opt every field out), and `execute` accepts it as a per-call override:
+
+```typescript
+const adapter = new PrismaAdapter({
+    provider: 'postgresql',
+    metadata,
+    caseSensitive: schema.filters.caseSensitive,
+});
+
+// per call, overriding the constructor value:
+adapter.execute(query, { caseSensitive: true });
 ```
 
 ## Limitations

--- a/packages/docs/packages/adapter-prisma.md
+++ b/packages/docs/packages/adapter-prisma.md
@@ -207,7 +207,7 @@ A record whose elements satisfy the two conditions only separately does not matc
 String comparison is [case-insensitive by default](/guide/filters#case-sensitivity) across all rapiq backends. Prisma expresses that with `mode: 'insensitive'`, which only some connectors accept, so the adapter takes a provider:
 
 ```typescript
-new PrismaAdapter({ provider: 'mysql', metadata });
+new PrismaAdapter({ provider: 'mysql', metadata: defineMetadata(datamodel, 'User') });
 ```
 
 | provider | behavior |

--- a/packages/docs/packages/adapter-sql.md
+++ b/packages/docs/packages/adapter-sql.md
@@ -1,6 +1,6 @@
 # @rapiq/adapter-sql
 
-Turns query AST nodes into **parameterized SQL fragments**. Database-agnostic — per-database behavior is injected as a small dialect option object, not a subclass. It is also the foundation the [TypeORM adapter](/packages/adapter-typeorm) builds on.
+Turns query AST nodes into **parameterized SQL fragments**. Database-agnostic: per-database behavior is injected as a small dialect option object, not a subclass. It is also the foundation the [TypeORM adapter](/packages/adapter-typeorm) builds on.
 
 ```sh
 npm install @rapiq/core @rapiq/adapter-sql
@@ -25,7 +25,7 @@ Presets ship for `pg`, `mysql`, `sqlite`, `mssql` and `oracle`:
 import { mysql, pg } from '@rapiq/adapter-sql';
 ```
 
-`resolveDialect(name)` maps a driver/connection type name (e.g. TypeORM's `connection.options.type` or a knex client name) to the matching preset — `postgres`, `mariadb`, `better-sqlite3`, `oracledb`, … — and returns `undefined` for unknown names:
+`resolveDialect(name)` maps a driver/connection type name (e.g. TypeORM's `connection.options.type` or a knex client name) to the matching preset (`postgres`, `mariadb`, `better-sqlite3`, `oracledb`, …) and returns `undefined` for unknown names:
 
 ```typescript
 import { resolveDialect } from '@rapiq/adapter-sql';
@@ -34,12 +34,12 @@ resolveDialect('mariadb'); // mysql preset
 ```
 
 ::: warning Dialects without regex support
-The `mssql` and `sqlite` presets omit the `regexp` callback — SQL Server has no regex operator, and stock SQLite ships without a `REGEXP` function. On those dialects the `contains` / `startsWith` / `endsWith` filter operators (and their negations) fall back to `LIKE ... ESCAPE '\'` with wildcard escaping; only the `regex` filter operator is unavailable and throws a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`).
+The `mssql` and `sqlite` presets omit the `regexp` callback: SQL Server has no regex operator, and stock SQLite ships without a `REGEXP` function. On those dialects the `contains` / `startsWith` / `endsWith` filter operators (and their negations) fall back to `LIKE ... ESCAPE '\'` with wildcard escaping; only the `regex` filter operator is unavailable and throws a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`).
 :::
 
 ## The root adapter
 
-Each parameter has an adapter/visitor pair (`FieldsAdapter`/`FieldsVisitor`, `SortAdapter`/`SortsVisitor`, `PaginationAdapter`/`PaginationVisitor`, `RelationsAdapter`/`RelationsVisitor`) that collects the walked state — selected columns, order map, limit/offset, relation paths. A root `Adapter` bundles all five; `execute(query)` walks a whole `Query` into it and returns the accumulated clause fragments:
+Each parameter has an adapter/visitor pair (`FieldsAdapter`/`FieldsVisitor`, `SortAdapter`/`SortsVisitor`, `PaginationAdapter`/`PaginationVisitor`, `RelationsAdapter`/`RelationsVisitor`) that collects the walked state: selected columns, order map, limit/offset, relation paths. A root `Adapter` bundles all five; `execute(query)` walks a whole `Query` into it and returns the accumulated clause fragments:
 
 ```typescript
 import { Adapter, pg } from '@rapiq/adapter-sql';
@@ -58,9 +58,9 @@ const fragments = adapter.execute(query);
 // }
 ```
 
-Construct the `Adapter` **per request** — it accumulates per-call state; the shareable, long-lived part is the options object.
+Construct the `Adapter` **per request**: it accumulates per-call state; the shareable, long-lived part is the options object.
 
-`@rapiq/adapter-sql` deliberately stops at fragments: composing the final `SELECT` statement — in particular `FROM`/`JOIN` conditions, which require knowledge of the table layout — is the job of the caller or a backend adapter. That's exactly what [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) does for TypeORM.
+`@rapiq/adapter-sql` deliberately stops at fragments: composing the final `SELECT` statement (in particular `FROM`/`JOIN` conditions, which require knowledge of the table layout) is the job of the caller or a backend adapter. That's exactly what [`@rapiq/adapter-typeorm`](/packages/adapter-typeorm) does for TypeORM.
 
 ::: warning Alias convention
 Fragments reference joined columns through the exported `buildRelationAlias(path)` derivation. It length-prefixes every path segment (`realm` → `r5_realm`, `role.realm` → `r4_role_5_realm`), so `role_realm` and `role.realm` cannot collapse onto one alias. Use the same helper when rendering `JOIN` clauses from `relations`, or inject one convention through the `relationAlias` adapter option. Keep a custom derivation collision-free and within your database's identifier length limit.
@@ -68,7 +68,7 @@ Fragments reference joined columns through the exported `buildRelationAlias(path
 
 ### Dotted paths & relations
 
-A dotted field path (`realm.name`) references a joined relation by default: the prefix registers with the relations adapter and the fragment renders against the derived join alias. Backends where a dotted prefix is not necessarily a relation override `isRelationPath(path)` on the relations adapter (default: `true`) — segments only count as a relation path while the hook confirms them, and the remainder stays part of the column name, rendered against the parent alias (the root alias, or the last confirmed relation's join alias). The [TypeORM adapter](/packages/adapter-typeorm) implements the hook via entity metadata so [embedded column paths](/packages/adapter-typeorm#embedded-columns) such as `profile.firstName` don't produce a bogus join.
+A dotted field path (`realm.name`) references a joined relation by default: the prefix registers with the relations adapter and the fragment renders against the derived join alias. Backends where a dotted prefix is not necessarily a relation override `isRelationPath(path)` on the relations adapter (default: `true`); segments only count as a relation path while the hook confirms them, and the remainder stays part of the column name, rendered against the parent alias (the root alias, or the last confirmed relation's join alias). The [TypeORM adapter](/packages/adapter-typeorm) implements the hook via entity metadata so [embedded column paths](/packages/adapter-typeorm#embedded-columns) such as `profile.firstName` don't produce a bogus join.
 
 ## Rendering filters standalone
 
@@ -88,7 +88,7 @@ const [sql, params] = filters.getQueryAndParameters();
 // params: ['jo', 18]
 ```
 
-Values are always bound as parameters — never interpolated into the SQL string.
+Values are always bound as parameters, never interpolated into the SQL string.
 
 ### Null semantics
 
@@ -103,7 +103,7 @@ A `null` filter value is rewritten to the SQL null predicates instead of being b
 
 An empty list never matches: `in(field, [])` renders `1 = 0` and `nin(field, [])` renders `1 = 1` (instead of the invalid `IN ()`).
 
-Negated operators are **exact complements** of their positive twins: a record that does not match `eq(field, a)` matches `ne(field, a)` — including records where the column is `NULL`. Since a bare SQL negation drops `NULL` rows under three-valued logic, negations render null-inclusively:
+Negated operators are **exact complements** of their positive twins: a record that does not match `eq(field, a)` matches `ne(field, a)`, including records where the column is `NULL`. Since a bare SQL negation drops `NULL` rows under three-valued logic, negations render null-inclusively:
 
 | Filter | SQL |
 |---|---|
@@ -115,34 +115,34 @@ Negated operators are **exact complements** of their positive twins: a record th
 
 The `contains` / `startsWith` / `endsWith` operators (and their negations) match their value **literally** on every dialect: regex metacharacters are escaped on regex-capable dialects, LIKE wildcards are escaped on the LIKE fallback. Only the `regex` operator interprets its `RegExp` or string value as a pattern. A JavaScript `RegExp` contributes its `source` and `ignoreCase` flag; a string is passed through unchanged so the selected database regex engine owns its syntax and validation.
 
-The negations match rows whose column is `NULL` (complement law, see above) — on the LIKE fallback they render `(field NOT LIKE ? ESCAPE '\' OR field IS NULL)`.
+The negations match rows whose column is `NULL` (complement law, see above); on the LIKE fallback they render `(field NOT LIKE ? ESCAPE '\' OR field IS NULL)`.
 
 ### Case sensitivity
 
-String equality (`eq` / `ne` / `in` / `nin`) matches [case-insensitively by default](/guide/filters#case-sensitivity). On dialects whose `=` is case-sensitive, both sides fold through the `caseFold` dialect callback — `lower(field) = lower(?)`:
+String equality (`eq` / `ne` / `in` / `nin`) matches [case-insensitively by default](/guide/filters#case-sensitivity). On dialects whose `=` is case-sensitive, both sides fold through the `caseFold` dialect callback, `lower(field) = lower(?)`:
 
 | Filter | pg / sqlite / oracle | mysql / mssql |
 |---|---|---|
 | `eq(field, 'a')` | `lower(field) = lower(?)` | `field = ?` |
 | `in(field, ['a', 1])` | `lower(field) IN (lower(?), ?)` | `field IN (?, ?)` |
 
-The `mysql` and `mssql` presets set `caseFold` to identity: their default collations (`*_ci`) already compare case-insensitively, and skipping `lower()` keeps plain indexes usable. Fields opted out via the `caseSensitive` visitor option render unfolded on every dialect:
+The `mysql` and `mssql` presets set `caseFold` to identity: their default collations (`*_ci`) already compare case-insensitively, and skipping `lower()` keeps plain indexes usable. Fields opted out via the top-level `caseSensitive` execute option render unfolded on every dialect (`true` opts every field out):
 
 ```typescript
 adapter.execute(query, { caseSensitive: ['id'] });
 ```
 
-On folding dialects, give hot string filter columns an expression index (`CREATE INDEX ... ON "user" (lower(name))`) — or opt them out.
+On folding dialects, give hot string filter columns an expression index (`CREATE INDEX ... ON "user" (lower(name))`), or opt them out.
 
-Folding only happens for string filter values. Backends with column metadata can exempt whole columns by overriding `isCaseFoldable(field)` on the filters adapter (default: `true`) — the [TypeORM adapter](/packages/adapter-typeorm) uses it to fold only string-typed columns.
+Folding only happens for string filter values. Backends with column metadata can exempt whole columns by overriding `isCaseFoldable(field)` on the filters adapter (default: `true`); the [TypeORM adapter](/packages/adapter-typeorm) uses it to fold only string-typed columns.
 
 ### ITSELF (element-level conditions)
 
-The [`ITSELF` marker](/guide/filters#operators) — an `elemMatch` interior condition on the array element itself, produced e.g. by the mongo parser's element-level `$elemMatch` and `$all` — has no SQL rendering: `elemMatch` maps to a relation join, and a joined row is not a scalar column. Both `@rapiq/adapter-sql` and `@rapiq/adapter-typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`). Dialect-level JSON-array support (`json_each` / `unnest`) may lift this later; evaluate such filters with [`@rapiq/adapter-memory`](/packages/adapter-memory) in the meantime.
+The [`ITSELF` marker](/guide/filters#operators) (an `elemMatch` interior condition on the array element itself, produced e.g. by the mongo parser's element-level `$elemMatch` and `$all`) has no SQL rendering: `elemMatch` maps to a relation join, and a joined row is not a scalar column. Both `@rapiq/adapter-sql` and `@rapiq/adapter-typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`). Dialect-level JSON-array support (`json_each` / `unnest`) may lift this later; evaluate such filters with [`@rapiq/adapter-memory`](/packages/adapter-memory) in the meantime.
 
 ### size (array length)
 
-The [`size` operator](/guide/filters#operators) has no SQL rendering either — an array-length check needs per-dialect JSON-array support (`json_array_length` on Postgres/SQLite, `JSON_LENGTH` on MySQL, `cardinality` for Postgres arrays). Both `@rapiq/adapter-sql` and `@rapiq/adapter-typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`); evaluate such filters with [`@rapiq/adapter-memory`](/packages/adapter-memory) in the meantime.
+The [`size` operator](/guide/filters#operators) has no SQL rendering either: an array-length check needs per-dialect JSON-array support (`json_array_length` on Postgres/SQLite, `JSON_LENGTH` on MySQL, `cardinality` for Postgres arrays). Both `@rapiq/adapter-sql` and `@rapiq/adapter-typeorm` throw a typed `AdapterError` (`ErrorCode.FEATURE_UNSUPPORTED`); evaluate such filters with [`@rapiq/adapter-memory`](/packages/adapter-memory) in the meantime.
 
 ## Field visibility gates
 
@@ -159,4 +159,4 @@ const rows = await driver.query(assemble(fragments));
 const output = applyFieldConditions(query.fields, rows);
 ```
 
-Skipping this step fails open: consumers receive the gated column unredacted.
+`compileFieldConditions(query.fields)` is the single-record form: it compiles the gates once into a reusable `(record) => redacted` function. Skipping this step fails open: consumers receive the gated column unredacted.

--- a/packages/docs/packages/adapter-typeorm.md
+++ b/packages/docs/packages/adapter-typeorm.md
@@ -1,6 +1,6 @@
 # @rapiq/adapter-typeorm
 
-Applies a parsed [`Query`](/guide/query-ast) directly to a TypeORM `SelectQueryBuilder` — filters become parameterized `WHERE` conditions, relations become joins, fields/sort/pagination map to `select`/`orderBy`/`take`+`skip`.
+Applies a parsed [`Query`](/guide/query-ast) directly to a TypeORM `SelectQueryBuilder`: filters become parameterized `WHERE` conditions, relations become joins, fields/sort/pagination map to `select`/`orderBy`/`take`+`skip`.
 
 ```sh
 npm install @rapiq/core @rapiq/adapter-sql @rapiq/adapter-typeorm
@@ -23,21 +23,21 @@ const { pagination } = adapter.execute(query);
 const [entities, total] = await queryBuilder.getManyAndCount();
 ```
 
-The `queryBuilder` (the builder to write into) is bound at construction; `execute(query)` then walks the parsed `Query`, collects the state into its sub-adapters, and applies it to that builder — returning the applied pagination (e.g. for the response `meta` block).
+The `queryBuilder` (the builder to write into) is bound at construction; `execute(query)` then walks the parsed `Query`, collects the state into its sub-adapters, and applies it to that builder, returning the applied pagination (e.g. for the response `meta` block).
 
-Builder state you set before `execute` is preserved: `WHERE` conditions stay (rapiq appends its filter tree with `AND`, and binds its parameters under a private namespace so caller bindings are never rebound), and a query that carries no sorts or pagination leaves a caller-owned `ORDER BY` / `take` / `skip` untouched. An application-owned tenant or authorization predicate therefore remains the baseline even when the client sends no filters. When the client *does* send sorts, fields or pagination, those replace the corresponding builder state — that is the request's job.
+Builder state you set before `execute` is preserved: `WHERE` conditions stay (rapiq appends its filter tree with `AND`, and binds its parameters under a private namespace so caller bindings are never rebound), and a query that carries no sorts or pagination leaves a caller-owned `ORDER BY` / `take` / `skip` untouched. An application-owned tenant or authorization predicate therefore remains the baseline even when the client sends no filters. When the client *does* send sorts, fields or pagination, those replace the corresponding builder state; that is the request's job.
 
-Construct the adapter **per request**, just like the `SelectQueryBuilder` you hand it — it holds per-call state. The shareable, long-lived part is your config, which you spread into the per-request options:
+Construct the adapter **per request**, just like the `SelectQueryBuilder` you hand it: it holds per-call state. The shareable, long-lived part is your config, which you spread into the per-request options:
 
 ```typescript
-// module scope — the reusable config
+// module scope: the reusable config
 const config = { relations: { joinAndSelect: true } };
 
-// per request — add the request's builder as `queryBuilder`
+// per request: add the request's builder as `queryBuilder`
 new TypeormAdapter({ ...config, queryBuilder }).execute(query);
 ```
 
-By default each call clears the adapter's own accumulated state. The bound `queryBuilder`, however, is mutated in place — joins and the selected projection are not rolled back — so build a fresh adapter (with a fresh builder) per query rather than re-running one onto an already-applied builder. Pass `{ clear: false }` as the second argument to accumulate several queries' conditions onto the same builder, and `{ visitor }` to forward options to the underlying visitors:
+By default each call clears the adapter's own accumulated state. The bound `queryBuilder`, however, is mutated in place (joins and the selected projection are not rolled back), so build a fresh adapter (with a fresh builder) per query rather than re-running one onto an already-applied builder. `execute` takes two per-call options as its second argument: `{ clear: false }` accumulates several queries' conditions onto the same builder, and `{ caseSensitive }` opts fields out of [case folding](#case-folding-column-types):
 
 ```typescript
 adapter.execute(query, { clear: false });
@@ -60,39 +60,39 @@ new TypeormAdapter({
 
 | Option | Description |
 |---|---|
-| `relations.joinAndSelect` | Hydrate **every** joined relation, including those joined only for a filter or sort. Off by default — without it, a relation joined purely for filtering/sorting stays unselected (its columns are hydrated only when a `fields` path references them). The option widens *which* relations hydrate, never how much of one is selected: fieldset narrowing (below) applies under it the same way. |
-| `relations.hydrationMode` | `'full'` (default) or `'key'`. Select granularity for the relations the adapter hydrates. `'full'` selects the whole subtree (`leftJoinAndSelect`) for a fieldset-free include; `'key'` selects only the relation's primary key (plain `leftJoin` + `addSelect(<alias>.<pk>)`), so the relation object is hydrated **id-only**. Use `'key'` to keep an `include`d relation defined under `GROUP BY <root>.id` on strict dialects — see the warning below. |
+| `relations.joinAndSelect` | Hydrate **every** joined relation, including those joined only for a filter or sort. Off by default; without it, a relation joined purely for filtering/sorting stays unselected (its columns are hydrated only when a `fields` path references them). The option widens *which* relations hydrate, never how much of one is selected: fieldset narrowing (below) applies under it the same way. |
+| `relations.hydrationMode` | `'full'` (default) or `'key'`. Select granularity for the relations the adapter hydrates. `'full'` selects the whole subtree (`leftJoinAndSelect`) for a fieldset-free include; `'key'` selects only the relation's primary key (plain `leftJoin` + `addSelect(<alias>.<pk>)`), so the relation object is hydrated **id-only**. Use `'key'` to keep an `include`d relation defined under `GROUP BY <root>.id` on strict dialects; see the warning below. |
 | `relations.joinType` | `'left'` (default) or `'inner'`. Left joins keep records whose relation is absent. |
-| `relations.onJoin` | Invoked as `(path, alias, queryBuilder)` for every join the adapter applies — e.g. to `addGroupBy` per join when the root query is grouped. Skipped (pre-existing) joins don't trigger it. |
+| `relations.onJoin` | Invoked as `(path, alias, queryBuilder)` for every join the adapter applies, e.g. to `addGroupBy` per join when the root query is grouped. Skipped (pre-existing) joins don't trigger it. |
 | `relations.relationAlias` | Derive the join alias for a relation path (default: collision-free length-prefixed segments, e.g. `role.realm` → `r4_role_5_realm`). Filter/sort/field references resolve against the same derivation. |
 
 A hydrated relation is selected as a complete subtree only while the query carries no direct fieldset for it: a per-relation fieldset (a client-sent `fields[child]=...` or the child schema's `fields.default`/`allowed`) narrows the selection to exactly those columns plus the relation's primary key, so the relation object hydrates reliably even when every listed column is NULL. Picks belonging to a deeper relation never narrow the traversed prefix.
 
-Relations are validated against the entity metadata of the attached query builder — a requested relation that doesn't exist on the entity is ignored. Joins are applied idempotently: relations already joined on the query builder (by the adapter or by your own code, matched by alias) are skipped, so applying a query twice does not duplicate joins.
+Relations are validated against the entity metadata of the attached query builder: a requested relation that doesn't exist on the entity is ignored. Joins are applied idempotently: relations already joined on the query builder (by the adapter or by your own code, matched by alias) are skipped, so applying a query twice does not duplicate joins.
 
 ::: warning Alias convention
 The exported `buildRelationAlias(path)` helper length-prefixes every segment: `realm` becomes `r5_realm`, and `role.realm` becomes `r4_role_5_realm`. This remains distinct even from a relation literally named `role_realm`. Fields, filters, sorts and joins all use the same derivation. Pre-existing joins are matched by that alias; use the helper for joins you apply yourself, or inject one convention via `relations.relationAlias`. Keep a custom derivation collision-free and within your database's identifier length limit.
 :::
 
 ::: warning `include` + `GROUP BY <root>.id`
-An `include`d relation **without a fieldset** is join-and-**selected as a complete subtree**, which adds *all* of the child's columns to the `SELECT` (this matches the [`@rapiq/adapter-memory`](/packages/adapter-memory) projection contract). Strict SQL dialects (postgres) reject those columns under a `GROUP BY <root>.id` pagination pattern — a `relations.onJoin` hook that adds `addGroupBy(alias + '.id')` per join — because each joined column is neither grouped nor aggregated. Hydrating an arbitrary subtree and collapsing to distinct roots are fundamentally incompatible there, regardless of how the columns are selected (the same applies to `relations.joinAndSelect: true`).
+An `include`d relation **without a fieldset** is join-and-**selected as a complete subtree**, which adds *all* of the child's columns to the `SELECT` (this matches the [`@rapiq/adapter-memory`](/packages/adapter-memory) projection contract). Strict SQL dialects (postgres) reject those columns under a `GROUP BY <root>.id` pagination pattern (a `relations.onJoin` hook that adds `addGroupBy(alias + '.id')` per join), because each joined column is neither grouped nor aggregated. Hydrating an arbitrary subtree and collapsing to distinct roots are fundamentally incompatible there, regardless of how the columns are selected (the same applies to `relations.joinAndSelect: true`).
 
 Pick one:
 
-- **A per-relation fieldset** — `include=<relation>` combined with `fields[<relation>]=<columns>` (or a child schema declaring `fields.default`/`allowed`) narrows the include to a plain `leftJoin` selecting the requested columns plus the relation's primary key (all groupable). Use this when you only need a few columns of the relation under a grouped root; a bare `fields=<relation>.<column>` path without the include behaves the same, minus the automatic primary key.
-- **Id-only hydration** — set `relations.hydrationMode: 'key'` to select only the relation's primary key, so the relation object is at least *defined* (id-only) and every selected join column is groupable. The subtree is not materialized — reach for this when a caller relies on the relation being present but does not need its columns.
-- **A non-grouping pagination strategy** — a distinct-root subquery or a two-phase *ids-then-load* when you genuinely need the full include alongside pagination.
+- **A per-relation fieldset**: `include=<relation>` combined with `fields[<relation>]=<columns>` (or a child schema declaring `fields.default`/`allowed`) narrows the include to a plain `leftJoin` selecting the requested columns plus the relation's primary key (all groupable). Use this when you only need a few columns of the relation under a grouped root; a bare `fields=<relation>.<column>` path without the include behaves the same, minus the automatic primary key.
+- **Id-only hydration**: set `relations.hydrationMode: 'key'` to select only the relation's primary key, so the relation object is at least *defined* (id-only) and every selected join column is groupable. The subtree is not materialized; reach for this when a caller relies on the relation being present but does not need its columns.
+- **A non-grouping pagination strategy**: a distinct-root subquery or a two-phase *ids-then-load* when you genuinely need the full include alongside pagination.
 
-`include` remains the right tool when you are **not** grouping the root — the full subtree hydrates without conflict.
+`include` remains the right tool when you are **not** grouping the root: the full subtree hydrates without conflict.
 :::
 
 ## Dialect detection
 
-The adapter resolves the SQL dialect from the attached query builder's connection type (`postgres`, `mysql`/`mariadb`, `sqlite`/`better-sqlite3`, `mssql`, `oracle`, …). Field escaping is delegated to the query builder itself; regex conditions use the matching [dialect preset](/packages/adapter-sql#dialects) — on regex-less dialects (SQLite, SQL Server) the `contains` / `startsWith` / `endsWith` operators fall back to `LIKE`, and the `regex` operator throws a typed `AdapterError`. When the connection type has no matching preset, the postgres preset is the documented last-resort default.
+The adapter resolves the SQL dialect from the attached query builder's connection type (`postgres`, `mysql`/`mariadb`, `sqlite`/`better-sqlite3`, `mssql`, `oracle`, …). Field escaping is delegated to the query builder itself; regex conditions use the matching [dialect preset](/packages/adapter-sql#dialects): on regex-less dialects (SQLite, SQL Server) the `contains` / `startsWith` / `endsWith` operators fall back to `LIKE`, and the `regex` operator throws a typed `AdapterError`. When the connection type has no matching preset, the postgres preset is the documented last-resort default.
 
 ## Case folding & column types
 
-[Case-insensitive string equality](/guide/filters#case-sensitivity) folds through `lower()` on case-sensitive dialects. The adapter resolves each filtered field against the entity metadata (relation paths included) and folds **only string-typed columns** — filtering an `int` column with an untyped wire string (`filter[age]=18`) renders a plain `=` instead of a `lower(...)` type error, and non-string columns never pay the folding cost. Unresolvable fields keep the folding default; opt fields out explicitly via `execute(query, { caseSensitive: [...] })`.
+[Case-insensitive string equality](/guide/filters#case-sensitivity) folds through `lower()` on case-sensitive dialects. The adapter resolves each filtered field against the entity metadata (relation paths included) and folds **only string-typed columns**: filtering an `int` column with an untyped wire string (`filter[age]=18`) renders a plain `=` instead of a `lower(...)` type error, and non-string columns never pay the folding cost. Unresolvable fields keep the folding default; opt fields out explicitly via `execute(query, { caseSensitive: [...] })`.
 
 ## Field visibility gates
 
@@ -115,11 +115,11 @@ Skipping the post-fetch call ships the gated value to the client, so treat this 
 
 ## Embedded columns
 
-Dotted field paths resolve against the entity metadata segment by segment — only real relations join. A path into an [embedded entity](https://typeorm.io/docs/entity/embedded-entities/) (`@Column(() => Profile)`), e.g. `profile.firstName`, is dotted without anything to join: it renders against its parent alias with the embedded column's database name (`"user"."profileFirstname"`) instead of producing a bogus `LEFT JOIN`. This applies uniformly to filters, sort and field selection, and composes with relations — `role.profile.firstName` joins only `role` and resolves the embedded remainder against that join's alias.
+Dotted field paths resolve against the entity metadata segment by segment: only real relations join. A path into an [embedded entity](https://typeorm.io/docs/entity/embedded-entities/) (`@Column(() => Profile)`), e.g. `profile.firstName`, is dotted without anything to join: it renders against its parent alias with the embedded column's database name (`"user"."profileFirstname"`) instead of producing a bogus `LEFT JOIN`. This applies uniformly to filters, sort and field selection, and composes with relations: `role.profile.firstName` joins only `role` and resolves the embedded remainder against that join's alias.
 
 ## Deriving schemas from entities
 
-Instead of hand-maintaining a [`Schema`](/guide/schemas) per resource, derive it from the TypeORM entity metadata. `defineSchemaRegistryWithDataSource` walks all entities of a data source and returns a populated `SchemaRegistry` — one schema per entity, cross-linked automatically:
+Instead of hand-maintaining a [`Schema`](/guide/schemas) per resource, derive it from the TypeORM entity metadata. `defineSchemaRegistryWithDataSource` walks all entities of a data source and returns a populated `SchemaRegistry`: one schema per entity, cross-linked automatically:
 
 ```typescript
 import { defineSchemaRegistryWithDataSource } from '@rapiq/adapter-typeorm';
@@ -134,7 +134,7 @@ const registry = defineSchemaRegistryWithDataSource(dataSource, {
 });
 ```
 
-Every schema gets its **structure** derived unconditionally: the schema name (lower-camel entity name, `RoleDetail` → `roleDetail`), the allowed relations, and the `schemaMapping` linking each relation to its target entity's schema — so nested paths like `role.detail` resolve across the registry without any manual wiring.
+Every schema gets its **structure** derived unconditionally: the schema name (lower-camel entity name, `RoleDetail` → `roleDetail`), the allowed relations, and the `schemaMapping` linking each relation to its target entity's schema, so nested paths like `role.detail` resolve across the registry without any manual wiring.
 
 Column-based **allow-lists** are opt-in per parameter: `allowed: 'inherit'` expands to the entity's column property paths. Hidden columns (`select: false`) and virtual join columns are always excluded; explicitly declared FK columns (e.g. `realmId`) are included. Any explicit option wins over its derived counterpart:
 
@@ -151,7 +151,7 @@ const schema = defineSchemaWithEntity(User, dataSource, {
 
 `defineSchemaWithEntity` also accepts an `EntityMetadata` directly (`defineSchemaWithEntity(dataSource.getMetadata(User))`), and the registry's `schemas` options can be keyed by entity class via a `Map` instead of the derived name. An options key that matches no entity throws, so entity renames fail loudly.
 
-To mix hand-written and derived schemas, pass an existing registry — entities whose derived name is already registered are skipped, so the hand-written schema stays authoritative and derivation fills in the rest:
+To mix hand-written and derived schemas, pass an existing registry: entities whose derived name is already registered are skipped, so the hand-written schema stays authoritative and derivation fills in the rest:
 
 ```typescript
 const registry = new SchemaRegistry();
@@ -160,17 +160,17 @@ registry.add(userSchema);   // curated by hand
 defineSchemaRegistryWithDataSource(dataSource, { registry });
 ```
 
-Passing `schemas` options for a skipped (already registered) name throws — options that would be silently ignored are treated as a mistake.
+Passing `schemas` options for a skipped (already registered) name throws; options that would be silently ignored are treated as a mistake.
 
-Derivation never sets [`strict`](/guide/schemas#strict-mode) — combined with `strict: true`, a derived `allowed: 'inherit'` opens **every** (non-hidden) column to clients, so opt sensitive resources into explicit lists instead.
+Derivation never sets [`strict`](/guide/schemas#strict-mode): combined with `strict: true`, a derived `allowed: 'inherit'` opens **every** (non-hidden) column to clients, so opt sensitive resources into explicit lists instead.
 
 ::: tip
-The data source only needs built metadata, not an open connection — deriving schemas at startup before `dataSource.initialize()` completes is fine as long as the metadata was built.
+The data source only needs built metadata, not an open connection; deriving schemas at startup before `dataSource.initialize()` completes is fine as long as the metadata was built.
 :::
 
 ## Validating schemas against entities
 
-Hand-written schemas drift silently: a renamed column leaves a dead key in an allow-list that either never matches again or surfaces as a runtime adapter error on first client use. `assertSchemaMatchesEntity` checks every key a schema references against the entity metadata — call it at boot so drift fails the deploy, not a request:
+Hand-written schemas drift silently: a renamed column leaves a dead key in an allow-list that either never matches again or surfaces as a runtime adapter error on first client use. `assertSchemaMatchesEntity` checks every key a schema references against the entity metadata; call it at boot so drift fails the deploy, not a request:
 
 ```typescript
 import { assertSchemaMatchesEntity } from '@rapiq/adapter-typeorm';
@@ -182,8 +182,8 @@ assertSchemaMatchesEntity(userSchema, dataSource.getMetadata(User));
 
 Validated keys: `fields.default` and `fields.allowed`, `filters.allowed` and the leaf fields of a `filters.default` condition tree, `sort.allowed` (tuple groups included) and the keys of `sort.default`, and `relations.allowed`. The rules:
 
-- Plain keys must be column property paths — embedded paths like `profile.firstName` included.
-- Dotted keys that aren't a column path must be headed by a relation. Only the head is checked; the remainder belongs to the related entity — validate that schema against its own entity.
+- Plain keys must be column property paths, embedded paths like `profile.firstName` included.
+- Dotted keys that aren't a column path must be headed by a relation. Only the head is checked; the remainder belongs to the related entity, so validate that schema against its own entity.
 - `relations.allowed` keys must be relation property names (dotted keys headed by a relation).
 
 On a mismatch the helper throws a `SchemaEntityMismatchError` (code `schemaEntityMismatch`, a `SchemaError` subclass) that collects **every** offending key rather than stopping at the first, and exposes `schema`, `entity` and `keys` as properties:
@@ -201,11 +201,11 @@ try {
 }
 ```
 
-Schemas produced by `defineSchemaWithEntity` don't need this — their structure comes from the metadata in the first place. The helper targets curated, hand-written schemas kept next to derived ones.
+Schemas produced by `defineSchemaWithEntity` don't need this: their structure comes from the metadata in the first place. The helper targets curated, hand-written schemas kept next to derived ones.
 
 ## Applying a single parameter
 
-A `Query` with only some parameters set applies just those — the rest are empty and become no-ops. To apply, say, only the filters of a parsed query:
+A `Query` with only some parameters set applies just those: the rest are empty and become no-ops. To apply, say, only the filters of a parsed query:
 
 ```typescript
 import { Query } from '@rapiq/core';
@@ -214,12 +214,12 @@ const adapter = new TypeormAdapter({ queryBuilder });
 adapter.execute(new Query({ filters: query.filters }));
 ```
 
-For lower-level control, each per-parameter sub-adapter (`adapter.filters`, `adapter.fields`, `adapter.sort`, `adapter.pagination`, `adapter.relations`) pairs with the matching `@rapiq/adapter-sql` visitor (`FiltersVisitor`, `FieldsVisitor`, `SortsVisitor`, `PaginationVisitor`, `RelationsVisitor`) and applies via its own `execute()` — the query builder is already bound from the adapter's construction.
+For lower-level control, each per-parameter sub-adapter (`adapter.filters`, `adapter.fields`, `adapter.sort`, `adapter.pagination`, `adapter.relations`) pairs with the matching `@rapiq/adapter-sql` visitor (`FiltersVisitor`, `FieldsVisitor`, `SortsVisitor`, `PaginationVisitor`, `RelationsVisitor`) and applies via its own `execute()`; the query builder is already bound from the adapter's construction.
 
 ## End-to-end example
 
-The complete Express endpoint — schemas, decoding, error handling, response `meta` — lives in the [Express & TypeORM recipe](/guide/recipes/express-typeorm).
+The complete Express endpoint (schemas, decoding, error handling, response `meta`) lives in the [Express & TypeORM recipe](/guide/recipes/express-typeorm).
 
 ::: info Migrating from typeorm-extension
-`applyQuery` used `leftJoinAndSelect` and returned the parsed pagination — `joinType: 'left'` (the default) and the `execute(query)` return value mirror that contract. See the [migration guide](/guide/migration-typeorm-extension).
+`applyQuery` used `leftJoinAndSelect` and returned the parsed pagination; `joinType: 'left'` (the default) and the `execute(query)` return value mirror that contract. See the [migration guide](/guide/migration-typeorm-extension).
 :::

--- a/packages/docs/packages/codec-url.md
+++ b/packages/docs/packages/codec-url.md
@@ -21,7 +21,7 @@ const decoded = codec.decode(wire!, { schema: 'user' });
 
 The façade owns both directions. Use `encodeAsync()` and `decodeAsync()` when a schema uses asynchronous filter validators.
 
-For receivers outside rapiq (e.g. strict JSON:API endpoints that reject unknown query parameters), the reserved stamp can be omitted — the output is still recognized structurally on decode:
+For receivers outside rapiq (e.g. strict JSON:API endpoints that reject unknown query parameters), the reserved stamp can be omitted; the output is still recognized structurally on decode:
 
 ```typescript
 codec.encode(query, { stamp: false });
@@ -34,8 +34,10 @@ Encoding uses `url-expression` by default and stamps `codec=url-expression`. Dec
 
 1. A stamped payload dispatches to the named dialect.
 2. An unstamped non-empty string `filter` is parsed as an expression.
-3. Any other unstamped defined `filter` — bracket/object input, or an empty `filter=` which carries no dialect signal — is parsed as legacy simple input.
+3. Any other unstamped defined `filter` (bracket/object input, or an empty `filter=` which carries no dialect signal) is parsed as legacy simple input.
 4. A payload naming an unknown codec throws `CodecError` with `CODEC_UNRESOLVABLE`.
+
+The dialect identifiers are exported as `URL_EXPRESSION_CODEC` (`'url-expression'`) and `URL_SIMPLE_CODEC` (`'url-simple'`): pass one via `encode(query, { codec })`, or use them for out-of-band content negotiation. The reserved `codec` wire key itself is exported as `CODEC_PARAMETER`.
 
 Input without a filter is dialect-neutral because fields, pagination, relations and sort share one wire grammar. Structural recognition is supplied by each registered dialect's `detect` hook (see [Custom codecs](#custom-codecs)), so it applies to third-party dialects too.
 
@@ -53,7 +55,7 @@ It carries flat filters, repeated fields, nested `and`/`or`/`not` trees and `ele
 filter=elemMatch(scores,gt($this,'5'))
 ```
 
-Operators without an expression grammar production—`regex`, `mod` and `exists`—throw a typed unsupported error during encoding rather than changing semantics.
+Operators without an expression grammar production (`regex`, `mod` and `exists`) throw a typed unsupported error during encoding rather than changing semantics.
 
 ## Legacy simple dialect
 
@@ -78,11 +80,15 @@ The simple dialect supports flat root-AND filters only. Nested groups, repeated 
 
 | Parameter | URL key | Example |
 |---|---|---|
-| fields | `fields` | `fields=id,name` / `fields[items]=id` |
+| fields | `fields` | `fields=id,name` / `fields[$root]=id,name&fields[items]=id` |
 | filters | `filter` | expression string or legacy bracket fields |
 | pagination | `page` | `page[limit]=25&page[offset]=50` |
 | relations | `include` | `include=realm,items` |
 | sort | `sort` | `sort=name,-age` |
+
+When root and relation fieldsets encode together, the root field group is spelled with the reserved `$root` token (exported as `URL_FIELDS_ROOT`): `fields[$root]=id,name&fields[items]=id`. A lone root group keeps the bare form (`fields=id,name`). Decoding accepts `$root` and the legacy `__DEFAULT__` spelling written by early 2.0 betas.
+
+The URL keys in the table are exported as the `URLParameter` constants; the reserved `codec` key as `CODEC_PARAMETER`.
 
 Within a dialect's supported subset, `decode(encode(query))` restores the same query up to scalar wire normalization (`'5'` becomes `5`, for example).
 
@@ -108,7 +114,7 @@ const decoded = codec.decode(req.query, {
 });
 ```
 
-Schema-aware encoding validates by piping the output through the schema-bound decoder — a `filters.validate` hook therefore runs once during a schema-aware `encode()` and again when the receiver decodes. Keep validators **idempotent** (re-validating an accepted filter must return it unchanged), or the two sides will disagree about the transported values.
+Schema-aware encoding validates by piping the output through the schema-bound decoder: a `filters.validate` hook therefore runs once during a schema-aware `encode()` and again when the receiver decodes. Keep validators **idempotent** (re-validating an accepted filter must return it unchanged), or the two sides will disagree about the transported values.
 
 ## Custom codecs
 

--- a/packages/docs/packages/core.md
+++ b/packages/docs/packages/core.md
@@ -1,6 +1,6 @@
 # @rapiq/core
 
-The foundation every other package builds on: the query AST, the typed build layer, the schema system, parser base classes and the error hierarchy. Frameworks-free and side-neutral — callers and receivers both depend on it.
+The foundation every other package builds on: the query AST, the typed build layer, the schema system, parser base classes and the error hierarchy. Frameworks-free and side-neutral; callers and receivers both depend on it.
 
 ```sh
 npm install @rapiq/core
@@ -14,14 +14,15 @@ npm install @rapiq/core
 | **Build layer** | `defineQuery`, `defineFields`, `defineFilters`, `definePagination`, `defineRelations`, `defineSorts` | [Building Queries](/guide/building-queries) |
 | **Condition helpers** | `eq`, `ne`, `lt`, `lte`, `gt`, `gte`, `inArray`, `nin`, `startsWith`, `notStartsWith`, `endsWith`, `notEndsWith`, `contains`, `notContains`, `regex`, `mod`, `size`, `exists`, `elemMatch`, `and`, `or`, `not` | [Condition helpers](/guide/building-queries#condition-helpers) |
 | **Composition** | `mergeQueries`, `Filters.merge` / `.and` / `.or` | [Merging & Composition](/guide/merging-queries) |
+| **Plan layer** | `planCondition`, `interpretPlan`, `distributeNegation`, `IPlanInterpreter`, `FILTER_OPERATOR_SEMANTICS`, plan types (`ConditionPlan`, `ComparePlan`, `CompoundPlan`, …) | [The visitor pattern](/guide/query-ast#the-visitor-pattern) |
 | **Schema system** | `defineSchema`, `Schema`, `SchemaRegistry`, per-parameter `define*Schema` factories, `ResolutionScope`, `Schema.describe()` | [Schemas & Validation](/guide/schemas) |
 | **Parser base** | `BaseParser`, per-parameter parse-option types | [Custom parsers](/guide/query-ast#writing-a-custom-parser-resolutionscope) |
 | **Errors** | `BaseError`, `ParseError` + per-parameter subclasses, `BuildError`, `MergeError`, `AdapterError`, `CodecError`, `ErrorCode` | [Error Handling](/guide/errors) |
-| **Utils** | `parseKey`, `stringifyKey`, `isObject`, `isPropertySet` | — |
+| **Utils** | `parseKey`, `stringifyKey`, `isObject`, `isPropertySet` | |
 
 ## Typed field paths
 
-The generics run on recursive key paths: `defineQuery<User>`, `defineSchema<User>` and every condition helper check field names — including dotted relation paths like `'realm.name'` — against the record type, with autocomplete. Paths are depth-limited to keep type-checking fast.
+The generics run on recursive key paths: `defineQuery<User>`, `defineSchema<User>` and every condition helper check field names (including dotted relation paths like `'realm.name'`) against the record type, with autocomplete. Paths are depth-limited to keep type-checking fast.
 
 ```typescript
 defineQuery<User>({
@@ -30,10 +31,14 @@ defineQuery<User>({
 });
 ```
 
+## The plan layer
+
+The filters contract for backend authors. A backend never branches on filter operator names: `planCondition(condition)` lowers a condition tree into a `ConditionPlan` with every semantic decision already made (negation twins resolved, null equality turned into null checks, case-fold verdicts computed), all derived from the `FILTER_OPERATOR_SEMANTICS` table, the single source of what an operator means. Interpreter-style backends (SQL, TypeORM, memory) consume the plan via `interpretPlan(plan, interpreter)` with an `IPlanInterpreter` implementation; serializer-style backends (Prisma, Drizzle) run `distributeNegation(plan)` first, which pushes group negation down to the leaves, and render only the resulting final forms. See [the visitor pattern](/guide/query-ast#the-visitor-pattern).
+
 ## What core deliberately does *not* contain
 
-- **No wire formats** — URL parameter names and query-string handling live in [`@rapiq/codec-url`](/packages/codec-url).
-- **No input dialects** — parsing simple/expression/mongo input lives in the [parser packages](/packages/parser-simple).
-- **No backends** — SQL/TypeORM/Prisma/Drizzle/memory execution lives in the [adapter packages](/packages/adapter-sql).
+- **No wire formats**: URL parameter names and query-string handling live in [`@rapiq/codec-url`](/packages/codec-url).
+- **No input dialects**: parsing simple/expression/mongo input lives in the [parser packages](/packages/parser-simple).
+- **No backends**: SQL/TypeORM/Prisma/Drizzle/memory execution lives in the [adapter packages](/packages/adapter-sql).
 
 If you only build queries in code and hand them to an in-process consumer, core is the only dependency you need.

--- a/packages/docs/packages/index.md
+++ b/packages/docs/packages/index.md
@@ -1,6 +1,6 @@
 # Package Overview
 
-rapiq is a family of small packages around one shared data structure — the [`Query`](/guide/query-ast). Install only what each side of your application needs; `@rapiq/core` is a peer dependency of everything else.
+rapiq is a family of small packages around one shared data structure: the [`Query`](/guide/query-ast). Install only what each side of your application needs; `@rapiq/core` is a peer dependency of everything else.
 
 ## The map
 
@@ -49,7 +49,7 @@ npm install @rapiq/core @rapiq/codec-url @rapiq/adapter-drizzle
 npm install @rapiq/core @rapiq/codec-url @rapiq/adapter-sql
 ```
 
-**Something in-process — guards, tests, mock backends:**
+**Something in-process (guards, tests, mock backends):**
 
 ```sh
 npm install @rapiq/core @rapiq/adapter-memory

--- a/packages/docs/packages/parser-expression.md
+++ b/packages/docs/packages/parser-expression.md
@@ -1,6 +1,6 @@
 # @rapiq/parser-expression
 
-Parses an expression language for filters — useful when a single string must carry a complex condition tree (search boxes, saved filters, CLI flags). The [expression URL codec](/packages/codec-url#expression-dialect) builds on it.
+Parses an expression language for filters: useful when a single string must carry a complex condition tree (search boxes, saved filters, CLI flags). The [expression URL codec](/packages/codec-url#expression-dialect) builds on it.
 
 ```sh
 npm install @rapiq/core @rapiq/parser-simple @rapiq/parser-expression
@@ -31,16 +31,16 @@ elemMatch(scores, gt($this, '5'))
 | `elemMatch(field, expr)` | array element match | `ELEM_MATCH` |
 | `size(field, n)` | array length (non-negative integer) | `SIZE` |
 | `and(expr, …)` / `or(expr, …)` | compound | `Filters` node |
-| `not(expr)` | [negation](/guide/filters#negation) — the exact complement of the interior | a single leaf with a negated twin normalizes to it (`not(eq(…))` → `NOT_EQUAL`, `not(in(…))` → `NOT_IN`, …), a double `not` cancels; everything else (ordering comparisons, `size`, `elemMatch`, groups) stays a first-class `NOT` `Filters` node |
+| `not(expr)` | [negation](/guide/filters#negation): the exact complement of the interior | a single leaf with a negated twin normalizes to it (`not(eq(…))` → `NOT_EQUAL`, `not(in(…))` → `NOT_IN`, …), a double `not` cancels; everything else (ordering comparisons, `size`, `elemMatch`, groups) stays a first-class `NOT` `Filters` node |
 
 Rules:
 
-- **Values are always single-quoted** — `gte(age, '18')`, not `gte(age, 18)`. Quoted numerals are coerced to numbers, `'true'`/`'false'` to booleans, `'null'` to `null`. Escape a quote by doubling it (`'it''s'`).
-- Quoted values are never comma-split — `eq(name, 'a,b')` is the literal string `'a,b'`; lists are separate arguments.
+- **Values are always single-quoted**: `gte(age, '18')`, not `gte(age, 18)`. Quoted numerals are coerced to numbers, `'true'`/`'false'` to booleans, `'null'` to `null`. Escape a quote by doubling it (`'it''s'`).
+- Quoted values are never comma-split: `eq(name, 'a,b')` is the literal string `'a,b'`; lists are separate arguments.
 - Field names allow `[A-Za-z0-9_-]` with dots for relation paths (`user.name`).
 - Inside an `elemMatch` interior, field paths are relative to the array element; the reserved `$this` marker (core's `ITSELF` constant) addresses the element itself. Outside an interior, `$this` is an error.
 
-The language mirrors the [condition helpers](/guide/building-queries#condition-helpers) one-to-one: `eq('name', 'John')` in code ≙ `eq(name, 'John')` on the wire.
+For the functions above, the language mirrors the [condition helpers](/guide/building-queries#condition-helpers): `eq('name', 'John')` in code ≙ `eq(name, 'John')` on the wire. The negated leaf helpers (`ne`, `notContains`, `notStartsWith`, `notEndsWith`) have no function spelling of their own (only `nin` does): write `not(eq(…))`, `not(contains(…))`, …, which normalize back to the twin on decode.
 
 ## Usage
 
@@ -56,10 +56,10 @@ const query = parser.parse({
 }, { schema: 'user' });
 ```
 
-Only the `filters` parameter uses the expression language — fields, relations, pagination and sort accept the same input as the [simple parser](/packages/parser-simple), and the whole thing returns the same [`Query`](/guide/query-ast).
+Only the `filters` parameter uses the expression language; fields, relations, pagination and sort accept the same input as the [simple parser](/packages/parser-simple), and the whole thing returns the same [`Query`](/guide/query-ast).
 
 There is also a standalone `parseFilters(input, options)` returning just the `Filters` node. For schemas with asynchronous filter validators, use `parseAsync()` / `parseFiltersAsync()` on the query parser, or `parseAsync()` / `parseExactAsync()` on `ExpressionFiltersParser`.
 
 ## Errors
 
-Syntax errors and schema violations throw `FiltersParseError` immediately — the expression parser has **no silent-drop mode** for malformed expressions. Malformed expressions carry `ErrorCode.SYNTAX_INVALID`; schema violations carry the key-related codes (`keyNotAllowed`, `keyPathInvalid`, …). See [Error Handling](/guide/errors).
+Syntax errors and schema violations throw `FiltersParseError` immediately: the expression parser has **no silent-drop mode** for malformed expressions. Malformed expressions carry `ErrorCode.SYNTAX_INVALID`; schema violations carry the key-related codes (`keyNotAllowed`, `keyPathInvalid`, …). See [Error Handling](/guide/errors).

--- a/packages/docs/packages/parser-mongo.md
+++ b/packages/docs/packages/parser-mongo.md
@@ -1,6 +1,6 @@
 # @rapiq/parser-mongo
 
-Parses MongoDB-style filter documents — useful when filters travel as structured JSON (request bodies, stored filters) or the calling application already speaks the [MongoDB query language](https://www.mongodb.com/docs/manual/reference/operator/query/). The dialect is input syntax only: the result is the same [`Query`](/guide/query-ast) every backend consumes — the receiving application does **not** need to run MongoDB.
+Parses MongoDB-style filter documents: useful when filters travel as structured JSON (request bodies, stored filters) or the calling application already speaks the [MongoDB query language](https://www.mongodb.com/docs/manual/reference/operator/query/). The dialect is input syntax only: the result is the same [`Query`](/guide/query-ast) every backend consumes; the receiving application does **not** need to run MongoDB.
 
 ```sh
 npm install @rapiq/core @rapiq/parser-simple @rapiq/parser-mongo
@@ -8,7 +8,7 @@ npm install @rapiq/core @rapiq/parser-simple @rapiq/parser-mongo
 
 ## The dialect
 
-Filters are plain objects with typed values — numbers stay numbers, there is no wire-string coercion (`Date` instances pass through into the AST as-is; ISO strings are **not** coerced to dates):
+Filters are plain objects with typed values: numbers stay numbers, there is no wire-string coercion (`Date` instances pass through into the AST as-is; ISO strings are **not** coerced to dates):
 
 ```typescript
 { name: 'John' }                                    // bare scalar → $eq
@@ -38,29 +38,29 @@ Multiple document entries combine with an implicit AND. `$and` / `$or` / `$nor` 
 | `$notEndsWith` † | `NOT_ENDS_WITH` | `ENDS_WITH` | string |
 | `$contains` † | `CONTAINS` | `NOT_CONTAINS` | string |
 | `$notContains` † | `NOT_CONTAINS` | `CONTAINS` | string |
-| `$regex` | `REGEX` | — (throws) | `RegExp` instance or pattern string |
-| `$options` | — (modifier) | — | flag string; only beside a string-valued `$regex` |
-| `$mod` | `MOD` | — (throws) | `[divisor, remainder]`, divisor ≠ 0 |
-| `$size` | `SIZE` | — (throws) | non-negative integer (array length) |
+| `$regex` | `REGEX` | none (throws) | `RegExp` instance or pattern string |
+| `$options` | none (modifier) | none | flag string; only beside a string-valued `$regex` |
+| `$mod` | `MOD` | none (throws) | `[divisor, remainder]`, divisor ≠ 0 |
+| `$size` | `SIZE` | none (throws) | non-negative integer (array length) |
 | `$exists` | `EXISTS` | boolean flag flipped | boolean |
-| `$elemMatch` | `ELEM_MATCH` | — (throws) | nested filter document (fields relative to the array element) or element-level operator object (operators apply to the element itself, via the `ITSELF` marker) |
-| `$all` | AND of `ELEM_MATCH` | — (throws) | non-empty array of scalar/`null`/`Date`; desugars to one independently scoped element match per value |
-| `$not` | negation | — (no nesting) | object of field-level operators |
+| `$elemMatch` | `ELEM_MATCH` | none (throws) | nested filter document (fields relative to the array element) or element-level operator object (operators apply to the element itself, via the `ITSELF` marker) |
+| `$all` | AND of `ELEM_MATCH` | none (throws) | non-empty array of scalar/`null`/`Date`; desugars to one independently scoped element match per value |
+| `$not` | negation | none (no nesting) | object of field-level operators |
 
-† **rapiq extension — not valid MongoDB.** These cover the substring matches MongoDB only reaches through `$regex`, mapping 1:1 to the AST operators every rapiq dialect shares.
+† **rapiq extension, not valid MongoDB.** These cover the substring matches MongoDB only reaches through `$regex`, mapping 1:1 to the AST operators every rapiq dialect shares.
 
 ::: warning Deviations from MongoDB
-- Nested plain objects expand to dotted key paths — `{ realm: { name: 'x' } }` ≡ `{ 'realm.name': 'x' }` — instead of MongoDB's exact-embedded-document match.
+- Nested plain objects expand to dotted key paths (`{ realm: { name: 'x' } }` ≡ `{ 'realm.name': 'x' }`) instead of MongoDB's exact-embedded-document match.
 - A bare array value means `$in` instead of MongoDB's exact-array match.
-- Negation is algebraic (De Morgan operator flipping) — it does not replicate MongoDB's missing-field semantics, where `$not` also matches documents lacking the field.
-- `$all` never falls back to plain equality on non-array fields — MongoDB's `{ tags: { $all: ['a'] } }` matches `tags: 'a'`, the rapiq desugar does not (element matches require a real array).
+- Negation is algebraic (De Morgan operator flipping); it does not replicate MongoDB's missing-field semantics, where `$not` also matches documents lacking the field.
+- `$all` never falls back to plain equality on non-array fields: MongoDB's `{ tags: { $all: ['a'] } }` matches `tags: 'a'`, the rapiq desugar does not (element matches require a real array).
 - `$where`, `$type` and the other evaluation/geo/bitwise operators are unsupported and throw.
-- MongoDB's `x` regex flag has no JavaScript equivalent — `$options: 'x'` is rejected.
+- MongoDB's `x` regex flag has no JavaScript equivalent, so `$options: 'x'` is rejected.
 - An empty sub-document `{}` inside a compound (MongoDB's match-all branch) is a grammar error.
 :::
 
 ::: warning Untrusted `$regex`
-`$regex` patterns pass through the parser verbatim — this is the only dialect that lets a client submit one. If filter documents come from untrusted clients and are evaluated in-process with [`@rapiq/adapter-memory`](/packages/adapter-memory), gate the operator with the schema's `filters.validate` hook — see the [regex trust model](/guide/filters#regex-trust-model).
+`$regex` patterns pass through the parser verbatim: this is the only dialect that lets a client submit one. If filter documents come from untrusted clients and are evaluated in-process with [`@rapiq/adapter-memory`](/packages/adapter-memory), gate the operator with the schema's `filters.validate` hook; see the [regex trust model](/guide/filters#regex-trust-model).
 :::
 
 ## Usage
@@ -92,7 +92,7 @@ const query = parser.parse({
 }, { schema: 'user' });
 ```
 
-Only the `filters` parameter uses the mongo dialect — fields, relations, pagination and sort accept the same input as the [simple parser](/packages/parser-simple), and the whole thing returns the same [`Query`](/guide/query-ast).
+Only the `filters` parameter uses the mongo dialect; fields, relations, pagination and sort accept the same input as the [simple parser](/packages/parser-simple), and the whole thing returns the same [`Query`](/guide/query-ast).
 
 There is also a standalone `MongoFiltersParser` returning just the `Filters` node; its `parseTyped(input, options)` accepts a `MongoFiltersParserInput<RECORD>`, so field keys and operator values are type-checked against the record type. For schemas with asynchronous filter validators, use `parseAsync()` or `parseTypedAsync()`.
 
@@ -100,9 +100,9 @@ There is also a standalone `MongoFiltersParser` returning just the `Filters` nod
 
 Failures fall into two classes:
 
-- **Grammar errors always throw** `FiltersParseError`, independent of the schema failure policy — unknown or misplaced `$`-operators, malformed operator values, invalid compound arrays, mixed operator and plain keys, non-object top-level input, documents nested deeper than 32 levels. A `$`-prefixed key is never a field name, so there is no silent-drop reading for a broken document; map these to a `400` response.
-- **Field-key / allow-list failures follow the schema policy** — dropped silently by default, thrown when `throwOnFailure` is set. A dropped field drops its whole entry, an `$elemMatch` subtree included.
+- **Grammar errors always throw** `FiltersParseError`, independent of the schema failure policy: unknown or misplaced `$`-operators, malformed operator values, invalid compound arrays, mixed operator and plain keys, non-object top-level input, documents nested deeper than 32 levels. A `$`-prefixed key is never a field name, so there is no silent-drop reading for a broken document; map these to a `400` response.
+- **Field-key / allow-list failures follow the schema policy**: dropped silently by default, thrown when `throwOnFailure` is set. A dropped field drops its whole entry, an `$elemMatch` subtree included.
 
-Absent input, `{}` and an all-dropped document are not failures — the schema's `filters.default` applies, like with the other parsers.
+Absent input, `{}` and an all-dropped document are not failures: the schema's `filters.default` applies, like with the other parsers.
 
 Error codes: malformed documents carry `ErrorCode.SYNTAX_INVALID`, invalid operator values `KEY_VALUE_INVALID`, non-object top-level input `INPUT_INVALID`, known-but-unsupported MongoDB operators (`$where`, `$type`, …) and non-negatable operators under `$not`/`$nor` (`$regex`, `$mod`, `$size`, `$elemMatch`, `$all`) `OPERATOR_UNSUPPORTED`. See [Error Handling](/guide/errors).

--- a/packages/docs/packages/parser-simple.md
+++ b/packages/docs/packages/parser-simple.md
@@ -1,12 +1,12 @@
 # @rapiq/parser-simple
 
-Parses plain object/array input — the URL-query-like "simple" dialect — into a [`Query`](/guide/query-ast). The [URL codec](/packages/codec-url) uses it for shared parameter parsing and legacy bracket-filter compatibility.
+Parses plain object/array input (the URL-query-like "simple" dialect) into a [`Query`](/guide/query-ast). The [URL codec](/packages/codec-url) uses it for shared parameter parsing and legacy bracket-filter compatibility.
 
 ```sh
 npm install @rapiq/core @rapiq/parser-simple
 ```
 
-**Reach for it directly when** your input already uses the canonical parameter keys (`fields`, `filters`, `pagination`, `relations`, `sort`) — e.g. a JSON request body or an internal call. For raw URL input, use [`@rapiq/codec-url`](/packages/codec-url) instead.
+**Reach for it directly when** your input already uses the canonical parameter keys (`fields`, `filters`, `pagination`, `relations`, `sort`), e.g. a JSON request body or an internal call. For raw URL input, use [`@rapiq/codec-url`](/packages/codec-url) instead.
 
 ## Usage
 
@@ -41,7 +41,8 @@ const query = parser.parse({
 |---|---|
 | `schema` | A `Schema` instance or the name of a registered schema. Omit to parse without validation. |
 | `strict` | Override the schema's [strict mode](/guide/schemas#strict-mode) for this call. |
-| `parameters` | Allow-list of parameters to parse, e.g. `['filters']`. A parameter not listed is neither parsed nor defaulted — the resulting `Query` leaves it empty, exactly as if neither input nor schema mentioned it. |
+| `parameters` | Allow-list of parameters to parse, e.g. `['filters']`. A parameter not listed is neither parsed nor defaulted: the resulting `Query` leaves it empty, exactly as if neither input nor schema mentioned it. |
+| `context` | Caller-defined value (e.g. the authenticated actor) forwarded to every [schema validate hook](/guide/schemas#validate-hooks-parse-context) this parse run invokes. Opaque to the parser; typing happens at the schema definition site (`defineSchema<RECORD, CONTEXT>`). |
 | `fields` / `filters` / `relations` / `pagination` / `sort` | Set to `false` to skip a parameter entirely. |
 
 If `filters.validate` may return a Promise, use `await parser.parseAsync(input, options)`. `parse()` remains synchronous for schemas whose validators are synchronous and throws `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER` if it encounters an async result.
@@ -53,7 +54,7 @@ A parameter absent from the input is still parsed, so schema defaults always app
 To keep schema defaults from materializing for parameters you do not intend to apply, mask them with the `parameters` option:
 
 ```typescript
-// a bulk delete must apply filters only — masking pagination keeps
+// a bulk delete must apply filters only: masking pagination keeps
 // the schema's maxLimit from silently truncating the row selection.
 const query = parser.parse(input, {
     schema: 'user',
@@ -61,21 +62,21 @@ const query = parser.parse(input, {
 });
 ```
 
-Masked-out relations do not gate relation paths in the other parameters — they resolve exactly as if the client had requested no relations.
+Masked-out relations do not gate relation paths in the other parameters; they resolve exactly as if the client had requested no relations.
 
 ## Input formats
 
 Per-parameter input shapes and the wire operator syntax are documented on the parameter pages:
 
-- [Fields](/guide/fields) — arrays, comma strings, `+`/`-` modifiers, per-relation records
-- [Filters](/guide/filters) — `!`, `<`, `<=`, `>`, `>=`, `~…~`, comma lists, `null`
-- [Pagination](/guide/pagination) — `{ limit, offset }`
-- [Relations](/guide/relations) — comma strings, arrays, dotted paths
-- [Sort](/guide/sort) — `-` prefix, comma lists, direction objects
+- [Fields](/guide/fields): arrays, comma strings, `+`/`-` modifiers, per-relation records
+- [Filters](/guide/filters): `!`, `<`, `<=`, `>`, `>=`, `~…~`, comma lists, `null`
+- [Pagination](/guide/pagination): `{ limit, offset }`
+- [Relations](/guide/relations): comma strings, arrays, dotted paths
+- [Sort](/guide/sort): `-` prefix, comma lists, direction objects
 
 ## Per-parameter parsers
 
-Each parameter also has a standalone parser class — `SimpleFieldsParser`, `SimpleFiltersParser`, `SimplePaginationParser`, `SimpleRelationsParser`, `SimpleSortParser` — with the same `(input, { schema })` signature, returning that parameter's AST node. Useful when only one parameter comes from user input. Every parser exposes `parseAsync()`; `SimpleFiltersParser` also exposes `parseTypedAsync()` alongside `parseTyped()`.
+Each parameter also has a standalone parser class (`SimpleFieldsParser`, `SimpleFiltersParser`, `SimplePaginationParser`, `SimpleRelationsParser`, `SimpleSortParser`) with the same `(input, { schema })` signature, returning that parameter's AST node. Useful when only one parameter comes from user input. Every parser exposes `parseAsync()`; `SimpleFiltersParser` also exposes `parseTypedAsync()` alongside `parseTyped()`.
 
 ### Typed filter input
 
@@ -100,11 +101,24 @@ const filters = filtersParser.parseTyped<User>({
 }, { schema: 'user' });
 ```
 
-Two deliberate gaps: the comparison family advertises no `!` spellings — a leading `!` before `<`/`>` markers is discarded on decode (a frozen v1 quirk) — and boolean fields accept no marker forms at all, only `true`/`false`/`null`/`'!null'`, because `'!true'` decodes to *not equal `true`*, which as an [exact complement](/guide/filters#null-semantics) also matches `null`/missing — it is not *equal `false`*.
+Two deliberate gaps: the comparison family advertises no `!` spellings (a leading `!` before `<`/`>` markers is discarded on decode, a frozen v1 quirk), and boolean fields accept no marker forms at all, only `true`/`false`/`null`/`'!null'`, because `'!true'` decodes to *not equal `true`*, which as an [exact complement](/guide/filters#null-semantics) also matches `null`/missing; it is not *equal `false`*.
 
 ::: info Widened in v2
-Earlier v2 betas hand-wrote this union with prefix spellings only — `~V~` (contains), `V~` (starts with) and their negated forms `!~V~` / `!V~` were compile-time errors, even though the wire grammar always decoded them. The union now derives from the wire table, so those spellings type-check. This is a type-level widening only: the wire format is byte-for-byte unchanged and stays v1-compatible.
+Earlier v2 betas hand-wrote this union with prefix spellings only: `~V~` (contains), `V~` (starts with) and their negated forms `!~V~` / `!V~` were compile-time errors, even though the wire grammar always decoded them. The union now derives from the wire table, so those spellings type-check. This is a type-level widening only: the wire format is byte-for-byte unchanged and stays v1-compatible.
 :::
+
+## Wire grammar API
+
+The filter value grammar itself is public: the single source for scalar coercion and operator-marker parsing shared by the parsers and the [URL codec](/packages/codec-url). Reach for it when a custom dialect or codec must stay byte-compatible with the simple wire format instead of re-implementing it; ordinary applications never touch it, the parser classes above consume it internally.
+
+| Export | Role |
+|---|---|
+| `FILTER_WIRE_SPEC` | The marker table: prefix/suffix spelling and value mode per positive operator. Declared order is decode precedence. `in`/`nin` own no rows; a comma-joined list is a value shape, lifted on decode. |
+| `FILTER_WIRE_NEGATION` | The `!` modifier. It binds only to operators with a complement twin in core's `FILTER_OPERATOR_SEMANTICS`; elsewhere a stripped `!` is discarded (frozen v1 quirk). |
+| `decodeFilterWireValue(input)` | Wire value in, verdict out (`FilterWireDecodeResult`): a decoded `{ operator, value }` condition or a failure code. Never throws; drop vs. throw stays the caller's policy. |
+| `encodeFilterWireValue(condition)` | Condition leaf in, wire token out. Throws typed errors for operators without a wire spelling and for values the dialect cannot express (commas, empties, marker collisions). |
+| `parseFilterScalar(input)` | The pure scalar coercion (`'18'` → `18`, `'true'` → `true`, `'null'` → `null`) shared by the simple and expression dialects. No comma splitting. |
+| `FilterWire*` types | `FilterWireCondition`, `FilterWireDecodeResult`, `FilterWireSpelling`, `FilterWireValueInput` and friends; the [typed filter input](#typed-filter-input) union derives from the same table. |
 
 ## Errors
 

--- a/packages/parser-simple/test/unit/parser/pagination.spec.ts
+++ b/packages/parser-simple/test/unit/parser/pagination.spec.ts
@@ -6,7 +6,8 @@
  */
 
 import {
-    PaginationParseError, 
+    ErrorCode,
+    PaginationParseError,
     defineSchema,
 } from '@rapiq/core';
 import type { Pagination } from '@rapiq/core';
@@ -68,6 +69,7 @@ describe('src/pagination/index.ts', () => {
         });
 
         const error = PaginationParseError.limitExceeded(50);
+        expect(error.code).toBe(ErrorCode.LIMIT_EXCEEDED);
 
         expect(() => parser.parse({ limit: 100 }, { schema })).toThrow(error);
     });


### PR DESCRIPTION
## What

Everything surfaced by the pre-release docs audit, in three layers.

### Code

- **core**: `Filters.and()`/`or()` on an empty receiver returned the injected conditions as a flat root-AND, so a later `merge()` could silently displace a scoping condition injected onto a query that carried no filters. The injected conditions now land in a nested group; the wrap-and-inject guarantee is unconditional and a hostile replace-merge throws `FILTERS_NOT_FLAT`. Injecting nothing returns the receiver.
- **adapter-prisma / adapter-drizzle**: finish the #868 move; `caseSensitive` is now genuinely top-level on the constructor and execute options of both serializer adapters (the #868 commit assumed it already was, but both nested it under a `filters` wrapper). The docs claim and the code now agree.
- **core**: `PaginationParseError.limitExceeded` carried the default `NONE` code; it now throws `ErrorCode.LIMIT_EXCEEDED`.

### Docs: audit fixes

- README build sample used invalid filter input (`gte(18)` as a field value); the execute row now names the memory adapter.
- Landing surfaces (hero, feature grid, code tabs, pipeline figure, site description) cover all five adapters and three parser dialects, teach `defineQuery` and show the stamped expression wire v2 actually writes.
- `guide/filters.md` states operator support honestly per backend (prisma/drizzle raise typed errors for regex/mod/size/ITSELF instead of approximating); the expression-keyword claim about negated helpers is corrected.
- `adapter-typeorm` page drops the removed `visitor` execute wrapper; the prisma/drizzle pages document the real `caseSensitive` surface plus the schema-to-adapter forwarding step.
- relations/sort document their `validate`/`validateMany` hooks (including the traversal gating); fields and codec-url document the `$root` wire token; parser-simple documents the `context` option and the filter wire-grammar exports; core documents the plan layer; schemas regenerates the `describe()` example from its own schema; errors gains the missing `OPERATOR_UNSUPPORTED`/`LIMIT_EXCEEDED` rows.
- Broken heading anchors repaired, `integrations/url.md` redirects like its siblings, the docs workspace README is excluded from the site build, and every em/en dash is gone from the published prose.

### Docs: recipes as one story

The recipes section now reads as chapters of one storyline over a single realm/user API, so a reader sees how the packages compose by watching one layer swap per chapter: overview map, frontend (client layer), Express & TypeORM (server baseline), **new** Prisma & Drizzle chapter (execute layer swap), **new** MongoDB-style search endpoint (input dialect swap), **new** memory-adapter testing chapter (database swap), authorization (cross-cutting).

## Verification

- Full build and test suite green across all packages.
- VitePress build green with dead-link checking; heading anchors verified against the built HTML.
- Every audit finding re-verified as resolved against the working tree; new recipe code samples checked against the package barrels and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable case-sensitive filtering for Prisma and Drizzle, including per-query overrides.
  * Added a dedicated error code for pagination limits exceeded.
  * Added documentation and recipes for MongoDB-style searches, Prisma/Drizzle backends, and in-memory testing.

* **Bug Fixes**
  * Improved filter combination behavior to preserve injected conditions and prevent unsafe replacements.
  * Clarified and expanded adapter, query, validation, pagination, and authorization guidance.

* **Documentation**
  * Refreshed navigation, examples, supported adapter details, and API usage throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->