### PR TITLE
chore: flip the release line to stable 2.0.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ npm run dev --workspace=packages/docs     # run the docs site locally
 npm run build --workspace=packages/docs   # build the docs site
 ```
 
-Note: the root `README.md` documents the upcoming v2; v1 lives on the `v1` branch.
+Note: the root `README.md` documents v2; v1 lives on the `v1` branch.
 
 ## Detailed Guides
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@
 
 ---
 
-> [!WARNING]
-> This README includes the documentation for the upcoming version 2.
->
-> This is the [link](https://github.com/tada5hi/rapiq/tree/v1) for the v1 (and prior).
+> [!NOTE]
+> The documentation for v1 (and prior) lives on the [v1 branch](https://github.com/tada5hi/rapiq/tree/v1).
 
 ## Why rapiq?
 

--- a/packages/adapter-drizzle/package.json
+++ b/packages/adapter-drizzle/package.json
@@ -43,7 +43,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/adapter-memory/package.json
+++ b/packages/adapter-memory/package.json
@@ -40,7 +40,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/adapter-prisma/package.json
+++ b/packages/adapter-prisma/package.json
@@ -46,7 +46,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/adapter-sql/package.json
+++ b/packages/adapter-sql/package.json
@@ -38,7 +38,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/adapter-typeorm/package.json
+++ b/packages/adapter-typeorm/package.json
@@ -54,7 +54,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/codec-url/package.json
+++ b/packages/codec-url/package.json
@@ -45,7 +45,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,7 +31,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/docs/guide/index.md
+++ b/packages/docs/guide/index.md
@@ -98,8 +98,8 @@ See the [package overview](/packages/) for the full map and a "which packages do
 
 It deliberately does **not** define the response format, replace your ORM, or generate endpoints; it only standardizes what a query *is* and what a client *may* ask for.
 
-::: warning Version 2
-These docs cover the upcoming **version 2**, which splits the former single `rapiq` package into focused `@rapiq/*` packages. The v1 documentation lives on the [v1 branch](https://github.com/tada5hi/rapiq/tree/v1); see [Migration from v1](/guide/migration-v1).
+::: info Version 2
+These docs cover **version 2**, which splits the former single `rapiq` package into focused `@rapiq/*` packages. The v1 documentation lives on the [v1 branch](https://github.com/tada5hi/rapiq/tree/v1); see [Migration from v1](/guide/migration-v1).
 :::
 
 ## Next steps

--- a/packages/parser-expression/package.json
+++ b/packages/parser-expression/package.json
@@ -39,7 +39,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/parser-mongo/package.json
+++ b/packages/parser-mongo/package.json
@@ -39,7 +39,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/packages/parser-simple/package.json
+++ b/packages/parser-simple/package.json
@@ -37,7 +37,7 @@
     "license": "MIT",
     "publishConfig": {
         "access": "public",
-        "tag": "beta"
+        "tag": "latest"
     },
     "keywords": [
         "query",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,8 +1,5 @@
 {
     "include-component-in-tag": true,
-    "prerelease": true,
-    "prerelease-type": "beta",
-    "versioning": "prerelease",
     "release-type": "node",
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,


### PR DESCRIPTION
Executes the GA flip (plan 028 section 1): everything moves in one PR so the next release publishes correctly.

- `release-please-config.json`: drop `prerelease`, `prerelease-type` and `versioning: "prerelease"` so release-please proposes `2.0.0` instead of another beta.
- `publishConfig.tag`: `beta` to `latest` in all ten public package manifests, so the `2.0.0` publish owns the `latest` dist-tag.
- Root `README.md`: the "upcoming version 2" warning callout becomes a plain v1 branch pointer.
- `packages/docs/guide/index.md`: the version 2 callout no longer says "upcoming".
- `AGENTS.md`: same wording fix.

Preconditions verified today: all ten packages are published at `2.0.0-beta.20` with `latest` == `beta`; drizzle-orm still has no stable 1.0 (`rc` == `1.0.0-rc.4` == the repo pin), so the adapter-drizzle precondition is satisfied by absence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to identify Version 2 as current.
  - Added guidance for accessing Version 1 and earlier documentation.
  - Changed the Version 2 notice from a warning to an informational callout.

- **Release Management**
  - Packages now publish under the `latest` channel instead of `beta`.
  - Removed beta prerelease configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->