### PR TITLE
fix: close pre-GA decode-hardening gaps

### DIFF
--- a/packages/codec-url/src/decoder/module.ts
+++ b/packages/codec-url/src/decoder/module.ts
@@ -5,7 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { parse } from 'qs';
 import type {
     BaseQueryParser,
     IFields,
@@ -25,6 +24,7 @@ import {
     isPropertySet,
 } from '@rapiq/core';
 import { URLParameter, URL_FIELDS_ROOT } from '../constants';
+import { parseQueryString } from '../utils';
 
 /**
  * Wire name → canonical parameter of the shared URL grammar.
@@ -112,7 +112,7 @@ export abstract class BaseURLDecoder {
         input: string,
         options: ParseParameterOptions = {},
     ) : IFields | null {
-        const output = parse(input);
+        const output = parseQueryString(input);
         if (!isObject(output)) {
             return null;
         }
@@ -131,7 +131,7 @@ export abstract class BaseURLDecoder {
         input: string,
         options: ParseParameterOptions = {},
     ) : IFilters | null {
-        const output = parse(input);
+        const output = parseQueryString(input);
         if (!isObject(output)) {
             return null;
         }
@@ -150,7 +150,7 @@ export abstract class BaseURLDecoder {
         input: string,
         options: ParseParameterOptions = {},
     ) : Promise<IFilters | null> {
-        const output = parse(input);
+        const output = parseQueryString(input);
         if (!isObject(output)) {
             return null;
         }
@@ -166,7 +166,7 @@ export abstract class BaseURLDecoder {
         input: string,
         options: ParseParameterOptions = {},
     ) : IPagination | null {
-        const output = parse(input);
+        const output = parseQueryString(input);
         if (!isObject(output)) {
             return null;
         }
@@ -182,7 +182,7 @@ export abstract class BaseURLDecoder {
         input: string,
         options: ParseParameterOptions = {},
     ) : IRelations | null {
-        const output = parse(input);
+        const output = parseQueryString(input);
         if (!isObject(output)) {
             return null;
         }
@@ -198,7 +198,7 @@ export abstract class BaseURLDecoder {
         input: string,
         options: ParseParameterOptions = {},
     ) : ISorts | null {
-        const output = parse(input);
+        const output = parseQueryString(input);
         if (!isObject(output)) {
             return null;
         }
@@ -225,7 +225,7 @@ export abstract class BaseURLDecoder {
     }
 
     protected prepare(input: string | ObjectLiteral) : ObjectLiteral | null {
-        const parsed = typeof input === 'string' ? parse(input) : input;
+        const parsed = typeof input === 'string' ? parseQueryString(input) : input;
         if (!isObject(parsed)) {
             return null;
         }

--- a/packages/codec-url/src/module.ts
+++ b/packages/codec-url/src/module.ts
@@ -11,8 +11,8 @@ import type {
     ObjectLiteral,
     ParseQueryOptions,
 } from '@rapiq/core';
-import { parse } from 'qs';
 import { CODEC_PARAMETER } from './constants';
+import { parseQueryString } from './utils';
 import type {
     URLCodecDefinition,
     URLCodecEncodeOptions,
@@ -127,7 +127,7 @@ export class URLCodec {
         codec: URLCodecDefinition,
         payload: ObjectLiteral,
     } | null {
-        const parsed = typeof input === 'string' ? parse(input) : input;
+        const parsed = typeof input === 'string' ? parseQueryString(input) : input;
         if (!isObject(parsed)) {
             return null;
         }

--- a/packages/codec-url/src/utils/index.ts
+++ b/packages/codec-url/src/utils/index.ts
@@ -7,3 +7,4 @@
 
 export * from './encode';
 export * from './fields';
+export * from './parse';

--- a/packages/codec-url/src/utils/parse.ts
+++ b/packages/codec-url/src/utils/parse.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { parse } from 'qs';
+
+/**
+ * qs treats a leading `?` as part of the first key name, so a caller
+ * passing `url.search` verbatim would silently lose every parameter
+ * (`?filter` is not a known wire key). Strip a single leading `?`
+ * before parsing — the same tolerance URLSearchParams applies.
+ */
+export function parseQueryString(input: string) : unknown {
+    return parse(input.charAt(0) === '?' ? input.substring(1) : input);
+}

--- a/packages/codec-url/test/unit/codec.spec.ts
+++ b/packages/codec-url/test/unit/codec.spec.ts
@@ -92,6 +92,31 @@ describe('URLCodec', () => {
         expect(decoded!.filters).toEqual(new Filters('and', [eq('name', 'John')]));
     });
 
+    it('should tolerate a leading question mark', () => {
+        // a caller passing `url.search` verbatim: qs would read `?filter`
+        // as the first key name and silently lose every parameter
+        const decoded = codec.decode('?filter[name]=John&sort=-name');
+
+        expect(decoded!.filters).toEqual(new Filters('and', [eq('name', 'John')]));
+        expect(decoded!.sorts.value).toHaveLength(1);
+    });
+
+    it('should tolerate a leading question mark on a stamped payload', () => {
+        const query = defineQuery({ filters: or(eq('name', 'John'), gte('age', 18)) });
+
+        const decoded = codec.decode(`?${codec.encode(query)!}`);
+
+        expect(decoded!.filters).toEqual(or(eq('name', 'John'), gte('age', 18)));
+    });
+
+    it('should strip only a single leading question mark', () => {
+        // `??filter` is not a recoverable url.search shape — the second
+        // `?` stays part of the key and the parameter is not recognized
+        const decoded = codec.decode('??filter[name]=John');
+
+        expect(decoded!.filters.value).toHaveLength(0);
+    });
+
     it('should omit the identity stamp on request', () => {
         const query = defineQuery({ filters: { name: 'John' } });
 

--- a/packages/codec-url/test/unit/simple-pagination.spec.ts
+++ b/packages/codec-url/test/unit/simple-pagination.spec.ts
@@ -8,6 +8,7 @@
 import {
     AdapterError,
     Pagination,
+    ParseError,
 } from '@rapiq/core';
 import { SimpleURLDecoder, SimpleURLEncoder } from '../../src/simple';
 
@@ -54,6 +55,24 @@ describe('pagination', () => {
         const decoded = decoder.decodePagination('?page[limit]=50');
 
         expect(decoded).toEqual(new Pagination(50, 0));
+    });
+
+    it('should reject a prototype-member pagination key that survives qs', () => {
+        // qs drops `__proto__`/`constructor` bracket keys itself (they are
+        // Object.prototype members), but keeps `prototype` under a safe
+        // parent — the parser-level guard catches that residue on the wire
+        expect(() => decoder.decodePagination('page[a][prototype][x]=1'))
+            .toThrowError(ParseError);
+    });
+
+    it('should fall back to defaults for hostile keys qs already dropped', () => {
+        // `__proto__`/`constructor` bracket structures never leave qs, so
+        // the parser sees an absent parameter — defaults, no pollution
+        const decoded = decoder.decodePagination('page[__proto__][polluted]=1');
+
+        expect(decoded).toEqual(new Pagination());
+        const probe: Record<string, unknown> = {};
+        expect(probe.polluted).toBeUndefined();
     });
 
     it('should throw for a zero or non-integer limit (outside the wire subset)', () => {

--- a/packages/codec-url/test/unit/simple-pagination.spec.ts
+++ b/packages/codec-url/test/unit/simple-pagination.spec.ts
@@ -48,6 +48,14 @@ describe('pagination', () => {
         expect(value).toEqual(decoded);
     });
 
+    it('should tolerate a leading question mark', () => {
+        // the parameter helpers share the main decode path's `url.search`
+        // tolerance — a single leading `?` is stripped before qs parsing
+        const decoded = decoder.decodePagination('?page[limit]=50');
+
+        expect(decoded).toEqual(new Pagination(50, 0));
+    });
+
     it('should throw for a zero or non-integer limit (outside the wire subset)', () => {
         expect(() => encoder.encodePagination(new Pagination(0)))
             .toThrowError(AdapterError);

--- a/packages/core/src/parser/base.ts
+++ b/packages/core/src/parser/base.ts
@@ -106,6 +106,34 @@ export abstract class BaseParser<
         return output;
     }
 
+    /**
+     * Reject an input object carrying a key whose path addresses an
+     * inherited prototype member. A parameter parser that never expands
+     * or groups its keys (pagination) does not run the hardened helpers
+     * above, but must not accept such keys silently either — the guard
+     * contract is uniform across every parameter. Nesting is bounded by
+     * the shared traversal depth for the same reason as `expandObject`.
+     */
+    protected assertSafeObjectKeys(
+        input: Record<string, any>,
+        depth = 0,
+    ) {
+        const keys = Object.keys(input);
+        for (const key of keys) {
+            if (depth + key.split('.').length > MAX_TRAVERSAL_DEPTH) {
+                throw ParseError.inputInvalid();
+            }
+
+            if (isUnsafeKey(key)) {
+                throw ParseError.inputInvalid();
+            }
+
+            if (isObject(input[key])) {
+                this.assertSafeObjectKeys(input[key], depth + key.split('.').length);
+            }
+        }
+    }
+
     protected groupObject(input: Record<string, any>) {
         const output : TempType = {
             attributes: Object.create(null),

--- a/packages/core/src/parser/parameter/filters/types.ts
+++ b/packages/core/src/parser/parameter/filters/types.ts
@@ -14,6 +14,13 @@ export type FiltersParseOptions<
 > = {
     relations?: Relations,
     schema?: string | Schema<RECORD> | FiltersSchema<RECORD>,
+    /**
+     * Throw on a key resolution failure instead of dropping the key.
+     * Honored by the simple and mongo dialects. The expression dialect
+     * IGNORES it and always throws: an expression cannot be partially
+     * reinterpreted safely — pruning a leaf inside `or(...)` would
+     * change the compound's meaning rather than narrow it.
+     */
     throwOnFailure?: boolean,
     strict?: boolean,
     context?: unknown,

--- a/packages/parser-simple/src/parameter/pagination/module.ts
+++ b/packages/parser-simple/src/parameter/pagination/module.ts
@@ -50,6 +50,11 @@ export class SimplePaginationParser<
             return this.finalizePagination(output, schema, throwOnFailure);
         }
 
+        // pagination performs no key grouping, so the prototype-member
+        // guard the grouping helpers apply elsewhere runs explicitly —
+        // a hostile key is rejected typed, not ignored.
+        this.assertSafeObjectKeys(input);
+
         let { limit, offset } = input as Record<string, any>;
 
         if (typeof limit !== 'undefined') {

--- a/packages/parser-simple/test/unit/parser/prototype-pollution.spec.ts
+++ b/packages/parser-simple/test/unit/parser/prototype-pollution.spec.ts
@@ -92,6 +92,37 @@ describe('src/parameter (prototype pollution)', () => {
         expect(({} as any).a).toBeUndefined();
     });
 
+    it.each(HOSTILE)('should not pollute via a %s pagination key', (prefix) => {
+        const before = propertyCount();
+
+        // pagination never groups its keys, so the guard runs explicitly
+        // in the parser: a hostile key is rejected typed, not ignored
+        expect(() => parser.parse({ pagination: { [prefix]: { polluted: '1' } } }))
+            .toThrow(ParseError);
+
+        expect(propertyCount()).toBe(before);
+        expect(({} as any).polluted).toBeUndefined();
+    });
+
+    it('should not pollute via a nested hostile pagination key', () => {
+        const before = propertyCount();
+
+        // a computed key is an OWN property (unlike a bare `__proto__`
+        // literal, which JS neutralizes before the parser ever sees it)
+        expect(() => parser.parse({ pagination: { limit: { ['__proto__']: { polluted: '1' } } } }))
+            .toThrow(ParseError);
+
+        expect(propertyCount()).toBe(before);
+        expect(({} as any).polluted).toBeUndefined();
+    });
+
+    it('should still parse legitimate pagination input', () => {
+        const output = parser.parse({ pagination: { limit: 10, offset: 5 } });
+
+        expect(output.pagination.limit).toEqual(10);
+        expect(output.pagination.offset).toEqual(5);
+    });
+
     it('should still parse a legitimate grouped sort key', () => {
         const output = parser.parse({ sort: ['0:name'] });
 


### PR DESCRIPTION
Closes the pre-GA gaps surfaced while validating the FLAME hub against `2.0.0-beta.19` (all hub suites green on the beta — these are the residual findings).

## Pagination joins the prototype-member key guard

Pagination was the one parameter the #883 hardening did not cover: it never expands or groups its keys, so a hostile `page` key was silently ignored rather than rejected. `BaseParser` gains `assertSafeObjectKeys()` (depth-bounded like `expandObject`), and `SimplePaginationParser.parse` runs it explicitly — a pagination key with a `__proto__`/`constructor`/`prototype` segment now raises the same typed `ParseError` as the other four parameters, in both dialects.

**BREAKING**: such keys previously parsed (ignored); they now throw. Legitimate clients are unaffected.

## `url.search` tolerance on decode

`codec.decode('?filter[name]=a')` decoded to an **empty query** — qs reads `?filter` as the first key name, so every parameter was silently lost. A single leading `?` is now stripped before parsing (the tolerance `URLSearchParams` applies), shared by the facade's stamp dispatch, the dialect decoders and every per-parameter helper — so dialect detection and decoding see the same payload. `??filter` stays unrecognized: only one `?` is stripped.

## `throwOnFailure` doc on the expression exception

The dialect asymmetry on disallowed filter keys (simple prunes per the schema's drop-vs-throw policy; expression always throws) is deliberate and documented in the guide — but `FiltersParseOptions.throwOnFailure` itself did not say the expression parser ignores it. The option's declaration now states the exception and its rationale, so a caller passing `throwOnFailure: false` to the expression parser is not left wondering why nothing changed.

## Verification

- Full monorepo `npm run build` + `npm run test` green on this branch (10 test projects).
- New pins: hostile pagination keys across both dialects incl. the `N:`-prefixed and nested own-property forms, no-pollution negative controls, `?`-tolerance on stamped/unstamped payloads and the `decodePagination` helper, single-`?`-only semantics.
- Downstream: FLAME hub runs `2.0.0-beta.19` with its own capability suite pinning the guard, the 400 mapping, and the codec round trip (PrivateAIM/hub@116dbdb50).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - URL query parsing now consistently handles a single leading `?` across decoding, filtering, sorting, relationships, and pagination.
  - Pagination input rejects unsafe object keys and deeply nested paths, preventing prototype pollution while preserving valid `limit` and `offset` parsing.

- **Security**
  - Added recursive validation for parsed object keys to block hostile property names and excessive traversal depth.

- **Documentation**
  - Clarified failure-handling behavior for filter expressions.

- **Tests**
  - Added coverage for leading-question-mark handling, stamped payloads, pagination, and prototype-pollution protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->