### PR TITLE
feat(codec-url): complete the per-parameter async mirror on the decoder and encoders

### DIFF
--- a/packages/codec-url/src/decoder/module.ts
+++ b/packages/codec-url/src/decoder/module.ts
@@ -127,6 +127,25 @@ export abstract class BaseURLDecoder {
         return this.parser.parseFields(normalizeFieldsWireInput(output), options);
     }
 
+    async decodeFieldsAsync(
+        input: string,
+        options: ParseParameterOptions = {},
+    ) : Promise<IFields | null> {
+        const output = parseQueryString(input);
+        if (!isObject(output)) {
+            return null;
+        }
+
+        if (isPropertySet(output, URLParameter.FIELDS)) {
+            return this.parser.parseFieldsAsync(
+                normalizeFieldsWireInput(output[URLParameter.FIELDS]),
+                options,
+            );
+        }
+
+        return this.parser.parseFieldsAsync(normalizeFieldsWireInput(output), options);
+    }
+
     decodeFilters(
         input: string,
         options: ParseParameterOptions = {},
@@ -178,6 +197,22 @@ export abstract class BaseURLDecoder {
         return this.parser.parsePagination(output, options);
     }
 
+    async decodePaginationAsync(
+        input: string,
+        options: ParseParameterOptions = {},
+    ) : Promise<IPagination | null> {
+        const output = parseQueryString(input);
+        if (!isObject(output)) {
+            return null;
+        }
+
+        if (isPropertySet(output, URLParameter.PAGINATION)) {
+            return this.parser.parsePaginationAsync(output[URLParameter.PAGINATION], options);
+        }
+
+        return this.parser.parsePaginationAsync(output, options);
+    }
+
     decodeRelations(
         input: string,
         options: ParseParameterOptions = {},
@@ -194,6 +229,22 @@ export abstract class BaseURLDecoder {
         return this.parser.parseRelations(output, options);
     }
 
+    async decodeRelationsAsync(
+        input: string,
+        options: ParseParameterOptions = {},
+    ) : Promise<IRelations | null> {
+        const output = parseQueryString(input);
+        if (!isObject(output)) {
+            return null;
+        }
+
+        if (isPropertySet(output, URLParameter.RELATIONS)) {
+            return this.parser.parseRelationsAsync(output[URLParameter.RELATIONS], options);
+        }
+
+        return this.parser.parseRelationsAsync(output, options);
+    }
+
     decodeSorts(
         input: string,
         options: ParseParameterOptions = {},
@@ -208,6 +259,22 @@ export abstract class BaseURLDecoder {
         }
 
         return this.parser.parseSorts(output, options);
+    }
+
+    async decodeSortsAsync(
+        input: string,
+        options: ParseParameterOptions = {},
+    ) : Promise<ISorts | null> {
+        const output = parseQueryString(input);
+        if (!isObject(output)) {
+            return null;
+        }
+
+        if (isPropertySet(output, URLParameter.SORT)) {
+            return this.parser.parseSortsAsync(output[URLParameter.SORT], options);
+        }
+
+        return this.parser.parseSortsAsync(output, options);
     }
 
     // --------------------------------------------------

--- a/packages/codec-url/src/expression/encoder/module.ts
+++ b/packages/codec-url/src/expression/encoder/module.ts
@@ -110,6 +110,10 @@ export class ExpressionURLEncoder {
         return this.simple.encodeFields(input, options);
     }
 
+    encodeFieldsAsync(input: IFields, options: ParseParameterOptions = {}) {
+        return this.simple.encodeFieldsAsync(input, options);
+    }
+
     encodeFilters(input: IFilters, options: ParseParameterOptions = {}) : string | null {
         const encoded = this.serializeFilters(input);
         if (encoded === null || !isSchemaAware(options)) {
@@ -145,12 +149,24 @@ export class ExpressionURLEncoder {
         return this.simple.encodePagination(input, options);
     }
 
+    encodePaginationAsync(input: IPagination, options: ParseParameterOptions = {}) {
+        return this.simple.encodePaginationAsync(input, options);
+    }
+
     encodeRelations(input: IRelations, options: ParseParameterOptions = {}) {
         return this.simple.encodeRelations(input, options);
     }
 
+    encodeRelationsAsync(input: IRelations, options: ParseParameterOptions = {}) {
+        return this.simple.encodeRelationsAsync(input, options);
+    }
+
     encodeSorts(input: ISorts, options: ParseParameterOptions = {}) {
         return this.simple.encodeSorts(input, options);
+    }
+
+    encodeSortsAsync(input: ISorts, options: ParseParameterOptions = {}) {
+        return this.simple.encodeSortsAsync(input, options);
     }
 
     // --------------------------------------------------

--- a/packages/codec-url/src/simple/encoder/module.ts
+++ b/packages/codec-url/src/simple/encoder/module.ts
@@ -126,6 +126,27 @@ export class SimpleURLEncoder {
         return this.runSerializer(this.visitor.visitFields(stripFieldConditions(decoded)));
     }
 
+    async encodeFieldsAsync(
+        input: IFields,
+        options: ParseParameterOptions = {},
+    ) : Promise<string | null> {
+        this.visitor.reset();
+
+        const encoded = this.runSerializer(this.visitor.visitFields(input));
+        if (encoded === null || !isSchemaAware(options)) {
+            return encoded;
+        }
+
+        const decoded = await this.decoder.decodeFieldsAsync(encoded, options);
+        if (!decoded) {
+            return null;
+        }
+
+        this.visitor.reset();
+
+        return this.runSerializer(this.visitor.visitFields(stripFieldConditions(decoded)));
+    }
+
     encodeField(input: IField) {
         this.visitor.reset();
 
@@ -195,6 +216,27 @@ export class SimpleURLEncoder {
         return this.runSerializer(this.visitor.visitPagination(decoded));
     }
 
+    async encodePaginationAsync(
+        input: IPagination,
+        options: ParseParameterOptions = {},
+    ) : Promise<string | null> {
+        this.visitor.reset();
+
+        const encoded = this.runSerializer(this.visitor.visitPagination(input));
+        if (encoded === null || !isSchemaAware(options)) {
+            return encoded;
+        }
+
+        const decoded = await this.decoder.decodePaginationAsync(encoded, options);
+        if (!decoded) {
+            return null;
+        }
+
+        this.visitor.reset();
+
+        return this.runSerializer(this.visitor.visitPagination(decoded));
+    }
+
     encodeRelations(input: IRelations, options: ParseParameterOptions = {}) {
         this.visitor.reset();
 
@@ -213,6 +255,27 @@ export class SimpleURLEncoder {
         return this.runSerializer(this.visitor.visitRelations(decoded));
     }
 
+    async encodeRelationsAsync(
+        input: IRelations,
+        options: ParseParameterOptions = {},
+    ) : Promise<string | null> {
+        this.visitor.reset();
+
+        const encoded = this.runSerializer(this.visitor.visitRelations(input));
+        if (encoded === null || !isSchemaAware(options)) {
+            return encoded;
+        }
+
+        const decoded = await this.decoder.decodeRelationsAsync(encoded, options);
+        if (!decoded) {
+            return null;
+        }
+
+        this.visitor.reset();
+
+        return this.runSerializer(this.visitor.visitRelations(decoded));
+    }
+
     encodeSorts(input: ISorts, options: ParseParameterOptions = {}) {
         this.visitor.reset();
 
@@ -222,6 +285,27 @@ export class SimpleURLEncoder {
         }
 
         const decoded = this.decoder.decodeSorts(encoded, options);
+        if (!decoded) {
+            return null;
+        }
+
+        this.visitor.reset();
+
+        return this.runSerializer(this.visitor.visitSorts(decoded));
+    }
+
+    async encodeSortsAsync(
+        input: ISorts,
+        options: ParseParameterOptions = {},
+    ) : Promise<string | null> {
+        this.visitor.reset();
+
+        const encoded = this.runSerializer(this.visitor.visitSorts(input));
+        if (encoded === null || !isSchemaAware(options)) {
+            return encoded;
+        }
+
+        const decoded = await this.decoder.decodeSortsAsync(encoded, options);
         if (!decoded) {
             return null;
         }

--- a/packages/codec-url/test/unit/expression-encoder-schema.spec.ts
+++ b/packages/codec-url/test/unit/expression-encoder-schema.spec.ts
@@ -5,7 +5,9 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import type { SchemaError } from '@rapiq/core';
 import {
+    ErrorCode,
     FiltersParseError,
     defineQuery,
     defineSchema,
@@ -69,5 +71,53 @@ describe('encoder (schema-aware)', () => {
 
         expect(decodeURIComponent(encoded!)).toEqual('filter=eq(name,\'JOHN\')');
         expect(decodeURIComponent(encodedFilters!)).toEqual('filter=eq(name,\'JOHN\')');
+    });
+
+    it('should await asynchronous field validators through encodeFieldsAsync, and refuse them through the sync path', async () => {
+        expect.assertions(2);
+
+        const schema = defineSchema({ fields: { validate: async (name) => name !== 'secret' } });
+        const query = defineQuery({ fields: ['id', 'secret'] });
+
+        const encoded = await encoder.encodeFieldsAsync(query.fields, { schema });
+        expect(decodeURIComponent(encoded!)).toEqual('fields=id');
+
+        try {
+            encoder.encodeFields(query.fields, { schema });
+        } catch (e) {
+            expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
+        }
+    });
+
+    it('should await asynchronous relation validators through encodeRelationsAsync, and refuse them through the sync path', async () => {
+        expect.assertions(2);
+
+        const schema = defineSchema({ relations: { validate: async (name) => name === 'realm' } });
+        const query = defineQuery({ relations: ['realm', 'items'] });
+
+        const encoded = await encoder.encodeRelationsAsync(query.relations, { schema });
+        expect(decodeURIComponent(encoded!)).toEqual('include=realm');
+
+        try {
+            encoder.encodeRelations(query.relations, { schema });
+        } catch (e) {
+            expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
+        }
+    });
+
+    it('should await asynchronous sort validators through encodeSortsAsync, and refuse them through the sync path', async () => {
+        expect.assertions(2);
+
+        const schema = defineSchema({ sorts: { validate: async (name) => name !== 'name' } });
+        const query = defineQuery({ sort: ['id', 'name'] });
+
+        const encoded = await encoder.encodeSortsAsync(query.sorts, { schema });
+        expect(decodeURIComponent(encoded!)).toEqual('sort=id');
+
+        try {
+            encoder.encodeSorts(query.sorts, { schema });
+        } catch (e) {
+            expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
+        }
     });
 });

--- a/packages/codec-url/test/unit/simple-encoder-schema.spec.ts
+++ b/packages/codec-url/test/unit/simple-encoder-schema.spec.ts
@@ -5,7 +5,9 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import type { SchemaError } from '@rapiq/core';
 import {
+    ErrorCode,
     ParseError,
     defineQuery,
     defineSchema,
@@ -148,5 +150,53 @@ describe('encoder (schema-aware)', () => {
 
         expect(decodeURIComponent(encoded!)).toEqual('filter[name]=JOHN');
         expect(decodeURIComponent(encodedFilters!)).toEqual('filter[name]=JOHN');
+    });
+
+    it('should await asynchronous field validators through encodeFieldsAsync, and refuse them through the sync path', async () => {
+        expect.assertions(2);
+
+        const schema = defineSchema<User>({ fields: { validate: async (name) => name !== 'secret' } });
+        const query = defineQuery({ fields: ['id', 'secret'] });
+
+        const encoded = await encoder.encodeFieldsAsync(query.fields, { schema });
+        expect(decodeURIComponent(encoded!)).toEqual('fields=id');
+
+        try {
+            encoder.encodeFields(query.fields, { schema });
+        } catch (e) {
+            expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
+        }
+    });
+
+    it('should await asynchronous relation validators through encodeRelationsAsync, and refuse them through the sync path', async () => {
+        expect.assertions(2);
+
+        const schema = defineSchema<User>({ relations: { validate: async (name) => name === 'realm' } });
+        const query = defineQuery({ relations: ['realm', 'items'] });
+
+        const encoded = await encoder.encodeRelationsAsync(query.relations, { schema });
+        expect(decodeURIComponent(encoded!)).toEqual('include=realm');
+
+        try {
+            encoder.encodeRelations(query.relations, { schema });
+        } catch (e) {
+            expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
+        }
+    });
+
+    it('should await asynchronous sort validators through encodeSortsAsync, and refuse them through the sync path', async () => {
+        expect.assertions(2);
+
+        const schema = defineSchema<User>({ sorts: { validate: async (name) => name !== 'name' } });
+        const query = defineQuery({ sort: ['id', 'name'] });
+
+        const encoded = await encoder.encodeSortsAsync(query.sorts, { schema });
+        expect(decodeURIComponent(encoded!)).toEqual('sort=id');
+
+        try {
+            encoder.encodeSorts(query.sorts, { schema });
+        } catch (e) {
+            expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
+        }
     });
 });


### PR DESCRIPTION
`@rapiq/codec-url`'s internal decoder and both encoders each expose five per-parameter methods but an async twin for **filters only**. Under a schema whose fields, relations or sorts validate hook is asynchronous, the per-parameter path throws `SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER` with no way to await.

This completes the mirror: `decodeFieldsAsync`, `decodePaginationAsync`, `decodeRelationsAsync`, `decodeSortsAsync` on `BaseURLDecoder`, and the matching four on `SimpleURLEncoder` and `ExpressionURLEncoder`.

## Why this shape

Not invented here. `@rapiq/core`'s `BaseQueryParser` already provides async twins for all five parameters (`parseFields`/`parseFieldsAsync` through `parseSorts`/`parseSortsAsync`), and `.agents/architecture.md` states the intent directly:

> The URL codecs and registry mirror the parser split with `encodeAsync()` / `decodeAsync()`.

codec-url mirrored it for filters only. This finishes the job, matching core's shape rather than picking a new one. The expression encoder delegates all four to the simple encoder, exactly as it already delegates the sync versions.

## Scope: internal consistency, not a user-facing fix

Worth stating plainly so this is reviewed for what it is. Measured against the built dists before writing anything:

| Probe | Result |
|---|---|
| `codec.encodeAsync()` with an async **fields** hook | `codec=url-expression&fields=id`, resolved **and the verdict applied** |
| `codec.encode()` (sync), same schema | throws `schemaValidatorAsyncRequiresAsyncParser` |
| `codec.decodeAsync()` / `codec.decode()` | same pattern in the decode direction |
| Control: **synchronous** hook on the sync path | works, so the throw is about awaiting, not about validation |
| Per-parameter symbols in the package exports | none |
| Public `URLCodec` methods | `register`, `encode`, `encodeAsync`, `decode`, `decodeAsync` |

So the supported public path already handled async hooks on every parameter correctly, and no consumer can reach the affected methods: none of the three classes is exported from the barrel, and the exported `IURLCodecEncoder` contract declares only `encode()` and an optional `encodeAsync()`. `encodeFiltersAsync` had no production caller either, only specs.

The value here is removing a trap for whoever next wires a per-parameter async path, who would otherwise find filters supported and the other four silently not.

## Tests

Six new specs across the simple and expression encoders. Each asserts **both** halves, so the twins are pinned as load-bearing rather than decorative:

```typescript
const encoded = await encoder.encodeFieldsAsync(query.fields, { schema });
expect(decodeURIComponent(encoded!)).toEqual('fields=id');   // hook's verdict applied

try {
    encoder.encodeFields(query.fields, { schema });
} catch (e) {
    expect((e as SchemaError).code).toEqual(ErrorCode.SCHEMA_VALIDATOR_ASYNC_REQUIRES_ASYNC_PARSER);
}
```

Without the second half, a spec would pass against a twin that awaits but silently drops validation, which would be worse than today's throw.

Confirmed red before implementation (`TypeError: encoder.encodeFieldsAsync is not a function`) and green after: codec-url 282 to 288.

## Notes

- **Purely additive**: 267 insertions, 0 deletions. No existing signature, behaviour or export changed, and the rebuilt `.d.mts` carries no new per-parameter symbols.
- **The pagination twin is intentionally vacuous.** Pagination has no validate hook, so it can never await anything today. It exists because core provides `parsePaginationAsync` and the point was to mirror core's shape exactly rather than leave a four-of-five surface.
- Each twin is a line-for-line mirror of its sync counterpart, differing only in awaiting the async decode: same options handling, same visitor-reset discipline, same null and empty-string semantics.

## Verification

`nx run-many -t build` 11/11, `nx run-many -t test` 10/10 on a fresh no-cache run, `eslint packages/codec-url` clean. `test:db` not run.
