### PR TITLE
fix(core): restamp sub-schemas when a schema name is reassigned

### DIFF
--- a/packages/core/src/schema/module.ts
+++ b/packages/core/src/schema/module.ts
@@ -132,6 +132,32 @@ export class Schema<
     // ---------------------------------------------------------
 
     /**
+     * Reassigning the name restamps every sub-schema, which the
+     * constructor otherwise does once. A sub-schema reaches back into
+     * the registry by the name it carries, so a stale one would resolve
+     * to the schema this one used to be.
+     */
+    override set name(input: string | undefined) {
+        super.name = input;
+
+        this.propagateName();
+    }
+
+    override get name() : string | undefined {
+        return super.name;
+    }
+
+    private propagateName() {
+        this.fields.name = this.options.name;
+        this.filters.name = this.options.name;
+        this.pagination.name = this.options.name;
+        this.relations.name = this.options.name;
+        this.sorts.name = this.options.name;
+    }
+
+    // ---------------------------------------------------------
+
+    /**
      * Serialize the declared constraints of every (selected)
      * parameter into a JSON-safe {@link SchemaDescription}. The
      * relation target map is composed here, since the schema

--- a/packages/core/test/unit/schema/schema.spec.ts
+++ b/packages/core/test/unit/schema/schema.spec.ts
@@ -10,6 +10,7 @@ import {
     FiltersSchema,
     PaginationSchema,
     RelationsSchema,
+    SchemaRegistry,
     SortSchema,
     defineFieldsSchema,
     defineSchema,
@@ -111,6 +112,52 @@ describe('src/schema/*.ts', () => {
 
             expect(schema.fields.strict).toBe(false);
             expect(schema.filters.strict).toBe(true);
+        });
+    });
+
+    describe('name', () => {
+        it('should restamp every sub-schema when the name is reassigned', () => {
+            const schema = defineSchema<User>({ name: 'before' });
+
+            schema.name = 'after';
+
+            expect(schema.name).toBe('after');
+            expect(schema.fields.name).toBe('after');
+            expect(schema.filters.name).toBe('after');
+            expect(schema.pagination.name).toBe('after');
+            expect(schema.relations.name).toBe('after');
+            expect(schema.sorts.name).toBe('after');
+        });
+
+        it('should restamp every sub-schema when a name is assigned for the first time', () => {
+            const schema = defineSchema<User>({});
+
+            schema.name = 'user';
+
+            expect(schema.fields.name).toBe('user');
+            expect(schema.sorts.name).toBe('user');
+        });
+
+        it('should clear the sub-schema name when the name is unset', () => {
+            const schema = defineSchema<User>({ name: 'user' });
+
+            schema.name = undefined;
+
+            expect(schema.name).toBeUndefined();
+            expect(schema.fields.name).toBeUndefined();
+            expect(schema.sorts.name).toBeUndefined();
+        });
+
+        it('should let a renamed schema resolve through the registry again', () => {
+            const registry = new SchemaRegistry();
+            const schema = defineSchema<User>({ name: 'before' });
+
+            schema.name = 'after';
+            registry.add(schema);
+
+            // the sub-schema names are what a ResolutionScope resolves back through
+            expect(registry.get(schema.fields.name as string)).toBe(schema);
+            expect(registry.get(schema.sorts.name as string)).toBe(schema);
         });
     });
 });


### PR DESCRIPTION
Found while prototyping the registration-name work in #908, which is closed and deferred. This half is a standalone bug on `master` today, so it is split out on its own.

## The bug

`Schema` propagates its name to the five sub-schemas in `extendSchemasOptions()`, which runs once, from the constructor. The `name` setter inherited from `BaseSchema` is public, so assigning it afterwards leaves them behind:

```typescript
const schema = defineSchema({ name: 'before' });
schema.name = 'after';

schema.name;            // 'after'
schema.fields.name;     // 'before'
```

That is not cosmetic. A sub-schema reaches back into the registry by the name it carries:

- `ResolutionScope.for()` resolves the record anchor with `registry.get(parameterSchema.name)` (`schema/resolver/module.ts:251`)
- `resolveBase()` does the same (`:637`)

So a stale name resolves to the schema this one used to be, or to nothing at all, and a renamed schema silently loses the anchor its relation-authorization obligations hang off. Nothing in the repo renames a schema post-construction today, which is why no test caught it, but the setter is public API.

## The fix

The setter is overridden on `Schema` to restamp the sub-schemas, including when the name is unset, so a sub-schema always mirrors the schema it belongs to.

## Tests

Four cases in `packages/core/test/unit/schema/schema.spec.ts`, all failing before the fix:

- reassigning a name restamps all five sub-schemas
- assigning a name for the first time (constructed without one) propagates
- unsetting the name clears it on the sub-schemas rather than leaving a stale one
- a renamed schema resolves back through the registry by its sub-schema names, which is the actual consequence rather than a property assertion

## Verification

643 core tests pass (639 before), all ten packages' test targets pass, `tsc --noEmit` clean, eslint clean on both changed files.

No API change: the accessor pair keeps `BaseSchema`'s signature, so this is behavior-only and additive to nothing.
