### PR TITLE
chore: source the issue model from @ebec/core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -731,9 +731,9 @@
             }
         },
         "node_modules/@ebec/core": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ebec/core/-/core-1.2.0.tgz",
-            "integrity": "sha512-6sjSW05IEBoPCXD2HoxV8glWzebKYyGZHbHS90ktfqwQLBbHMKpcoIuJnihg1FjJc7gwU8mMOOzVkhIj2oUrVQ==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@ebec/core/-/core-1.3.1.tgz",
+            "integrity": "sha512-nb1p8IV/D/i7d8XHqkxV4CESV3RVmRFrDrJte9EReolxCJMgCK8sUh4SW2xw3GaaD3kdQRTjfQ4XNhasGvP91w==",
             "license": "MIT"
         },
         "node_modules/@electric-sql/pglite": {
@@ -4684,12 +4684,6 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
-        },
-        "node_modules/blemish": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/blemish/-/blemish-1.0.0.tgz",
-            "integrity": "sha512-52giOo7ElB4EX0c9uaRR1Hu+azEFlEgEfprbIoB5/H1nT4/+ZhWJ6ct4axXJA+GhkQo2qcBoSsSmzoyXxHaJWA==",
-            "license": "MIT"
         },
         "node_modules/boolbase": {
             "version": "1.0.0",
@@ -12603,7 +12597,7 @@
             "version": "2.2.0",
             "license": "MIT",
             "dependencies": {
-                "blemish": "^1.0.0",
+                "@ebec/core": "^1.3.1",
                 "pathtrace": "^2.2.3",
                 "qs": "^6.15.3"
             },
@@ -12624,8 +12618,7 @@
             "version": "2.2.0",
             "license": "MIT",
             "dependencies": {
-                "@ebec/core": "^1.2.0",
-                "blemish": "^1.0.0",
+                "@ebec/core": "^1.3.1",
                 "pathtrace": "^2.2.3"
             }
         },
@@ -12646,6 +12639,7 @@
             "version": "2.2.0",
             "license": "MIT",
             "devDependencies": {
+                "@ebec/core": "^1.3.1",
                 "@rapiq/core": "^2.2.0",
                 "@rapiq/parser-simple": "^2.2.0"
             },
@@ -12659,6 +12653,7 @@
             "version": "2.2.0",
             "license": "MIT",
             "devDependencies": {
+                "@ebec/core": "^1.3.1",
                 "@rapiq/core": "^2.2.0",
                 "@rapiq/parser-simple": "^2.2.0"
             },
@@ -12672,6 +12667,7 @@
             "version": "2.2.0",
             "license": "MIT",
             "devDependencies": {
+                "@ebec/core": "^1.3.1",
                 "@rapiq/core": "^2.2.0"
             },
             "peerDependencies": {

--- a/packages/codec-url/package.json
+++ b/packages/codec-url/package.json
@@ -16,7 +16,7 @@
         "dist/"
     ],
     "dependencies": {
-        "blemish": "^1.0.0",
+        "@ebec/core": "^1.3.1",
         "pathtrace": "^2.2.3",
         "qs": "^6.15.3"
     },

--- a/packages/codec-url/src/error/module.ts
+++ b/packages/codec-url/src/error/module.ts
@@ -6,8 +6,8 @@
  */
 
 import { arrayToPath } from 'pathtrace';
-import { flattenIssueItems } from 'blemish';
-import type { Issue } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
+import type { Issue } from '@ebec/core';
 import { extractIssueParameter } from '@rapiq/core';
 import { PARAMETER_WIRE_NAMES } from './constants';
 import type { FormatErrorsOptions, FormattedError } from './types';

--- a/packages/codec-url/test/data/expect.ts
+++ b/packages/codec-url/test/data/expect.ts
@@ -6,7 +6,7 @@
  */
 
 import { ErrorCode, ParseError } from '@rapiq/core';
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 
 /**
  * Assert that a parse rejected its input, and that the violation `expected`

--- a/packages/codec-url/test/unit/error.spec.ts
+++ b/packages/codec-url/test/unit/error.spec.ts
@@ -14,8 +14,8 @@ import {
     defineSchema,
 } from '@rapiq/core';
 import type { IssueInput, ParseError } from '@rapiq/core';
-import { defineIssueGroup } from 'blemish';
-import type { IssueItem } from 'blemish';
+import { defineIssueGroup } from '@ebec/core';
+import type { IssueItem } from '@ebec/core';
 import { URLParameter, createURLCodec, formatErrors } from '../../src';
 
 const issue = (overrides: Partial<IssueInput> = {}) : IssueItem => buildIssue({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,8 +58,7 @@
     },
     "homepage": "https://github.com/Tada5hi/rapiq#readme",
     "dependencies": {
-        "@ebec/core": "^1.2.0",
-        "blemish": "^1.0.0",
+        "@ebec/core": "^1.3.1",
         "pathtrace": "^2.2.3"
     }
 }

--- a/packages/core/src/errors/base.ts
+++ b/packages/core/src/errors/base.ts
@@ -6,7 +6,7 @@
  */
 
 import { BaseError as EbecBaseError, markInstanceof } from '@ebec/core';
-import type { Issue } from 'blemish';
+import type { Issue } from '@ebec/core';
 import { BASE_ERROR_MARKER } from './check';
 import { ErrorCode } from './code';
 import type { BaseErrorOptions, IBaseError, SerializedError } from './types';
@@ -48,7 +48,7 @@ export class BaseError extends EbecBaseError implements IBaseError {
      * asserts the trace too. Assert the class or the code, or reach into
      * `issues`, rather than comparing whole errors.
      */
-    public readonly issues : readonly Issue[];
+    public override readonly issues : readonly Issue[];
 
     constructor(input: BaseErrorOptions | string) {
         // both forms default the code to NONE: left to the base, a bare

--- a/packages/core/src/errors/issue/module.ts
+++ b/packages/core/src/errors/issue/module.ts
@@ -5,8 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { defineIssueItem } from 'blemish';
-import type { Issue, IssueItem } from 'blemish';
+import { defineIssueItem } from '@ebec/core';
+import type { Issue, IssueItem } from '@ebec/core';
 import type { Parameter } from '../../constants';
 import { normalizeParameter } from '../../utils';
 import type { IssueInput } from './types';
@@ -15,7 +15,7 @@ import type { IssueInput } from './types';
  * Build the issue a rapiq site reports.
  *
  * The parameter is normalized here, at the one point where it is still
- * typed: past this call it lives in blemish's open `meta` bag, where the
+ * typed: past this call it lives in @ebec/core's open `meta` bag, where the
  * deprecated `sort` spelling would survive unnoticed.
  */
 export function buildIssue(input: IssueInput) : IssueItem {

--- a/packages/core/src/errors/issue/types.ts
+++ b/packages/core/src/errors/issue/types.ts
@@ -11,11 +11,11 @@ import type { ErrorCodeInput } from '../types';
 /**
  * What a rapiq site reports when it rejects client input.
  *
- * The stored node is blemish's; this is the shape its producers speak, so a
+ * The stored node is @ebec/core's; this is the shape its producers speak, so a
  * recording site names `parameter` under type control rather than assembling
  * an untyped `meta` bag itself.
  *
- * `parameter` and `key` become blemish `meta` keys. Both meet its documented
+ * `parameter` and `key` become @ebec/core `meta` keys. Both meet its documented
  * bar for that field (provenance a consumer cannot reconstruct from `path`),
  * and neither is a rendering decision: a `fields` rejection and a `filters`
  * rejection at `['items', 'secret']` are indistinguishable by path, and the

--- a/packages/core/src/errors/parse.ts
+++ b/packages/core/src/errors/parse.ts
@@ -7,12 +7,11 @@
 
 import { isObject } from '../utils';
 import { BaseError } from './base';
-import { markInstanceof } from '@ebec/core';
+import { flattenIssueItems, markInstanceof } from '@ebec/core';
 import { PARSE_ERROR_MARKER } from './check';
 import { ErrorCode } from './code';
 import { ErrorMessage } from './messages';
-import { flattenIssueItems } from 'blemish';
-import type { Issue } from 'blemish';
+import type { Issue } from '@ebec/core';
 import type { BaseErrorOptions, IParseError } from './types';
 
 export class ParseError extends BaseError implements IParseError {

--- a/packages/core/src/errors/types.ts
+++ b/packages/core/src/errors/types.ts
@@ -5,8 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { IBaseError as IError } from '@ebec/core';
-import type { Issue } from 'blemish';
+import type { IBaseError as IError, Issue } from '@ebec/core';
 import type { ErrorCode } from './code';
 
 /**
@@ -16,8 +15,8 @@ import type { ErrorCode } from './code';
  * matters because branching on `code` is the documented machine contract. The
  * open half is not slack: a trace can merge issues another library recorded,
  * and a consumer's own error class carries its own code, so a closed union
- * would be describing a world rapiq does not control. Same idiom blemish uses
- * for `IssueItem.code`, so the two agree.
+ * would be describing a world rapiq does not control. Same idiom @ebec/core
+ * uses for `IssueItem.code`, so the two agree.
  */
 export type ErrorCodeInput = `${ErrorCode}` | (string & {});
 
@@ -57,7 +56,7 @@ export interface IParseError extends IBaseError {}
  * along so `isBaseError` / `isParseError` still recognize the value once it is
  * a plain object: the guards match the serialized chain, not just a live
  * brand. Issue `expected` and `received` members are omitted at runtime even
- * though blemish's optional members keep this structural type assignable.
+ * though @ebec/core's optional members keep this structural type assignable.
  */
 export type SerializedError = {
     name: string,

--- a/packages/core/src/parser/index-policy.ts
+++ b/packages/core/src/parser/index-policy.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 import { Parameter } from '../constants';
 import {
     Filters,

--- a/packages/core/src/parser/issue/module.ts
+++ b/packages/core/src/parser/issue/module.ts
@@ -9,8 +9,8 @@ import {
     flattenIssueItems,
     isIssueGroup,
     prefixIssuePath,
-} from 'blemish';
-import type { Issue, IssueItem } from 'blemish';
+} from '@ebec/core';
+import type { Issue, IssueItem } from '@ebec/core';
 import type { Parameter } from '../../constants';
 import { MAX_ISSUES, buildIssue } from '../../errors';
 import type { IParseError, IssueInput } from '../../errors';

--- a/packages/core/src/parser/issue/types.ts
+++ b/packages/core/src/parser/issue/types.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Issue } from 'blemish';
+import type { Issue } from '@ebec/core';
 import type { Parameter } from '../../constants';
 import type { IParseError, IssueInput } from '../../errors';
 

--- a/packages/core/src/schema/resolver/module.ts
+++ b/packages/core/src/schema/resolver/module.ts
@@ -34,7 +34,7 @@ import type {
     ParameterSchema,
     ResolutionScopeContext,
 } from './types';
-import type { Issue } from 'blemish';
+import type { Issue } from '@ebec/core';
 
 const PARAMETER_SCHEMA_CLASSES = {
     [Parameter.FIELDS]: FieldsSchema,

--- a/packages/core/test/data/expect.ts
+++ b/packages/core/test/data/expect.ts
@@ -6,7 +6,7 @@
  */
 
 import { ErrorCode, ParseError } from '../../src';
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 
 /**
  * Assert that a parse rejected its input, and that the violation `expected`

--- a/packages/core/test/unit/errors/issue.spec.ts
+++ b/packages/core/test/unit/errors/issue.spec.ts
@@ -5,11 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { INSTANCEOF_PROPERTY, markInstanceof } from '@ebec/core';
 import {
+    INSTANCEOF_PROPERTY,
     defineIssueGroup,
     flattenIssueItems,
-} from 'blemish';
+    markInstanceof,
+} from '@ebec/core';
 import {
     BASE_ERROR_MARKER,
     BaseError,

--- a/packages/core/test/unit/errors/serialization.spec.ts
+++ b/packages/core/test/unit/errors/serialization.spec.ts
@@ -5,8 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BASE_ERROR_INSTANCE, INSTANCEOF_PROPERTY } from '@ebec/core';
-import { defineIssueGroup } from 'blemish';
+import { BASE_ERROR_INSTANCE, INSTANCEOF_PROPERTY, defineIssueGroup } from '@ebec/core';
 import {
     BASE_ERROR_MARKER,
     BaseError,

--- a/packages/core/test/unit/parser/base-query-parser.spec.ts
+++ b/packages/core/test/unit/parser/base-query-parser.spec.ts
@@ -8,7 +8,7 @@
 // two small sub-parser stubs drive the orchestrator under test.
 /* eslint-disable max-classes-per-file */
 
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 import {
     BaseQueryParser,
     ErrorCode,

--- a/packages/core/test/unit/parser/index-policy.spec.ts
+++ b/packages/core/test/unit/parser/index-policy.spec.ts
@@ -8,7 +8,7 @@
 import {
     defineIssueGroup,
     flattenIssueItems,
-} from 'blemish';
+} from '@ebec/core';
 import {
     ErrorCode,
     FilterCompoundOperator,

--- a/packages/parser-expression/package.json
+++ b/packages/parser-expression/package.json
@@ -16,6 +16,7 @@
         "dist/"
     ],
     "devDependencies": {
+        "@ebec/core": "^1.3.1",
         "@rapiq/core": "^2.2.0",
         "@rapiq/parser-simple": "^2.2.0"
     },

--- a/packages/parser-expression/test/data/expect.ts
+++ b/packages/parser-expression/test/data/expect.ts
@@ -6,7 +6,7 @@
  */
 
 import { ErrorCode, ParseError } from '@rapiq/core';
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 
 /**
  * Assert that a parse rejected its input, and that the violation `expected`

--- a/packages/parser-mongo/package.json
+++ b/packages/parser-mongo/package.json
@@ -16,6 +16,7 @@
         "dist/"
     ],
     "devDependencies": {
+        "@ebec/core": "^1.3.1",
         "@rapiq/core": "^2.2.0",
         "@rapiq/parser-simple": "^2.2.0"
     },

--- a/packages/parser-mongo/test/data/expect.ts
+++ b/packages/parser-mongo/test/data/expect.ts
@@ -6,7 +6,7 @@
  */
 
 import { ErrorCode, ParseError } from '@rapiq/core';
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 
 /**
  * Assert that a parse rejected its input, and that the violation `expected`

--- a/packages/parser-simple/package.json
+++ b/packages/parser-simple/package.json
@@ -16,6 +16,7 @@
         "dist/"
     ],
     "devDependencies": {
+        "@ebec/core": "^1.3.1",
         "@rapiq/core": "^2.2.0"
     },
     "peerDependencies": {

--- a/packages/parser-simple/test/data/expect.ts
+++ b/packages/parser-simple/test/data/expect.ts
@@ -6,7 +6,7 @@
  */
 
 import { ErrorCode, ParseError } from '@rapiq/core';
-import { flattenIssueItems } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
 
 /**
  * Assert that a parse rejected its input, and that the violation `expected`

--- a/packages/parser-simple/test/unit/parser/issues.spec.ts
+++ b/packages/parser-simple/test/unit/parser/issues.spec.ts
@@ -20,8 +20,8 @@ import {
     isParseError,
     preserve,
 } from '@rapiq/core';
-import { flattenIssueItems } from 'blemish';
-import type { Issue } from 'blemish';
+import { flattenIssueItems } from '@ebec/core';
+import type { Issue } from '@ebec/core';
 import { SimpleFieldsParser, SimplePaginationParser, SimpleParser } from '../../../src';
 import { expectRejected } from '../../data';
 import type { User } from '../../data';


### PR DESCRIPTION
## Summary

`blemish`'s issue model has been absorbed into `@ebec/core` and the `blemish` package is being retired. This points rapiq at the new home.

The model was **moved, not reimplemented** — every symbol behaves identically, so this is a specifier swap rather than a behaviour change. Requires `@ebec/core@^1.3.1`.

## Changes

- Import specifier swapped from `blemish` to `@ebec/core` across `packages/core` (8 sites) and `packages/codec-url` (1 file), plus the test files in both.
- `@ebec/core` bumped to `^1.3.1` in both packages; `blemish` removed from every manifest and the lockfile.
- `packages/core/src/errors/base.ts` — `issues` now carries an `override` modifier. `@ebec/core` 1.3.x declares `issues` on `BaseError`, so rapiq's own declaration genuinely overrides it and `noImplicitOverride` correctly asks us to say so.
- Duplicate `@ebec/core` import lines merged where the swap produced two imports from the same module (`import/no-duplicates`).

## Scope expansion: a phantom dependency this change exposed

`packages/parser-simple`, `packages/parser-expression` and `packages/parser-mongo` have test files importing `blemish` while declaring **neither** `blemish` nor `@ebec/core` in their own `package.json`. They only ever resolved because npm hoisted `blemish` to the root on behalf of `packages/core` and `packages/codec-url`.

Removing `blemish` broke all three suites with `Cannot find package 'blemish'`. Fixed both halves rather than one:

- the five test files now import from `@ebec/core`, and
- each of the three packages now **declares** `@ebec/core` as a devDependency.

Declaring it is the part that matters. Swapping the specifier alone would have re-created the identical phantom against a different package, and whoever next removed `@ebec/core` from `packages/core` would have hit the same failure with the same confusion.

## Verification

- [x] `npm run test` from the repo root — all 10 nx projects, 154 files, **2471 tests**, 0 failures
- [x] `npm run build` clean
- [x] Scoped `npx eslint` clean (exit 0) on every package touched
- [x] No `blemish` reference in any `src/`, `package.json`, or `package-lock.json`
- [x] No barrel exports `*` from both `@ebec/core` and `blemish` — that combination silently drops all 26 shared names with no error

## Two pre-existing issues found, deliberately not fixed here

**Root `npm run lint` fails**, and did before this branch: 2377 errors on the base commit versus 2276 with these changes. Every one is the same `tsconfigRootDir` parse error from eslint walking `.claude/worktrees/*` — five stale gitignored checkouts in the local working copy. Worth a one-line `ignores` entry in `eslint.config.mjs`, as its own change.

**A second phantom-dependency pattern** in `adapter-drizzle`, `adapter-prisma` and `adapter-typeorm`, which use sibling workspace packages (`@rapiq/adapter-memory`, `@rapiq/codec-url`) without declaring them. Lower severity than the `blemish` case — npm's workspace symlinking makes it unlikely to break spontaneously — so it's reported rather than folded in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Consolidated issue handling around the latest shared core package.
  - Removed the legacy error-handling dependency where no longer needed.
  - Updated development tooling across parser packages for consistency.

- **Tests**
  - Updated test coverage and validation utilities to use the unified issue-handling implementation.
  - Preserved existing error structures and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->